### PR TITLE
fix(ci): drop explicit pnpm version from action input

### DIFF
--- a/.github/workflows/cloudflare-deploy.yml
+++ b/.github/workflows/cloudflare-deploy.yml
@@ -24,8 +24,6 @@ jobs:
       - name: Setup pnpm
         if: hashFiles('pnpm-lock.yaml') != ''
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Setup Node
         if: hashFiles('pnpm-lock.yaml') != ''

--- a/.github/workflows/register-skills.yml
+++ b/.github/workflows/register-skills.yml
@@ -25,8 +25,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
Setup pnpm rejects having both `version:` in the workflow and `packageManager` in package.json. Drop the workflow input.