### PR TITLE
ci: lower main approval count to 0 for hackathon

### DIFF
--- a/.github/rulesets/main.json
+++ b/.github/rulesets/main.json
@@ -14,7 +14,7 @@
     {
       "type": "pull_request",
       "parameters": {
-        "required_approving_review_count": 1,
+        "required_approving_review_count": 0,
         "dismiss_stale_reviews_on_push": false,
         "require_code_owner_review": false,
         "require_last_push_approval": false,


### PR DESCRIPTION
Sync ruleset file to match the API state (PUT applied separately). Reverts before demo day.