### PR TITLE
feat(bridge): rename to skill_import + structured logs + smoke test

### DIFF
--- a/scripts/test-issue-11.mts
+++ b/scripts/test-issue-11.mts
@@ -1,0 +1,155 @@
+#!/usr/bin/env tsx
+// Test issue #11 — stdio MCP smoke test for the bridge.
+//
+// Spawns @skillname/bridge as a child, speaks raw MCP JSON-RPC over stdio,
+// asserts the renamed built-in tools are present and the old ones are gone.
+// Run from repo root: pnpm tsx scripts/test-issue-11.mts
+
+import { spawn } from 'node:child_process'
+
+interface JsonRpcRequest {
+  jsonrpc: '2.0'
+  id: number
+  method: string
+  params?: unknown
+}
+
+interface JsonRpcResponse {
+  jsonrpc: '2.0'
+  id: number
+  result?: any
+  error?: { code: number; message: string }
+}
+
+const c = {
+  cyan:  (s: string) => `\x1b[36m${s}\x1b[0m`,
+  green: (s: string) => `\x1b[32m${s}\x1b[0m`,
+  red:   (s: string) => `\x1b[31m${s}\x1b[0m`,
+  dim:   (s: string) => `\x1b[2m${s}\x1b[0m`,
+}
+
+console.log(c.cyan('══ Issue #11 — bridge stdio MCP smoke test ══'))
+console.log()
+
+// Spawn the bridge via tsx so we don't require a build step.
+const child = spawn('pnpm', ['--silent', 'tsx', 'skillname-pack/packages/bridge/src/server.ts'], {
+  stdio: ['pipe', 'pipe', 'pipe'],
+})
+
+let stderrBuf = ''
+child.stderr.on('data', (d) => {
+  stderrBuf += d.toString()
+})
+
+// Read JSON-RPC responses from stdout, line-delimited.
+const pending = new Map<number, (resp: JsonRpcResponse) => void>()
+let stdoutBuf = ''
+child.stdout.on('data', (d) => {
+  stdoutBuf += d.toString()
+  let nl: number
+  while ((nl = stdoutBuf.indexOf('\n')) !== -1) {
+    const line = stdoutBuf.slice(0, nl).trim()
+    stdoutBuf = stdoutBuf.slice(nl + 1)
+    if (!line) continue
+    try {
+      const msg = JSON.parse(line) as JsonRpcResponse
+      if (typeof msg.id === 'number' && pending.has(msg.id)) {
+        pending.get(msg.id)!(msg)
+        pending.delete(msg.id)
+      }
+    } catch {
+      /* not a json-rpc line */
+    }
+  }
+})
+
+let nextId = 1
+function rpc<T = any>(method: string, params?: unknown, timeoutMs = 5000): Promise<T> {
+  const id = nextId++
+  const req: JsonRpcRequest = { jsonrpc: '2.0', id, method, params }
+  return new Promise<T>((resolve, reject) => {
+    const t = setTimeout(() => {
+      pending.delete(id)
+      reject(new Error(`rpc ${method} timed out after ${timeoutMs}ms`))
+    }, timeoutMs)
+    pending.set(id, (resp) => {
+      clearTimeout(t)
+      if (resp.error) reject(new Error(`rpc ${method}: ${resp.error.message}`))
+      else resolve(resp.result as T)
+    })
+    child.stdin.write(JSON.stringify(req) + '\n')
+  })
+}
+
+let failures = 0
+function check(label: string, ok: boolean, detail?: string): void {
+  if (ok) {
+    console.log(`  ${c.green('✓')} ${label}`)
+  } else {
+    failures++
+    console.log(`  ${c.red('✗')} ${label}${detail ? c.dim('  ' + detail) : ''}`)
+  }
+}
+
+try {
+  // 1. Initialize
+  const init = await rpc('initialize', {
+    protocolVersion: '2024-11-05',
+    capabilities: {},
+    clientInfo: { name: 'test-issue-11', version: '0.0.1' },
+  })
+  check('initialize succeeds', !!init?.serverInfo, init?.serverInfo && `server=${init.serverInfo.name}`)
+  check('server identifies as skillname', init?.serverInfo?.name === 'skillname')
+
+  // 2. tools/list
+  const list = await rpc<{ tools: Array<{ name: string; description: string }> }>('tools/list')
+  const toolNames = list.tools.map((t) => t.name)
+  check(`tools/list returns ${toolNames.length} tools`, toolNames.length >= 2, `[${toolNames.join(', ')}]`)
+  check('skill_import is registered', toolNames.includes('skill_import'))
+  check('skill_list_imported is registered', toolNames.includes('skill_list_imported'))
+  check('old manifest_load is gone', !toolNames.includes('manifest_load'))
+  check('old manifest_list_loaded is gone', !toolNames.includes('manifest_list_loaded'))
+
+  // 3. skill_import description should mention "import" not "load manifest"
+  const skillImport = list.tools.find((t) => t.name === 'skill_import')
+  check(
+    'skill_import description mentions "import"',
+    !!skillImport && /import/i.test(skillImport.description),
+  )
+
+  // 4. Calling a non-existent tool returns a clean error, not a crash
+  const callBad = await rpc<{ content: any[]; isError?: boolean }>('tools/call', {
+    name: 'nonexistent_tool',
+    arguments: {},
+  })
+  check('unknown tool returns isError', callBad.isError === true)
+
+  // 5. Calling skill_import with a bogus name returns isError, not a crash
+  const callBadEns = await rpc<{ content: any[]; isError?: boolean }>('tools/call', {
+    name: 'skill_import',
+    arguments: { ensName: 'this-name-does-not-exist-in-ens-anywhere.eth', chain: 'sepolia' },
+  })
+  check('skill_import on missing name returns isError', callBadEns.isError === true)
+} catch (e: any) {
+  failures++
+  console.log(`  ${c.red('✗')} unhandled error: ${e.message}`)
+} finally {
+  child.kill()
+}
+
+console.log()
+if (stderrBuf.trim()) {
+  console.log(c.dim('--- bridge stderr (first 8 lines) ---'))
+  for (const line of stderrBuf.trim().split('\n').slice(0, 8)) {
+    console.log(c.dim('  ' + line))
+  }
+  console.log()
+}
+
+if (failures === 0) {
+  console.log(c.green('All checks passed. Issue #11 (code) ready to merge.'))
+  process.exit(0)
+} else {
+  console.log(c.red(`${failures} check(s) failed. Fix before opening the PR.`))
+  process.exit(1)
+}

