### PR TITLE
release: skill-pivot framing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,18 @@ When working on the source files in `packages/`, treat them as authored-in-place
 
 **Project name vs. spec name:** the project / repo / package scope is **skillname**. The ENS text-record namespace it implements stays as `xyz.manifest.skill.*` because that's a stable spec key — skillname is the registry, "skill" is what gets registered. Don't rename the text-record keys or the schema `$id` URL (`https://manifest.eth/schemas/skill-v1.json`); both are part of the on-the-wire spec.
 
+## Conceptual model — atomic skill granularity
+
+The unit is **one ENS name = one atomic skill (function)**. An agent is a list of imports of these names. This is the wedge vs. competing ENS-AI projects, which map agents (not skills) to ENS names.
+
+When working in this codebase:
+- A bundle should describe **one** function in its `tools[]` array. Multi-tool bundles still parse, but the canonical pattern is one-function-per-bundle (e.g. `quote.uniswap.eth` → `get_quote`, `swap.uniswap.eth` → `execute_swap`).
+- Use **"skill"** not **"agent"** in user-facing copy. The framing is `import quote from "quote.uniswap.eth"`.
+- Don't conflate "skill" (the atomic ENS-named function) with "bundle" (the manifest+tools+prompts payload). The bundle *contains* the skill.
+- Composition happens via the `xyz.manifest.skill.imports` text record (roadmap #3): a manifest declares its imports, the bridge walks the graph, transitive tools are registered.
+
+See [`README.md`](./README.md) for the public framing and [`skillname-pack/docs/ROADMAP.md`](./skillname-pack/docs/ROADMAP.md) for the hierarchical build checklist.
+
 ## Commit conventions
 
 When committing or opening PRs against `hien-p/Skillname` (or any artifact that ends up public on this repo), **do not include `Co-Authored-By: Claude …` trailers, do not sign commits as "claude", and do not mention "Claude" or "Anthropic" in commit messages, PR titles, descriptions, or issue comments**. The visible author/contributor list must show only `hien-p`. This applies to every commit regardless of how the change was produced.

--- a/README.md
+++ b/README.md
@@ -1,154 +1,131 @@
 # skillname
 
-> **ENS-native registry for AI agent skills.**
-> Resolve any ENS name into a verified MCP skill bundle and load tools dynamically. No custom adapters per protocol. No hard-coded endpoints.
+> **ENS is the import statement for AI.**
+> One ENS name = one AI skill. Compose agents by importing names.
 
-**Status:** ETHGlobal Open Agents · Apr 24 – May 6, 2026 · Targeting ENS (both tracks) + KeeperHub + 0G
+**Status:** ETHGlobal Open Agents · Apr 24 – May 6, 2026 · ENS (both tracks) + KeeperHub + 0G
 
-> *Project / repo / package = `skillname`. The on-the-wire spec it implements stays at `xyz.manifest.skill.*` ENS text records and the `https://manifest.eth/schemas/skill-v1.json` schema id — those are stable spec keys, decoupled from the registry's name.*
+---
 
-## Problem
-
-Today, an AI agent looks like this from the outside:
+## In one line
 
 ```
-0x91A3...f2c9
-https://random-api.com/mcp
-unknown owner
-unknown tools
-unknown reputation
+import quote from "quote.uniswap.eth"
 ```
 
-You don't know who controls it, what it can do, what it depends on, or whether it's trustworthy.
+That ENS name resolves to a manifest on IPFS describing **one function** — input schema, output schema, optional payment via x402, trust signals. Any MCP client (Claude Desktop, OpenClaw, Cursor) imports it dynamically. No custom adapter per protocol. No registry to register with. No API key.
 
-Worse — every AI agent framework rewrites adapter glue per protocol. One MCP adapter for Uniswap, another for Aave, another for ENS itself. **N protocols × M agent frameworks = adapter explosion.** Every agent team pays the tax.
+## In one paragraph
 
-Anthropic's MCP Registry solves this for the Web2 case via DNS/GitHub. That registry doesn't compose with onchain identity, NFT-based name ownership, or onchain payment rails — exactly the primitives Ethereum already has.
+The unit is atomic: **one ENS name → one callable function**. Owner of the ENS = author of the function. An agent is a list of imports. The same primitive scales from one tool to a recursive dependency graph, with version pinning, lockfiles, on-chain analytics from x402 payments, and tradable ownership via OpenSea — all without leaving ENS + IPFS.
 
-## Solution
+## Why this is unique
 
-Each protocol publishes one content-addressed MCP skill bundle to IPFS, then sets ENS text records pointing at the CID. Any MCP client (Claude Desktop, OpenClaw, Cursor, custom) resolves the ENS name, fetches the bundle, validates it against schema v1, and registers the bundle's tools dynamically. **N + M, not N × M.**
+The wedge is **granularity**. Other ENS-AI projects map *agents* to ENS names; we map *functions* to names. An agent is just a manifest of imports.
 
-```
-research.agent.eth
-  → ENS text record: xyz.manifest.skill = ipfs://bafy...
-  → bundle: manifest.json + tools/ + prompts/ + examples/
-  → MCP client loads tools (with optional ENSIP-25 + ERC-8004 verification)
-```
+| Project | Their unit | skillname |
+|---|---|---|
+| MVR (Sui) | `@org/package` SuiNS | `skill.org.eth` ENS |
+| DoloX | agent has ENS | **skill** has ENS |
+| LPlens | one agent → many tools | **one ENS → one tool** |
+| AgentPassports | ENS verifies policy | ENS **is** callable |
+| npm | centralized registry | each function lives at its own ENS |
 
-ENS gives this four things a plain JSON registry doesn't:
+No project in the 58-entry hackathon roster works at this granularity. This is the slot.
 
-- **Human-readable names** wallets already render (MetaMask, Rainbow, Etherscan)
-- **NFT-native ownership** that transfers cleanly — sell the name, sell the publishing authority
-- **ENSIP-25 binding** to ERC-8004 for verifiable agent identity
-- **Free `*.eth.limo` public surface** per name
+## Two-tier read
+
+**Cover** — for judges, Twitter, anyone meeting it the first time:
+> ENS is the import statement for AI.
+
+**Engine** — for engineers, builders, anyone digging deeper:
+> A package manager + analytics + marketplace + trust layer for AI skills, anchored on ENS. Like npm + crates.io + OpenSea, where every call is an on-chain x402 USDC payment. Granularity at the function level, not the agent level.
+
+Both are true. Cover is the headline; engine is what's underneath. Same product.
 
 ## How it works
 
 ```
-┌──────────────────────────────────────────────────────────┐
-│  MCP CLIENT (Claude Desktop / OpenClaw / Cursor)         │
-│  + skillname Bridge                                      │
-└──────────────────────────────────────────────────────────┘
+┌─────────────────────────────────────────────┐
+│  MCP CLIENT (Claude / OpenClaw / Cursor)    │
+│  + skillname Bridge                         │
+└─────────────────────────────────────────────┘
                   │
-                  │ ① user: "Use research.agent.eth"
+                  │ import quote.uniswap.eth
                   ▼
-┌──────────────────────────────────────────────────────────┐
-│  ENS Universal Resolver via viem                         │
-│   text(node, "xyz.manifest.skill")     → ipfs://bafy...  │
-│   text(node, "xyz.manifest.skill.version") → "1.0.0"     │
-│   text(node, "agent-registration[…][…]") → "1" (ENSIP-25)│
-└──────────────────────────────────────────────────────────┘
+┌─────────────────────────────────────────────┐
+│  ENS Universal Resolver via viem             │
+│   text(node, "xyz.manifest.skill")          │
+│   text(node, "xyz.manifest.skill.imports")  │
+└─────────────────────────────────────────────┘
                   │
-                  │ ② fetch bundle + verify CID
+                  │ fetch + verify CID; walk imports
                   ▼
-┌──────────────────────────────────────────────────────────┐
-│  IPFS / 0G Storage (Storacha primary, 0G dual-pin)       │
-│  manifest.json + tools/ + prompts/ + examples/           │
-└──────────────────────────────────────────────────────────┘
+┌─────────────────────────────────────────────┐
+│  IPFS / 0G   manifest.json                   │
+│  one function: name, input, output, exec    │
+└─────────────────────────────────────────────┘
                   │
-                  │ ③ register MCP tools dynamically
+                  │ register single tool in MCP
                   ▼
-┌──────────────────────────────────────────────────────────┐
-│  Tool calls route by execution.type:                     │
-│   • local: handler in bundle                             │
-│   • http: direct fetch                                   │
-│   • keeperhub: KeeperHub MCP + optional x402 payment     │
-└──────────────────────────────────────────────────────────┘
+┌─────────────────────────────────────────────┐
+│  Tool calls route by execution.type:        │
+│   • local   • http                          │
+│   • keeperhub + x402 (paid → on-chain)      │
+└─────────────────────────────────────────────┘
 ```
 
-## ENS text record convention
+## Demo flow (4 min, 7 scenes)
 
-| Key | Value | Required |
-|---|---|---|
-| `xyz.manifest.skill` | `ipfs://bafy...` (CID of bundle) | yes |
-| `xyz.manifest.skill.version` | `1.0.0` (semver) | yes |
-| `xyz.manifest.skill.schema` | URI of the schema being validated against | yes |
-| `xyz.manifest.skill.execution` | `keeperhub` \| `local` \| `axl` | optional |
-| `xyz.manifest.skill.0g` | 0G blob ID for dual-pin redundancy | optional |
-| `agent-registration[<reg>][<id>]` | `1` (ENSIP-25 ↔ ERC-8004 binding) | optional |
+1. **Hook (0:00–0:25).** Open `skillname.eth/explorer` → grid of skills with live call counts. *"Each card is one ENS name, one function."*
+2. **Simple import (0:25–1:00).** In Claude Desktop: `Use quote.uniswap.eth` → one tool appears. Get a quote. *"One ENS name, one skill."*
+3. **Compose (1:00–1:45).** Manifest with `imports: [quote, swap, score]` → bridge walks the graph → 3 tools loaded. *"Imports compose. Lockfile pinned on-chain."*
+4. **Analytics (1:45–2:15).** Click `quote.uniswap.eth` in explorer → 12K calls / 30d, $621 revenue, top callers. *"Every call is an on-chain x402 tx — analytics can't be faked."*
+5. **Versioning (2:15–2:40).** Show `v1.quote.uniswap.eth` (NameWrapper-locked) vs `v2`. Lockfile pins exact resolution. *"npm semver, on-chain."*
+6. **Paid execution (2:40–3:20).** `swap.uniswap.eth` triggers x402 challenge → EIP-3009 USDC pay → KeeperHub swap → BaseScan tx confirmed.
+7. **Closing (3:20–4:00).** *"ENS is the import statement for AI."*
 
-`setText(...)` is gated by ENS Registry / NameWrapper ownership — only the ENS name owner can publish under that name. **No new auth contract needed.** Sell the ENS name on OpenSea, you sell the publishing authority. This is the same access pattern Sui's MVR uses, applied to 3.5M existing ENS names.
+Full script: [`docs/demo-script.md`](./skillname-pack/docs/demo-script.md).
 
 ## Deliverables
 
-### Shipped
+Full hierarchical checklist with sub-issues at [`docs/ROADMAP.md`](./skillname-pack/docs/ROADMAP.md). Summary:
 
-- [x] **JSON Schema v1** — [`packages/schema/skill-v1.schema.json`](./skillname-pack/packages/schema/skill-v1.schema.json)
-  Full draft-07 schema. Bundle root requires `name` / `ensName` / `version` / `tools[]`. Three execution variants (`local` / `http` / `keeperhub`) discriminated via `oneOf`. Payment block (`x402` / `mpp`). Trust block (`ensip25` + `erc8004`).
+### Tier 1 — Cover (MUST for demo)
+- [x] **Schema v1** — atomic skill manifest, three execution types, payment, trust ([skill-v1.schema.json](./skillname-pack/packages/schema/skill-v1.schema.json))
+- [x] **SDK `resolveSkill()`** — viem ENS read, IPFS gateway fetch, ENSIP-25 verify, ERC-7930 encoder ([sdk/src/index.ts](./skillname-pack/packages/sdk/src/index.ts))
+- [x] **MCP bridge skeleton** — stdio, dynamic registration, `http` executor working, `keeperhub` stubbed ([bridge/server.ts](./skillname-pack/packages/bridge/src/server.ts))
+- [x] **System dashboard** at [skillname.pages.dev](https://skillname.pages.dev) — Nothing-style bento UI
+- [ ] **Three reference skills** published on Sepolia: `quote.uniswap.eth`, `swap.uniswap.eth`, `score.gitcoin.eth`
+- [ ] **Bridge live in Claude Desktop** — D5 kill-criterion
+- [ ] **`skill.imports`** dependency walker + lockfile generator
+- [ ] **KeeperHub adapter** + **x402 payment** end-to-end on Base Sepolia
 
-- [x] **SDK `resolveSkill()`** — [`packages/sdk/src/index.ts`](./skillname-pack/packages/sdk/src/index.ts)
-  Pure-TS resolver. Wraps viem's `getEnsText` against the Universal Resolver on mainnet/sepolia, fetches the bundle from public IPFS gateways (`w3s.link`, `ipfs.io`, `cloudflare-ipfs.com`), and runs ENSIP-25 verification including the **ERC-7930 interoperable-address encoder** (`encodeErc7930`). Exports typed surface: `SkillBundle`, `Tool`, `Execution`, `ResolveResult`.
+### Tier 2 — Engine (HIGH for ENS Most Creative + 0G Framework)
+- [ ] **Skill Explorer** — search + skill detail + dep tree + analytics charts
+- [ ] **On-chain analytics indexer** — scan x402 USDC tx on Base, aggregate per skill
+- [ ] **Versioning + lockfile** — subname-as-version with NameWrapper fuses
+- [ ] **CLI** — `skill init | publish | resolve | verify | lock`
 
-- [x] **MCP bridge skeleton** — [`packages/bridge/src/server.ts`](./skillname-pack/packages/bridge/src/server.ts)
-  stdio MCP server. Two built-in tools — `manifest_load` and `manifest_list_loaded`. In-memory bundle cache with 5-min TTL. Dynamic tool registration with `<bundle>__<tool>` namespacing on `ListTools`. Working `http` executor; `local` and `keeperhub` paths are stubbed with explicit TODOs marked by phase.
+### Tier 3 — Stretch
+- [ ] **ERC-7857 iNFT** royalty wrapper for skill ownership
+- [ ] **OpenSea metadata** showing live call/revenue stats
+- [ ] **ENSIP draft** for `xyz.manifest.skill.*` namespace
 
-- [x] **Reference bundle manifest** — [`examples/research-agent/manifest.json`](./skillname-pack/examples/research-agent/manifest.json)
-  Hand-authored bundle covering all three execution types in one file: `contract_scan` (local), `market_research` (http via CoinGecko), `execute_contract_call` (keeperhub + $0.05 USDC x402 on Base Sepolia). Includes a populated `trust.erc8004` block to drive the ENSIP-25 verification path end-to-end.
+## Why this wins each track
 
-- [x] **Plan + design docs**
-  - [`BUILD_PLAN.md`](./skillname-pack/BUILD_PLAN.md) — 14-day plan, role split (Bridge / Execution / Identity-Storage), kill-criteria per checkpoint, prize alignment matrix
-  - [`docs/architecture.md`](./skillname-pack/docs/architecture.md) — end-to-end sequence diagram with one column per component (User → Claude → Bridge → viem → IPFS → KeeperHub → Base) + component responsibility table
-  - [`docs/demo-script.md`](./skillname-pack/docs/demo-script.md) — 4-minute, 8-scene recording script with per-beat narration and timing
-  - [`docs/explorer-spec.md`](./skillname-pack/docs/explorer-spec.md) — D10 read-only web explorer spec: routes, layout, three-state verified badge, error states, tech-stack rationale
-  - [`docs/VISION.md`](./skillname-pack/docs/VISION.md) — post-hackathon target spec (Agent Name Registry framing, dependency graph, Sessions API)
-  - [`FEEDBACK.md`](./skillname-pack/FEEDBACK.md) — KeeperHub Builder Feedback Bounty skeleton
+| Sponsor | Track | Where it lands |
+|---|---|---|
+| ENS | Best AI Integration | Bridge resolves ENS at runtime, no hard-coded values, demo proves it |
+| ENS | Most Creative Use | Granularity (function = ENS), subname access tokens, ENSIP-25 binding to ERC-8004, ENSIP draft |
+| KeeperHub | Best Use | x402 + KeeperHub adapter, OpenClaw packaging |
+| 0G | Framework | "Other builders publish skills here" — primitives others adopt; iNFT optional stretch |
 
-- [x] **Project setup**
-  - [`setup-day1.sh`](./skillname-pack/setup-day1.sh) — bootstrap script that expands the seed payload into a working pnpm monorepo with CI workflow scaffolded
-  - [`how_to_contributing.md`](./how_to_contributing.md) — branch workflow (`main` ↔ production, `staging` ↔ testnet, `feature/*`, `hotfix/*` with back-merge rule)
-  - [`CLAUDE.md`](./CLAUDE.md) — orientation for contributors using Claude Code in this repo
+## Live
 
-### Pending
-
-#### MVP demo-able
-
-- [ ] Schema validator wired into SDK — the ajv import in [`packages/sdk/src/index.ts`](./skillname-pack/packages/sdk/src/index.ts) lines 143–144 is currently commented out
-- [ ] CID hash verification via `@helia/verified-fetch` — current implementation uses plain gateway fetch
-- [ ] CLI: `skill publish | resolve | verify` — [`packages/cli/`](./skillname-pack/packages/cli/) exists but `src/commands/` is empty
-- [ ] Storacha publish pipeline end-to-end — `w3up-client` upload + ENS `setText` orchestration
-- [ ] Reference bundle tool / prompt / example files — only [`manifest.json`](./skillname-pack/examples/research-agent/manifest.json) exists; no executable handlers under `tools/`, no markdown under `prompts/`
-- [ ] ENS test name registered on Sepolia + text records set
-- [ ] Bridge running live in Claude Desktop — **D5 kill-criterion** per BUILD_PLAN
-
-#### Onchain execution + identity
-
-- [ ] KeeperHub execution adapter — `executeKeeperHub` in [`packages/bridge/src/server.ts`](./skillname-pack/packages/bridge/src/server.ts) is currently a stub
-- [ ] x402 payment flow — `@x402/hono` middleware + CDP facilitator + EIP-3009 USDC `transferWithAuthorization` + retry-with-`X-PAYMENT` flow
-- [ ] ERC-8004 Identity NFT mint script + `agent-registration[<erc7930>][<agentId>]` text record set on the test ENS name
-- [ ] ENSIP-25 verified-badge end-to-end — bundle declares trust → SDK reads binding → bridge surfaces ✓ in `manifest_load` response
-- [ ] Read-only web explorer — per [`docs/explorer-spec.md`](./skillname-pack/docs/explorer-spec.md)
-
-#### Polish + record
-
-- [ ] OpenClaw skill packaging — `clawhub install skillname/research-agent` working; same bundle visible in two MCP clients
-- [ ] 0G Storage dual-pin in publish pipeline + `xyz.manifest.skill.0g` text record
-- [ ] eth.limo deployment of explorer — static export → IPFS pin → ENS `contenthash` set on `skillname.eth`
-- [ ] Demo recording — code freeze May 5 6PM, 5 takes, upload unlisted to YouTube and embed in submission
-
-### Out of scope
-
-Subname-per-version locking (NameWrapper fuses), wildcard resolver for fleets (ENSIP-10), full ERC-8004 reputation aggregation, marketplace / discovery UI, AXL P2P discovery, dependency-graph walking, live observability Sessions API, ENSIP draft submission — all deferred to post-hackathon. Direction (full pivot to VISION.md spec vs cherry-pick) decided after the May 6 submission.
+- Production: [skillname.pages.dev](https://skillname.pages.dev)
+- Staging: [staging.skillname.pages.dev](https://staging.skillname.pages.dev)
+- Repo: this one ([github.com/hien-p/Skillname](https://github.com/hien-p/Skillname))
 
 ## License
 

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -914,7 +914,7 @@
 
         <div class="hero-resolver">
           <div class="label">CURRENTLY RESOLVING</div>
-          <div class="ens" id="ensName">research.agent.eth</div>
+          <div class="ens" id="ensName">quote.uniswap.eth</div>
           <div class="cid" id="cidLine">ipfs://bafybeigq3kpjp7xqv2nyo5lr3p6m4w5bkhhy7g2t4zvk · verified</div>
         </div>
 
@@ -1319,13 +1319,13 @@
   }, 220);
 
   const messages = [
-    'ENS RESOLVED · research.agent.eth · 182 MS',
+    'SKILL IMPORTED · quote.uniswap.eth · 182 MS',
     'IPFS GATEWAY · w3s.link · CID VERIFIED',
     'ENSIP-25 BIND · agent-registration[8004][42] = 1',
-    'TOOL REGISTERED · research_agent__contract_scan',
+    'IMPORT RESOLVED · quote_uniswap__get_quote',
     'X402 CHALLENGE · 0.05 USDC · BASE-SEPOLIA',
     'KEEPERHUB · execute_contract_call · OK',
-    'BUNDLE CACHE · TTL 5:00 · WARM',
+    'LOCKFILE PINNED · ipfs://bafy...lock · OK',
     'BRIDGE READY · stdio · MCP 0.6.0',
   ];
   let msgIdx = 0;

--- a/skillname-pack/docs/ROADMAP.md
+++ b/skillname-pack/docs/ROADMAP.md
@@ -1,0 +1,270 @@
+# Roadmap
+
+> Detailed build checklist with hierarchical sub-issues. Aligned with [`BUILD_PLAN.md`](../BUILD_PLAN.md). Each top-level issue has a goal statement, acceptance criteria as sub-tasks, and a priority tag.
+>
+> **Pivot framing:** the unit is **one ENS name = one atomic skill (function)**. An agent is a list of imports. This roadmap reflects that.
+
+## How to read this
+
+- `[x]` = shipped (linked to commit, file, or PR where possible)
+- `[ ]` = open work
+- **MUST** = ships before demo, or no demo
+- **HIGH** = depth layer that wins ENS Most Creative + 0G Framework tracks
+- **NICE** = stretch goals after Tier 1+2 are green
+- **SKIP** = explicitly out of scope for the May 5 freeze
+
+---
+
+## Tier 1 — Cover
+
+### #1 Atomic ENS skill resolution · MUST
+
+**Goal:** `import quote.uniswap.eth` returns one fully-typed function manifest.
+
+- [x] Schema v1 with bundle root + tool definition — [`packages/schema/skill-v1.schema.json`](../packages/schema/skill-v1.schema.json)
+- [x] SDK `resolveSkill()` — [`packages/sdk/src/index.ts`](../packages/sdk/src/index.ts)
+- [x] SDK defaults to Sepolia + pinned Universal Resolver `0xeEeEEEeE14D718C2B47D9923Deab1335E144EeEe`
+- [x] `ENS_SEPOLIA` constants for all 9 deployed contracts
+- [ ] **Reference skills** — atomic, one tool each
+  - [ ] `quote.uniswap.eth` → `get_quote(tokenIn, tokenOut, chain)` (free, http to CoinGecko or read-only)
+  - [ ] `swap.uniswap.eth` → `execute_swap(...)` with x402 + KeeperHub
+  - [ ] `score.gitcoin.eth` → `trust_score(address)` (free, http)
+  - [ ] `weather.tomorrow.eth` (free local example) → `forecast(lat, lng)` — proves "any function" works
+- [ ] **Sepolia ENS names registered + text records set**
+  - [ ] Register the four names via [sepolia.app.ens.domains](https://sepolia.app.ens.domains)
+  - [ ] Set `xyz.manifest.skill = ipfs://<cid>` on each
+  - [ ] Set `xyz.manifest.skill.version = 1.0.0`
+  - [ ] Set `xyz.manifest.skill.schema = https://manifest.eth/schemas/skill-v1.json`
+- [ ] **Schema validator wired into SDK** (currently commented out at [`sdk/src/index.ts:143`](../packages/sdk/src/index.ts))
+  - [ ] `pnpm --filter @skillname/schema build` produces `validate()` export
+  - [ ] SDK imports + runs validator before returning
+  - [ ] Reject malformed bundles with specific ajv error path
+- [ ] **CID hash verification** via `@helia/verified-fetch`
+  - [ ] Replace plain gateway fetch in `fetchAndVerify()`
+  - [ ] Verify content hash matches CID before returning bundle
+
+### #2 Bridge imports skill into Claude · MUST
+
+**Goal:** Saying "Use `quote.uniswap.eth`" in Claude Desktop registers exactly one tool, named `quote_uniswap__get_quote`.
+
+- [x] Stdio MCP transport — [`bridge/server.ts`](../packages/bridge/src/server.ts)
+- [x] `manifest_load` + `manifest_list_loaded` built-in tools
+- [x] Dynamic tool registration with `<bundle>__<tool>` namespacing
+- [x] Working `http` executor
+- [x] In-memory bundle cache, 5-min TTL
+- [ ] **Live test in Claude Desktop** ← **D5 kill-criterion per BUILD_PLAN**
+  - [ ] Configure `claude_desktop_config.json` with `@skillname/bridge`
+  - [ ] Restart Claude Desktop
+  - [ ] Type `Use quote.uniswap.eth` → verify tool surfaces in tool picker
+  - [ ] Call the tool → verify result renders
+  - [ ] Record screen capture for D7 rehearsal
+- [ ] Update bridge surface text from "load manifest" → "import skill" wording (cosmetic, matches new pitch)
+- [ ] Bridge log format with structured prefixes (`→ ← ✓`) for demo readability
+
+### #3 Dependency graph · MUST
+
+**Goal:** `my-trader.eth` declares `imports: [quote, swap, score]` → bridge auto-resolves transitive deps.
+
+- [ ] **Add `skill.imports` text record key**
+  - [ ] SDK constant `SKILL_IMPORTS_KEY = 'xyz.manifest.skill.imports'`
+  - [ ] Schema: bundle.imports[] field with semver matchers
+  - [ ] Reference manifest example with imports list
+- [ ] **SDK `walkImports(ensName, depth=3)`**
+  - [ ] Recursive resolver, breadth-first
+  - [ ] Cycle detection (max depth 5, refuse cycles)
+  - [ ] Returns flat dependency tree with parent-child links
+- [ ] **Lockfile generator**
+  - [ ] Walk tree → produce `{name, version, cid}[]` flat list
+  - [ ] Pin to IPFS, return CID
+  - [ ] Optionally write CID to `xyz.manifest.skill.lockfile` text record
+- [ ] **Bridge integration**
+  - [ ] On `manifest_load`, walk imports
+  - [ ] Register transitive tools in MCP
+  - [ ] Surface dependency tree in `manifest_list_loaded` output
+- [ ] **Reference**: `my-trader.eth` imports `quote+swap+score`, demo Scene 3
+
+### #4 Paid execution: KeeperHub + x402 · MUST
+
+**Goal:** Claude calls `swap.uniswap.eth` → wallet auto-pays $0.05 USDC via EIP-3009 → KeeperHub executes → tx lands on Base Sepolia.
+
+- [x] Schema: payment block (`x402` | `mpp`) with price + token + network
+- [x] Bridge: `executeKeeperHub` stub with payment branch
+- [ ] **CDP (Coinbase Developer Platform) integration**
+  - [ ] CDP API key + private key obtained
+  - [ ] x402 facilitator endpoint configured
+  - [ ] Test settlement on Base Sepolia
+- [ ] **`@x402/hono` middleware** wrapped around KeeperHub re-export
+  - [ ] HTTP server: `apps/keeperhub-paid/`
+  - [ ] Returns 402 challenge with payment requirements
+  - [ ] Validates `X-PAYMENT` header on retry
+- [ ] **Bridge x402 client flow**
+  - [ ] Detect 402 challenge response
+  - [ ] EIP-3009 `transferWithAuthorization` signing with agent wallet
+  - [ ] Retry with `X-PAYMENT` header
+  - [ ] Surface tx hash in result
+- [ ] **Pre-fund agent wallet on Base Sepolia**
+  - [ ] 5 USDC + 0.1 ETH from CDP/Alchemy faucets
+  - [ ] Verify balance before D11 cold-test
+- [ ] **BaseScan tx confirmation in demo flow**
+  - [ ] Result format includes BaseScan link
+  - [ ] Demo Scene 6 shows the link click → confirmed tx
+
+---
+
+## Tier 2 — Engine
+
+### #5 Skill Explorer (web UI) · HIGH
+
+**Goal:** Web app at `skillname.eth.limo` like crates.io / npmjs.com.
+
+- [x] System dashboard placeholder at [skillname.pages.dev](https://skillname.pages.dev) — [`apps/web/index.html`](../../apps/web/index.html)
+- [ ] **Routes**
+  - [ ] `/` — landing + search input + 6 example skill cards
+  - [ ] `/explorer/[ensName]` — skill detail page
+  - [ ] `/spec` — JSON Schema renderer
+- [ ] **Resolution**
+  - [ ] Use `@skillname/sdk` `resolveSkill()` in client component
+  - [ ] eth.limo deploy demands static export — must work fully client-side
+  - [ ] Public Alchemy/Infura RPC from browser
+- [ ] **Skill detail content**
+  - [ ] Manifest summary (name, version, description, license)
+  - [ ] Tools list with execution pills (local / http / keeperhub)
+  - [ ] Imports tree (transitive view, collapsible)
+  - [ ] Dependents (who imports this) — depends on #6 indexer
+  - [ ] Analytics charts (calls, revenue, top callers) — depends on #6 indexer
+  - [ ] Verified badge (3 states: `verified` / `unverified` / `mismatch`) per [`docs/explorer-spec.md`](./explorer-spec.md)
+- [ ] **"Open in Claude" CTA** → copy `claude_desktop_config.json` snippet
+- [ ] **Deploy to eth.limo**
+  - [ ] Static export → IPFS pin via Storacha
+  - [ ] Set ENS `contenthash` on `skillname.eth`
+  - [ ] Verify `skillname.eth.limo` resolves
+
+### #6 On-chain analytics indexer · HIGH
+
+**Goal:** Each skill detail page shows real call count + revenue from on-chain x402 tx.
+
+- [ ] **Indexer architecture** — Cloudflare Worker + KV (or D1)
+- [ ] **Source**: scan Base mainnet/Sepolia for x402 settlement tx (USDC `transferWithAuthorization`)
+- [ ] **Map tx → skill ENS name**
+  - [ ] Decode `X-PAYMENT` payload (off-chain) OR
+  - [ ] Use settlement event topic + payee mapping
+- [ ] **Aggregate per skill**
+  - [ ] Total calls (lifetime + last 30d + last 7d)
+  - [ ] Total revenue (USDC, last 30d)
+  - [ ] Top callers (top 5 wallets, anonymized)
+  - [ ] Time-series (daily for 30d)
+- [ ] **REST API** at `analytics.skillname.eth.limo/skill/<ens>`
+- [ ] **Frontend** consumes API
+  - [ ] Time-series sparkline → bar chart
+  - [ ] Revenue total + delta vs prior period
+  - [ ] Top callers list with ENS reverse-resolution
+
+### #7 Versioning + lockfile · HIGH
+
+**Goal:** `quote.uniswap.eth@^2` resolves to v2 latest. Lockfile pins exact CID.
+
+- [ ] **Subname-as-version registration**
+  - [ ] Script: register `v1.quote.uniswap.eth`, `v2.quote.uniswap.eth` etc. on Sepolia
+  - [ ] Burn NameWrapper fuses (CANNOT_TRANSFER, CANNOT_SET_RESOLVER) → immutable
+  - [ ] Each version subname has its own `xyz.manifest.skill = ipfs://...` text record
+- [ ] **Parent-name version index**
+  - [ ] `quote.uniswap.eth` text record `skill.versions = v1:0.9.0,v2:2.0.0` (CSV)
+  - [ ] Text record `skill.latest = v2`
+- [ ] **Semver matcher in SDK**
+  - [ ] Parse `^1`, `~2.1`, exact `v1.0.0`
+  - [ ] Match against version index → return correct subname
+- [ ] **Lockfile**
+  - [ ] CLI verb `skill lock` walks imports, writes lockfile
+  - [ ] Lockfile pinned to IPFS, CID set as `xyz.manifest.skill.lockfile`
+  - [ ] Bridge respects lockfile if present (reproducible builds)
+
+### #8 CLI · HIGH
+
+**Goal:** One command publishes a skill bundle and sets ENS records.
+
+- [ ] **`packages/cli/src/commands/`** — currently empty
+  - [ ] `init.ts` — scaffold a new bundle directory with `manifest.json`, tools/, etc.
+  - [ ] `publish.ts` — Storacha upload + ENS `setText` orchestration
+  - [ ] `resolve.ts` — run `resolveSkill()` from terminal
+  - [ ] `verify.ts` — schema + ENSIP-25 check
+  - [ ] `lock.ts` — generate + pin lockfile
+- [ ] **Bin alias**: `skill` (in `package.json`)
+- [ ] **Wallet integration**
+  - [ ] Read `WALLET_PRIVATE_KEY` from `.env`
+  - [ ] OR walletconnect bridge for browser sign-in
+- [ ] **Storacha integration**
+  - [ ] `@web3-storage/w3up-client` for IPFS uploads
+  - [ ] Bundle directory → CID
+- [ ] **ENS publishing**
+  - [ ] viem `setText` calls via PublicResolver on Sepolia
+  - [ ] Confirm tx, retry on failure
+
+---
+
+## Tier 3 — Stretch
+
+### #9 ERC-7857 iNFT royalty wrapper · NICE
+
+**Goal:** Skill ownership = transferable iNFT. % of x402 revenue auto-routed to NFT holder.
+
+- [ ] Mint skill ENS as iNFT (token-bound account)
+- [ ] Splitter contract on Base
+- [ ] On x402 settlement, % to NFT holder
+- [ ] OpenSea metadata reflects live call count + revenue
+- [ ] 0G Storage holds the "intelligence" layer (sealed inference) — fits 0G iNFT track
+
+### #10 Marketplace integration · NICE
+
+**Goal:** A skill ENS listed on OpenSea Sepolia shows real call/revenue stats.
+
+- [ ] OpenSea metadata template that pulls from ENS text records
+- [ ] Test listing a skill ENS at low price on Sepolia OpenSea
+- [ ] Buyer flow: transfer ENS → inherits manifest publish authority
+- [ ] Demo Scene 7: open OpenSea tab showing the listing
+
+### #11 ENSIP draft · NICE
+
+- [ ] Forum post at https://discuss.ens.domains/c/ai
+- [ ] Specify `xyz.manifest.skill.*` namespace as candidate ENSIP
+- [ ] Reference implementation = this repo
+- [ ] Submit before May 6 to claim "draft ENSIP submitted" in pitch
+
+---
+
+## Skipped (explicit non-goals)
+
+- Advanced search/filter in Explorer (hardcoded list works for demo)
+- Multi-author governance / DAO ownership
+- Dispute resolution / takedown flow
+- Mainnet deployment of demo names (Sepolia only)
+- Custom resolver contracts (use ENS PublicResolver)
+- Subname access tokens (mentioned in pitch as creative angle, but not built)
+
+---
+
+## D-by-D burndown
+
+| Day | Date | What ships | Owner |
+|---|---|---|---|
+| D6 | Apr 29 | #1 reference skills authored (4 manifests) | Dev C |
+| D6 | Apr 29 | #4 KeeperHub Tier 0 stub through `execute_contract_call` | Dev B |
+| D7 | Apr 30 | #2 D5 kill-criterion live in Claude Desktop | Jason |
+| D8 | May 1 | #3 walkImports + lockfile draft | Jason |
+| D9 | May 2 | #4 x402 paid call lands on BaseScan | Dev B |
+| D10 | May 3 | #5 Explorer skill detail; #6 indexer v0 | Dev C |
+| D11 | May 4 | #7 versioning script; D11 cold-test rehearsal | All |
+| D12 | May 5 | **code freeze 6PM**; demo recording (5 takes) | Jason |
+| D13 | May 6 | submission on ETHGlobal Hacker Dashboard | Jason |
+
+---
+
+## Appendix — sub-issue conventions
+
+When opening these as GitHub issues:
+
+- **Title** = the sub-task, prefixed with parent number: `#3.2 SDK walkImports recursive resolver`
+- **Body** = goal + acceptance criteria as a checkbox list, plus links to relevant files
+- **Labels** = `tier-1` / `tier-2` / `tier-3`, plus `must` / `high` / `nice`
+- **Milestone** = `D7-mvp` / `D10-prize` / `D12-freeze`
+- **Assignee** = single owner per issue
+- **Closing** = a PR that links via `Closes #N` lands on `staging`


### PR DESCRIPTION
Brings the 'one ENS = one atomic skill' pivot to production. README, ROADMAP, dashboard, CLAUDE.md updated. Verified live on staging.