--- a/skillname-pack/packages/bridge/src/server.ts
+++ b/skillname-pack/packages/bridge/src/server.ts
@@ -1,7 +1,8 @@
 /**
  * @skillname/bridge
  *
- * MCP stdio server that resolves ENS names into MCP tools dynamically.
+ * MCP stdio server. Resolves an ENS name into one or more MCP tools and
+ * registers them dynamically — "ENS as the import statement for AI."
  *
  * Configure in Claude Desktop:
  *   ~/Library/Application Support/Claude/claude_desktop_config.json
@@ -16,9 +17,9 @@
  *   }
  *
  * Then in Claude:
- *   "Use research.agent.eth"
- *   → Bridge resolves ENS, fetches bundle, registers tools
- *   → Claude can immediately call those tools
+ *   "Use quote.uniswap.eth"
+ *   → Bridge resolves the ENS name, fetches the manifest, registers its tool
+ *   → Claude can immediately call it
  */
 
 import { Server } from '@modelcontextprotocol/sdk/server/index.js'
@@ -31,18 +32,32 @@ import {
 import { resolveSkill, type ResolveResult, type Tool } from '@skillname/sdk'
 
 // -------------------------------------------------------------------------
+// Structured stderr logging.
+// MCP uses stdout for the wire protocol — every diagnostic must go to stderr.
+// We prefix lines with arrows so the demo screen recording reads cleanly.
+// -------------------------------------------------------------------------
+
+const log = {
+  in:   (msg: string) => process.stderr.write(`→ ${msg}\n`),
+  out:  (msg: string) => process.stderr.write(`← ${msg}\n`),
+  ok:   (msg: string) => process.stderr.write(`✓ ${msg}\n`),
+  err:  (msg: string) => process.stderr.write(`✗ ${msg}\n`),
+  info: (msg: string) => process.stderr.write(`· ${msg}\n`),
+}
+
+// -------------------------------------------------------------------------
 // State
 // -------------------------------------------------------------------------
 
-interface LoadedBundle {
+interface ImportedSkill {
   ensName: string
   result: ResolveResult
-  loadedAt: number
+  importedAt: number
 }
 
-const loaded: Map<string, LoadedBundle> = new Map()
+const imported: Map<string, ImportedSkill> = new Map()
 
-const CACHE_TTL_MS = 5 * 60 * 1000  // 5 min
+const CACHE_TTL_MS = 5 * 60 * 1000 // 5 min
 
 // -------------------------------------------------------------------------
 // MCP server
@@ -53,56 +68,55 @@ const server = new Server(
   { capabilities: { tools: {} } }
 )
 
-// Built-in tool: load_manifest
-const LOAD_MANIFEST_TOOL: MCPTool = {
-  name: 'manifest_load',
+// Built-in: skill_import — replaces the old manifest_load
+const SKILL_IMPORT_TOOL: MCPTool = {
+  name: 'skill_import',
   description:
-    'Load MCP tools from an ENS name. Resolves the name via ENS text records, fetches the skill bundle from IPFS, and registers all its tools dynamically. Use this whenever the user mentions an ENS name like "use research.agent.eth" or "load tools from foo.eth".',
+    'Import a skill by ENS name. Resolves the name via ENS text records, fetches the bundle from IPFS, and registers its function(s) as MCP tools. Use this whenever the user mentions an ENS name like "import quote.uniswap.eth", "use swap.uniswap.eth", or "load skills from foo.eth".',
   inputSchema: {
     type: 'object',
     properties: {
       ensName: {
         type: 'string',
-        description:
-          'ENS name to resolve, e.g. "research.agent.eth" or "deepbook.eth"',
+        description: 'ENS name to import, e.g. "quote.uniswap.eth" or "score.gitcoin.eth"',
       },
       chain: {
         type: 'string',
         enum: ['mainnet', 'sepolia'],
         default: 'sepolia',
-        description: 'Chain to resolve ENS on',
+        description: 'Chain to resolve ENS on (default: sepolia for hackathon)',
       },
     },
     required: ['ensName'],
   },
 }
 
-const MANIFEST_LIST_TOOL: MCPTool = {
-  name: 'manifest_list_loaded',
+const SKILL_LIST_TOOL: MCPTool = {
+  name: 'skill_list_imported',
   description:
-    'List all currently loaded skill bundles and their tools. Useful for confirming what is available.',
+    'List every skill currently imported and the function(s) it registered. Useful for confirming what is available before calling a tool.',
   inputSchema: { type: 'object', properties: {} },
 }
 
 // -------------------------------------------------------------------------
-// Tool listing — returns built-ins + dynamically loaded tools
+// Tool listing — built-ins + dynamically imported skills
 // -------------------------------------------------------------------------
 
 server.setRequestHandler(ListToolsRequestSchema, async () => {
   const dynamicTools: MCPTool[] = []
 
-  for (const [, b] of loaded) {
-    for (const t of b.result.bundle.tools) {
+  for (const [, s] of imported) {
+    for (const t of s.result.bundle.tools) {
       dynamicTools.push({
-        name: `${b.result.bundle.name}__${t.name}`,
-        description: `[${b.ensName}] ${t.description}`,
+        name: `${s.result.bundle.name}__${t.name}`,
+        description: `[${s.ensName}] ${t.description}`,
         inputSchema: t.inputSchema as MCPTool['inputSchema'],
       })
     }
   }
 
   return {
-    tools: [LOAD_MANIFEST_TOOL, MANIFEST_LIST_TOOL, ...dynamicTools],
+    tools: [SKILL_IMPORT_TOOL, SKILL_LIST_TOOL, ...dynamicTools],
   }
 })
 
@@ -114,60 +128,61 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
   const name = req.params.name
   const args = req.params.arguments ?? {}
 
-  // -- Built-in: load manifest --
-  if (name === 'manifest_load') {
+  // -- Built-in: import a skill --
+  if (name === 'skill_import') {
     const ensName = args.ensName as string
     const chain = (args.chain as 'mainnet' | 'sepolia') ?? 'sepolia'
+    const t0 = Date.now()
+    log.in(`skill_import ${ensName} (${chain})`)
 
     try {
       const result = await resolveSkill(ensName, { chain })
-      loaded.set(ensName, { ensName, result, loadedAt: Date.now() })
+      imported.set(ensName, { ensName, result, importedAt: Date.now() })
 
       const verified = result.ensip25?.bound ? '✓ verified' : 'unverified'
       const toolsList = result.bundle.tools
-        .map((t) => `  - ${result.bundle.name}__${t.name}: ${t.description}`)
+        .map((t) => `  · ${result.bundle.name}__${t.name}: ${t.description}`)
         .join('\n')
+
+      const dt = Date.now() - t0
+      log.ok(`imported ${ensName} (${verified}) in ${dt}ms`)
+      log.info(`registered ${result.bundle.tools.length} tool(s) from ${result.cid.slice(0, 16)}…`)
 
       return {
         content: [
           {
             type: 'text',
             text:
-              `Loaded ${result.bundle.tools.length} tools from ${ensName} (${verified})\n` +
+              `Imported ${result.bundle.tools.length} tool(s) from ${ensName} (${verified})\n` +
               `Version: ${result.version ?? 'unspecified'}\n` +
               `CID: ${result.cid}\n\n` +
-              `Available tools:\n${toolsList}`,
+              `Tools:\n${toolsList}`,
           },
         ],
       }
     } catch (e: any) {
+      log.err(`import ${ensName} failed: ${e.message}`)
       return {
-        content: [
-          {
-            type: 'text',
-            text: `Failed to load ${ensName}: ${e.message}`,
-          },
-        ],
+        content: [{ type: 'text', text: `Failed to import ${ensName}: ${e.message}` }],
         isError: true,
       }
     }
   }
 
-  // -- Built-in: list --
-  if (name === 'manifest_list_loaded') {
+  // -- Built-in: list imported --
+  if (name === 'skill_list_imported') {
+    log.in('skill_list_imported')
     const lines: string[] = []
-    for (const [ens, b] of loaded) {
-      lines.push(`${ens} (v${b.result.version ?? '?'}):`)
-      for (const t of b.result.bundle.tools) {
-        lines.push(`  - ${b.result.bundle.name}__${t.name}`)
+    for (const [ens, s] of imported) {
+      const age = Math.floor((Date.now() - s.importedAt) / 1000)
+      lines.push(`${ens} (v${s.result.version ?? '?'}, ${age}s ago):`)
+      for (const t of s.result.bundle.tools) {
+        lines.push(`  · ${s.result.bundle.name}__${t.name}`)
       }
     }
     return {
       content: [
-        {
-          type: 'text',
-          text: lines.length ? lines.join('\n') : 'No bundles loaded.',
-        },
+        { type: 'text', text: lines.length ? lines.join('\n') : 'No skills imported yet. Use skill_import to bring one in.' },
       ],
     }
   }
@@ -175,6 +190,7 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
   // -- Dynamic: dispatch by namespace --
   const sep = name.indexOf('__')
   if (sep === -1) {
+    log.err(`unknown tool: ${name}`)
     return {
       content: [{ type: 'text', text: `Unknown tool: ${name}` }],
       isError: true,
@@ -183,34 +199,35 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
 
   const bundleName = name.slice(0, sep)
   const toolName = name.slice(sep + 2)
+  log.in(`${name} (looking up ${bundleName}/${toolName})`)
 
-  // Find loaded bundle by name (not ENS)
-  let bundle: LoadedBundle | undefined
-  for (const b of loaded.values()) {
-    if (b.result.bundle.name === bundleName) {
-      bundle = b
+  let skill: ImportedSkill | undefined
+  for (const s of imported.values()) {
+    if (s.result.bundle.name === bundleName) {
+      skill = s
       break
     }
   }
-  if (!bundle) {
+  if (!skill) {
+    log.err(`bundle "${bundleName}" not imported`)
     return {
       content: [
-        { type: 'text', text: `Bundle "${bundleName}" not loaded. Run manifest_load first.` },
+        { type: 'text', text: `Skill "${bundleName}" not imported. Use skill_import first.` },
       ],
       isError: true,
     }
   }
 
-  const tool = bundle.result.bundle.tools.find((t) => t.name === toolName)
+  const tool = skill.result.bundle.tools.find((t) => t.name === toolName)
   if (!tool) {
+    log.err(`tool ${toolName} not in ${bundleName}`)
     return {
-      content: [{ type: 'text', text: `Tool ${toolName} not in bundle ${bundleName}` }],
+      content: [{ type: 'text', text: `Tool ${toolName} not in skill ${bundleName}` }],
       isError: true,
     }
   }
 
-  // -- Route based on execution type --
-  return await executeRouted(tool, args, bundle)
+  return await executeRouted(tool, args, skill)
 })
 
 // -------------------------------------------------------------------------
@@ -220,16 +237,18 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
 async function executeRouted(
   tool: Tool,
   args: Record<string, unknown>,
-  bundle: LoadedBundle
+  skill: ImportedSkill
 ) {
+  log.info(`exec.type = ${tool.execution.type}`)
   switch (tool.execution.type) {
     case 'local':
-      return executeLocal(tool, args, bundle)
+      return executeLocal(tool, args, skill)
     case 'keeperhub':
-      return executeKeeperHub(tool, args, bundle)
+      return executeKeeperHub(tool, args, skill)
     case 'http':
-      return executeHttp(tool, args, bundle)
+      return executeHttp(tool, args, skill)
     default:
+      log.err(`unsupported execution: ${(tool.execution as any).type}`)
       return {
         content: [
           { type: 'text', text: `Unsupported execution type: ${(tool.execution as any).type}` },
@@ -239,8 +258,8 @@ async function executeRouted(
   }
 }
 
-async function executeLocal(tool: Tool, args: Record<string, unknown>, _bundle: LoadedBundle) {
-  // For hackathon: stub. Real impl loads handler from bundle and executes.
+async function executeLocal(tool: Tool, args: Record<string, unknown>, _skill: ImportedSkill) {
+  // Hackathon stub: real impl loads handler from bundle and executes.
   return {
     content: [
       {
@@ -251,44 +270,55 @@ async function executeLocal(tool: Tool, args: Record<string, unknown>, _bundle: 
   }
 }
 
-async function executeKeeperHub(tool: Tool, args: Record<string, unknown>, _bundle: LoadedBundle) {
-  // Day 8: route to KeeperHub MCP via HTTP
-  // Day 9: handle x402 payment challenge if execution.payment present
+async function executeKeeperHub(tool: Tool, args: Record<string, unknown>, _skill: ImportedSkill) {
+  // Issue #13: route to KeeperHub MCP + handle x402 challenge.
   const exec = tool.execution as Extract<Tool['execution'], { type: 'keeperhub' }>
 
   if (exec.payment) {
-    // TODO: implement x402 flow
     return {
       content: [
         {
           type: 'text',
-          text: `[D9] Would call KeeperHub ${exec.tool ?? exec.workflowId} with x402 payment ${exec.payment.price} ${exec.payment.token} on ${exec.payment.network}. Args: ${JSON.stringify(args)}`,
+          text: `[#13] Would call KeeperHub ${exec.tool ?? exec.workflowId} with x402 payment ${exec.payment.price} ${exec.payment.token} on ${exec.payment.network}. Args: ${JSON.stringify(args)}`,
         },
       ],
     }
   }
 
-  // TODO: direct KeeperHub MCP call
   return {
     content: [
       {
         type: 'text',
-        text: `[D8 stub] Would call KeeperHub ${exec.tool ?? exec.workflowId}. Args: ${JSON.stringify(args)}`,
+        text: `[#13 stub] Would call KeeperHub ${exec.tool ?? exec.workflowId}. Args: ${JSON.stringify(args)}`,
       },
     ],
   }
 }
 
-async function executeHttp(tool: Tool, args: Record<string, unknown>, _bundle: LoadedBundle) {
+async function executeHttp(tool: Tool, args: Record<string, unknown>, _skill: ImportedSkill) {
   const exec = tool.execution as Extract<Tool['execution'], { type: 'http' }>
-  const res = await fetch(exec.endpoint, {
-    method: exec.method ?? 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(args),
-  })
+  const t0 = Date.now()
+  log.out(`${exec.method ?? 'POST'} ${exec.endpoint}`)
+
+  // For GET, send args as query string; for everything else, JSON body.
+  let url = exec.endpoint
+  let init: RequestInit = { method: exec.method ?? 'POST' }
+  if ((exec.method ?? 'POST') === 'GET') {
+    const qs = new URLSearchParams()
+    for (const [k, v] of Object.entries(args)) {
+      if (v !== undefined && v !== null) qs.set(k, String(v))
+    }
+    url += (url.includes('?') ? '&' : '?') + qs.toString()
+  } else {
+    init.headers = { 'Content-Type': 'application/json' }
+    init.body = JSON.stringify(args)
+  }
+
+  const res = await fetch(url, init)
   const text = await res.text()
+  log.ok(`${res.status} in ${Date.now() - t0}ms`)
   return {
-    content: [{ type: 'text', text: `HTTP ${res.status}: ${text}` }],
+    content: [{ type: 'text', text }],
     isError: !res.ok,
   }
 }
@@ -300,11 +330,10 @@ async function executeHttp(tool: Tool, args: Record<string, unknown>, _bundle: L
 async function main() {
   const transport = new StdioServerTransport()
   await server.connect(transport)
-  // stderr only — stdout is reserved for MCP protocol
-  console.error('skillname bridge ready')
+  log.ok('skillname bridge ready · stdio · MCP')
 }
 
 main().catch((e) => {
-  console.error('Fatal:', e)
+  log.err(`fatal: ${e.message ?? e}`)
   process.exit(1)
 })

--- a/skillname-pack/packages/sdk/src/index.ts
+++ b/skillname-pack/packages/sdk/src/index.ts
@@ -12,7 +12,10 @@ import { createPublicClient, http, type Address, type PublicClient } from 'viem'
 import { mainnet, sepolia } from 'viem/chains'
 import { normalize, namehash } from 'viem/ens'
 import { validate as validateBundle } from '@skillname/schema'
-import { createVerifiedFetch, type VerifiedFetch } from '@helia/verified-fetch'
+// @helia/verified-fetch is dynamically imported in getVerifiedFetch() —
+// it pulls libp2p webrtc with native bindings, so we only load it on the
+// first verified fetch call. If the dynamic import fails, the SDK falls
+// through to the public-gateway path silently.
 
 // -------------------------------------------------------------------------
 // Types
@@ -201,12 +204,23 @@ export async function resolveSkill(
 // Fetch + content-address verify
 // -------------------------------------------------------------------------
 
-// Lazy-init Helia verified-fetch — initializing it eagerly costs ~300ms and
-// loads native bindings, so we defer until the first resolution call.
-let _verifiedFetch: VerifiedFetch | null = null
-async function getVerifiedFetch(): Promise<VerifiedFetch> {
-  if (!_verifiedFetch) {
-    _verifiedFetch = await createVerifiedFetch()
+// Lazy + optional Helia verified-fetch. Dynamic import keeps the helia
+// dep — including its libp2p-webrtc native binding — out of the SDK's
+// load path. If helia is unavailable in the host (browser, edge worker,
+// or environment without native deps), verified fetch is skipped and
+// callers fall through to the public-gateway path.
+type VerifiedFetchFn = (resource: string | URL | Request) => Promise<Response>
+let _verifiedFetch: VerifiedFetchFn | null = null
+let _verifiedFetchAttempted = false
+async function getVerifiedFetch(): Promise<VerifiedFetchFn | null> {
+  if (_verifiedFetchAttempted) return _verifiedFetch
+  _verifiedFetchAttempted = true
+  try {
+    const mod = await import('@helia/verified-fetch')
+    _verifiedFetch = (await mod.createVerifiedFetch()) as VerifiedFetchFn
+  } catch (e) {
+    console.warn('verified-fetch unavailable, will use gateway:', (e as Error).message)
+    _verifiedFetch = null
   }
   return _verifiedFetch
 }
@@ -219,11 +233,13 @@ async function fetchAndVerify(
   if (!options.skipVerification) {
     try {
       const verifiedFetch = await getVerifiedFetch()
-      const response = await verifiedFetch(`ipfs://${cid}/manifest.json`)
-      if (response.ok) {
-        return (await response.json()) as SkillBundle
+      if (verifiedFetch) {
+        const response = await verifiedFetch(`ipfs://${cid}/manifest.json`)
+        if (response.ok) {
+          return (await response.json()) as SkillBundle
+        }
+        console.warn(`Verified fetch returned ${response.status}; falling back to gateway`)
       }
-      console.warn(`Verified fetch returned ${response.status}; falling back to gateway`)
     } catch (e) {
       console.warn('Verified fetch failed, falling back to gateway:', e)
     }


### PR DESCRIPTION
Resolves the code half of [#11](https://github.com/hien-p/Skillname/issues/11). The Claude Desktop test (the actual D5 kill-criterion) is your last manual step.

### What ships

- `manifest_load` → `skill_import`, `manifest_list_loaded` → `skill_list_imported` — matches the 'import' pivot.
- Structured stderr logging (`→` `←` `✓` `✗` `·` prefixes) so the demo screen recording reads like a real device console.
- HTTP executor now sends GET args as query string (it used to send a body, which most APIs reject).
- SDK's `@helia/verified-fetch` import is now dynamic. If helia or its native libp2p-webrtc binding isn't loadable (CI / browser / edge), the SDK silently falls through to public-gateway fetch instead of crashing on import. **This was the actual blocker for the bridge booting at all** — without it, issue #11 was unreachable.
- New `scripts/test-issue-11.mts` — spawns the bridge as a child, speaks raw MCP JSON-RPC, asserts:
  - initialize succeeds, server name is `skillname`
  - `skill_import` and `skill_list_imported` registered
  - old `manifest_load` / `manifest_list_loaded` gone
  - description mentions 'import'
  - unknown tool + bad ENS return `isError` without crashing

### Run the test

```bash
pnpm tsx scripts/test-issue-11.mts
```

10/10 passing locally.

### Your D5 step (Claude Desktop, manual)

After this lands and you've got at least one ENS name registered (`skilltest.eth` once the second tx lands), edit `~/Library/Application Support/Claude/claude_desktop_config.json`:

```json
{
  "mcpServers": {
    "skillname": {
      "command": "node",
      "args": ["<absolute-path-to>/skillname-pack/packages/bridge/dist/server.js"]
    }
  }
}
```

Run `pnpm --filter @skillname/bridge build` first to populate `dist/`. Restart Claude Desktop. In a chat, say *Use `<your-test-name>.eth`* — the `skill_import` tool should fire and surface the imported function in the tool picker.

Refs #11.