### PR TITLE
feat: 0G storage as primary backend (pin + resolve)

### DIFF
--- a/.github/workflows/pin-and-register.yml
+++ b/.github/workflows/pin-and-register.yml
@@ -1,0 +1,64 @@
+name: Pin to 0G + register skills on Sepolia
+
+on:
+  workflow_dispatch:
+    inputs:
+      parent:
+        description: "Parent ENS name on Sepolia (must be owned by SEPOLIA_PRIVATE_KEY)"
+        required: true
+        default: "skilltest.eth"
+      slug:
+        description: "Slug to pin (single bundle). Leave empty to pin all bundles."
+        required: false
+        default: ""
+
+concurrency:
+  group: pin-and-register
+  cancel-in-progress: false
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build packages
+        run: pnpm build
+
+      - id: pin
+        name: Pin to 0G
+        env:
+          SEPOLIA_PRIVATE_KEY: ${{ secrets.SEPOLIA_PRIVATE_KEY }}
+          OG_RPC_URL: ${{ vars.OG_RPC_URL || 'https://evmrpc-testnet.0g.ai' }}
+        run: |
+          if [ -n "${{ inputs.slug }}" ]; then
+            pnpm tsx scripts/pin-to-0g.ts "${{ inputs.slug }}"
+          else
+            pnpm tsx scripts/pin-to-0g.ts
+          fi
+
+      - name: Register subnames + set text records
+        env:
+          SEPOLIA_PRIVATE_KEY: ${{ secrets.SEPOLIA_PRIVATE_KEY }}
+          SEPOLIA_RPC_URL: ${{ secrets.SEPOLIA_RPC_URL }}
+        run: |
+          ROOTS="${{ steps.pin.outputs.roots }}"
+          if [ -z "$ROOTS" ]; then
+            echo "::warning::pin step did not produce any 0G roots; skipping register"
+            exit 0
+          fi
+          pnpm tsx scripts/register-skills.ts \
+            --parent "${{ inputs.parent }}" \
+            --roots "$ROOTS"

--- a/package.json
+++ b/package.json
@@ -13,13 +13,17 @@
     "cli": "pnpm --filter @skillname/cli exec skill",
     "validate-skills": "./scripts/test-issue-10.sh"
   },
-  "engines": { "node": ">=20" },
+  "engines": {
+    "node": ">=20"
+  },
   "packageManager": "pnpm@10.28.0",
   "devDependencies": {
-    "typescript": "^5.6.3",
-    "tsx": "^4.19.2",
-    "vitest": "^2.1.8",
+    "@0glabs/0g-ts-sdk": "^0.3.3",
     "@types/node": "^22.10.0",
-    "viem": "^2.21.55"
+    "ethers": "^6.16.0",
+    "tsx": "^4.19.2",
+    "typescript": "^5.6.3",
+    "viem": "^2.21.55",
+    "vitest": "^2.1.8"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,15 @@ importers:
 
   .:
     devDependencies:
+      '@0glabs/0g-ts-sdk':
+        specifier: ^0.3.3
+        version: 0.3.3(bufferutil@4.1.0)(ethers@6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(utf-8-validate@5.0.10)
       '@types/node':
         specifier: ^22.10.0
         version: 22.19.17
+      ethers:
+        specifier: ^6.16.0
+        version: 6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       tsx:
         specifier: ^4.19.2
         version: 4.21.0
@@ -19,7 +25,7 @@ importers:
         version: 5.9.3
       viem:
         specifier: ^2.21.55
-        version: 2.48.4(typescript@5.9.3)(zod@3.25.76)
+        version: 2.48.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       vitest:
         specifier: ^2.1.8
         version: 2.1.9(@types/node@22.19.17)(terser@5.46.2)
@@ -40,7 +46,7 @@ importers:
         version: link:../sdk
       viem:
         specifier: ^2.21.55
-        version: 2.48.4(typescript@5.9.3)(zod@3.25.76)
+        version: 2.48.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
 
   skillname-pack/packages/schema:
     dependencies:
@@ -55,15 +61,20 @@ importers:
     dependencies:
       '@helia/verified-fetch':
         specifier: ^2.3.0
-        version: 2.6.19(react-native@0.85.2(@babel/core@7.29.0)(react@19.2.5))
+        version: 2.6.19(bufferutil@4.1.0)(react-native@0.85.2(@babel/core@7.29.0)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@5.0.10))(utf-8-validate@5.0.10)
       '@skillname/schema':
         specifier: workspace:*
         version: link:../schema
       viem:
         specifier: ^2.21.55
-        version: 2.48.4(typescript@5.9.3)(zod@3.25.76)
+        version: 2.48.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
 
 packages:
+
+  '@0glabs/0g-ts-sdk@0.3.3':
+    resolution: {integrity: sha512-Ug/9gdeBnmTYU6obPXWChD8XqNUSyOI53vWWsbK2IXNymQc84gd1cDneQ2Vz2AZP26290pIp5FgmNgkVNOyxIA==}
+    peerDependencies:
+      ethers: 6.13.1
 
   '@achingbrain/http-parser-js@0.5.9':
     resolution: {integrity: sha512-nPuMf2zVzBAGRigH/1jFpb/6HmJsps+15f4BPlGDp3vsjYB2ZgruAErUpKpcFiVRz3DHLXcGNmuwmqZx/sVI7A==}
@@ -73,6 +84,9 @@ packages:
 
   '@achingbrain/ssdp@4.2.4':
     resolution: {integrity: sha512-1dZIV7dwYJRS1sTA0qIDzsMdwZAnPa7DGb2YuPqMq4PjEjvzBBuz2WIsXnrkRFCNY00JuqLiMby9GecnGsOgaQ==}
+
+  '@adraffy/ens-normalize@1.10.1':
+    resolution: {integrity: sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==}
 
   '@adraffy/ens-normalize@1.11.1':
     resolution: {integrity: sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==}
@@ -470,6 +484,15 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@ethersproject/bytes@5.8.0':
+    resolution: {integrity: sha512-vTkeohgJVCPVHu5c25XWaWQOZ4v+DkGoC42/TS2ond+PARCxTJvgTFUNDZovyQ/uAQ4EcpqqowKydcdmRKjg7A==}
+
+  '@ethersproject/keccak256@5.8.0':
+    resolution: {integrity: sha512-A1pkKLZSz8pDaQ1ftutZoaN46I6+jvuqugx5KYNeQOPqq+JZ0Txm7dlWesCHB5cndJSu5vP2VKptKf7cksERng==}
+
+  '@ethersproject/logger@5.8.0':
+    resolution: {integrity: sha512-Qe6knGmY+zPPWTC+wQrpitodgBfH7XoceCGL5bJVejmH+yCS3R8jJm8iiWuvWbG76RUmyEG53oqv6GMVWqunjA==}
+
   '@helia/bitswap@2.2.0':
     resolution: {integrity: sha512-fYHjXM8SZpgRkGRM7qq8VVpBsrSLHlRGTLUEesfKZ+wYBYHZaqpn0mT9KbdLZowLrooz0qaUUiF6OIZBNmArcw==}
 
@@ -685,6 +708,9 @@ packages:
     resolution: {integrity: sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==}
     engines: {node: ^14.21.3 || >=16}
 
+  '@noble/curves@1.2.0':
+    resolution: {integrity: sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==}
+
   '@noble/curves@1.9.1':
     resolution: {integrity: sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==}
     engines: {node: ^14.21.3 || >=16}
@@ -696,6 +722,10 @@ packages:
   '@noble/curves@2.2.0':
     resolution: {integrity: sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==}
     engines: {node: '>= 20.19.0'}
+
+  '@noble/hashes@1.3.2':
+    resolution: {integrity: sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==}
+    engines: {node: '>= 16'}
 
   '@noble/hashes@1.8.0':
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
@@ -984,6 +1014,9 @@ packages:
   '@types/node@22.19.17':
     resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
 
+  '@types/node@22.7.5':
+    resolution: {integrity: sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==}
+
   '@types/retry@0.12.2':
     resolution: {integrity: sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==}
 
@@ -1062,6 +1095,9 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  aes-js@4.0.0-beta.5:
+    resolution: {integrity: sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==}
+
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
@@ -1110,6 +1146,9 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
+  axios@0.27.2:
+    resolution: {integrity: sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==}
+
   axios@1.15.2:
     resolution: {integrity: sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==}
 
@@ -1156,6 +1195,10 @@ packages:
 
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
+
+  bufferutil@4.1.0:
+    resolution: {integrity: sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==}
+    engines: {node: '>=6.14.2'}
 
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
@@ -1258,6 +1301,10 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  d@1.0.2:
+    resolution: {integrity: sha512-MOqHvMWF9/9MX6nza0KgvFH4HpMU0EF5uUDXqX/BtxtU8NfB0QzRtJ8Oe/6SuS4kbhyzVJwjd97EA4PKrzJ8bw==}
+    engines: {node: '>=0.12'}
 
   datastore-core@10.0.4:
     resolution: {integrity: sha512-IctgCO0GA7GHG7aRm3JRruibCsfvN4EXNnNIlLCZMKIv0TPkdAL5UFV3/xTYFYrrZ1jRNrXZNZRvfcVf/R+rAw==}
@@ -1376,6 +1423,17 @@ packages:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
 
+  es5-ext@0.10.64:
+    resolution: {integrity: sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==}
+    engines: {node: '>=0.10'}
+
+  es6-iterator@2.0.3:
+    resolution: {integrity: sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==}
+
+  es6-symbol@3.1.4:
+    resolution: {integrity: sha512-U9bFFjX8tFiATgtkJ1zg25+KviIXpgRvRHS8sau3GfhVzThRQrOeksPeT0BWW2MNZs1OEWJ1DPXOQMn0KKRkvg==}
+    engines: {node: '>=0.12'}
+
   esbuild@0.21.5:
     resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
     engines: {node: '>=12'}
@@ -1397,12 +1455,23 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
+  esniff@2.0.1:
+    resolution: {integrity: sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==}
+    engines: {node: '>=0.10'}
+
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
   etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
+
+  ethers@6.16.0:
+    resolution: {integrity: sha512-U1wulmetNymijEhpSEQ7Ct/P/Jw9/e7R1j5XIbPRydgV2DjLVMsULDlNksq3RQnFgKoLlZf88ijYtWEXcPa07A==}
+    engines: {node: '>=14.0.0'}
+
+  event-emitter@0.3.5:
+    resolution: {integrity: sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==}
 
   event-iterator@2.0.0:
     resolution: {integrity: sha512-KGft0ldl31BZVV//jj+IAIGCxkvvUkkON+ScH6zfoX+l+omX6001ggyRSpI0Io2Hlro0ThXotswCtfzS8UkIiQ==}
@@ -1431,6 +1500,9 @@ packages:
 
   exponential-backoff@3.1.3:
     resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
+
+  ext@1.7.0:
+    resolution: {integrity: sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -1713,6 +1785,9 @@ packages:
     resolution: {integrity: sha512-rbku49cWloU5bSMI+zaRaXdQHXnthP6DZ/vLnfdSKyL4zUzuWnomtOEiZZOd+ioQ+avFo/qau3KPTc7Fjy1uPA==}
     engines: {node: '>=12'}
 
+  is-typedarray@1.0.0:
+    resolution: {integrity: sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==}
+
   is-wsl@2.2.0:
     resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
     engines: {node: '>=8'}
@@ -1846,6 +1921,9 @@ packages:
   jest-worker@29.7.0:
     resolution: {integrity: sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  js-sha3@0.8.0:
+    resolution: {integrity: sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -2061,6 +2139,9 @@ packages:
     resolution: {integrity: sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==}
     engines: {node: '>= 0.4.0'}
 
+  next-tick@1.1.0:
+    resolution: {integrity: sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==}
+
   node-abi@3.89.0:
     resolution: {integrity: sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==}
     engines: {node: '>=10'}
@@ -2077,6 +2158,10 @@ packages:
   node-forge@1.4.0:
     resolution: {integrity: sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==}
     engines: {node: '>= 6.13.0'}
+
+  node-gyp-build@4.8.4:
+    resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
+    hasBin: true
 
   node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
@@ -2101,6 +2186,9 @@ packages:
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  open-jsonrpc-provider@0.2.1:
+    resolution: {integrity: sha512-b+pRxakRwAqp+4OTh2TeH+z2zwVGa0C4fbcwIn6JsZdjd4VBmsp7KfCdmmV3XH8diecwXa5UILCw4IwAtk1DTQ==}
 
   open@7.4.2:
     resolution: {integrity: sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==}
@@ -2283,6 +2371,9 @@ packages:
   readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
+
+  reconnecting-websocket@4.4.0:
+    resolution: {integrity: sha512-D2E33ceRPga0NvTDhJmphEgJ7FUYF0v4lr1ki0csq06OdlxKfugGzN0dSkxM/NfqCxYELK4KcaTOUOjTV6Dcng==}
 
   reflect-metadata@0.2.2:
     resolution: {integrity: sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==}
@@ -2541,6 +2632,9 @@ packages:
   tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
 
+  tslib@2.7.0:
+    resolution: {integrity: sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -2560,6 +2654,12 @@ packages:
     resolution: {integrity: sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==}
     engines: {node: '>=8'}
 
+  type@2.7.3:
+    resolution: {integrity: sha512-8j+1QmAbPvLZow5Qpi6NCaN8FB60p/6x8/vfNqOk/hC+HuvFZhL4+WfekuhQLiqFZXOgQdrs3B+XxEmCc6b3FQ==}
+
+  typedarray-to-buffer@3.1.5:
+    resolution: {integrity: sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==}
+
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
@@ -2578,6 +2678,9 @@ packages:
   uint8arrays@5.1.1:
     resolution: {integrity: sha512-9muQwa4wZG4dKi9gMAIBtnk2Pw87SRpvWTH6lOGm19V2Uqxr4uomUf2PGqPnWc+qs06sN8owUU4jfcoWOcfwVQ==}
 
+  undici-types@6.19.8:
+    resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
+
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
@@ -2594,6 +2697,10 @@ packages:
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
+
+  utf-8-validate@5.0.10:
+    resolution: {integrity: sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==}
+    engines: {node: '>=6.14.2'}
 
   utf8-byte-length@1.0.5:
     resolution: {integrity: sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA==}
@@ -2695,6 +2802,10 @@ packages:
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
+  websocket@1.0.35:
+    resolution: {integrity: sha512-/REy6amwPZl44DDzvRCkaI1q1bIiQB0mEFQLUrhz3z2EK91cp3n72rAjUlrTP0zV22HJIUOVHQGPxhFRjxjt+Q==}
+    engines: {node: '>=4.0.0'}
+
   whatwg-fetch@3.6.20:
     resolution: {integrity: sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==}
 
@@ -2728,6 +2839,18 @@ packages:
     peerDependencies:
       bufferutil: ^4.0.1
       utf-8-validate: ^5.0.2
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  ws@8.17.1:
+    resolution: {integrity: sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
     peerDependenciesMeta:
       bufferutil:
         optional: true
@@ -2770,6 +2893,11 @@ packages:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
 
+  yaeti@0.0.6:
+    resolution: {integrity: sha512-MvQa//+KcZCUkBTIC9blM+CU9J2GzuTytsOUwf2lidtvkx/6gnEp1QvJv34t9vdjhFmha/mUiNDbN0D0mJWdug==}
+    engines: {node: '>=0.10.32'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
@@ -2790,6 +2918,18 @@ packages:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
 snapshots:
+
+  '@0glabs/0g-ts-sdk@0.3.3(bufferutil@4.1.0)(ethers@6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(utf-8-validate@5.0.10)':
+    dependencies:
+      '@ethersproject/bytes': 5.8.0
+      '@ethersproject/keccak256': 5.8.0
+      ethers: 6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      open-jsonrpc-provider: 0.2.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - supports-color
+      - utf-8-validate
 
   '@achingbrain/http-parser-js@0.5.9':
     dependencies:
@@ -2813,6 +2953,8 @@ snapshots:
       freeport-promise: 2.0.0
       merge-options: 3.0.4
       xml2js: 0.6.2
+
+  '@adraffy/ens-normalize@1.10.1': {}
 
   '@adraffy/ens-normalize@1.11.1': {}
 
@@ -3115,6 +3257,17 @@ snapshots:
   '@esbuild/win32-x64@0.27.7':
     optional: true
 
+  '@ethersproject/bytes@5.8.0':
+    dependencies:
+      '@ethersproject/logger': 5.8.0
+
+  '@ethersproject/keccak256@5.8.0':
+    dependencies:
+      '@ethersproject/bytes': 5.8.0
+      js-sha3: 0.8.0
+
+  '@ethersproject/logger@5.8.0': {}
+
   '@helia/bitswap@2.2.0':
     dependencies:
       '@helia/interface': 5.4.0
@@ -3283,7 +3436,7 @@ snapshots:
       progress-events: 1.1.0
       uint8arrays: 5.1.1
 
-  '@helia/verified-fetch@2.6.19(react-native@0.85.2(@babel/core@7.29.0)(react@19.2.5))':
+  '@helia/verified-fetch@2.6.19(bufferutil@4.1.0)(react-native@0.85.2(@babel/core@7.29.0)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@5.0.10))(utf-8-validate@5.0.10)':
     dependencies:
       '@helia/block-brokers': 4.2.4
       '@helia/car': 4.2.0
@@ -3299,12 +3452,12 @@ snapshots:
       '@libp2p/kad-dht': 15.1.11
       '@libp2p/logger': 5.2.0
       '@libp2p/peer-id': 5.1.9
-      '@libp2p/webrtc': 5.2.24(react-native@0.85.2(@babel/core@7.29.0)(react@19.2.5))
-      '@libp2p/websockets': 9.2.19
+      '@libp2p/webrtc': 5.2.24(react-native@0.85.2(@babel/core@7.29.0)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@5.0.10))
+      '@libp2p/websockets': 9.2.19(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       '@multiformats/dns': 1.0.13
       cborg: 4.5.8
       file-type: 20.5.0
-      helia: 5.5.1(react-native@0.85.2(@babel/core@7.29.0)(react@19.2.5))
+      helia: 5.5.1(bufferutil@4.1.0)(react-native@0.85.2(@babel/core@7.29.0)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@5.0.10))(utf-8-validate@5.0.10)
       interface-blockstore: 5.3.2
       interface-datastore: 8.3.2
       ipfs-unixfs-exporter: 13.7.3
@@ -3788,7 +3941,7 @@ snapshots:
       uint8arraylist: 2.4.9
       uint8arrays: 5.1.1
 
-  '@libp2p/webrtc@5.2.24(react-native@0.85.2(@babel/core@7.29.0)(react@19.2.5))':
+  '@libp2p/webrtc@5.2.24(react-native@0.85.2(@babel/core@7.29.0)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@5.0.10))':
     dependencies:
       '@chainsafe/is-ip': 2.1.0
       '@chainsafe/libp2p-noise': 16.1.5
@@ -3820,7 +3973,7 @@ snapshots:
       protons-runtime: 5.6.0
       race-event: 1.6.1
       race-signal: 1.1.3
-      react-native-webrtc: 124.0.7(react-native@0.85.2(@babel/core@7.29.0)(react@19.2.5))
+      react-native-webrtc: 124.0.7(react-native@0.85.2(@babel/core@7.29.0)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@5.0.10))
       uint8-varint: 2.0.4
       uint8arraylist: 2.4.9
       uint8arrays: 5.1.1
@@ -3828,7 +3981,7 @@ snapshots:
       - react-native
       - supports-color
 
-  '@libp2p/websockets@9.2.19':
+  '@libp2p/websockets@9.2.19(bufferutil@4.1.0)(utf-8-validate@5.0.10)':
     dependencies:
       '@libp2p/interface': 2.11.0
       '@libp2p/utils': 6.7.2
@@ -3836,13 +3989,13 @@ snapshots:
       '@multiformats/multiaddr-matcher': 2.0.2
       '@multiformats/multiaddr-to-uri': 11.0.2
       '@types/ws': 8.18.1
-      it-ws: 6.1.5
+      it-ws: 6.1.5(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       main-event: 1.0.4
       p-defer: 4.0.1
       p-event: 6.0.1
       progress-events: 1.1.0
       race-signal: 1.1.3
-      ws: 8.20.0
+      ws: 8.20.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -3908,6 +4061,10 @@ snapshots:
 
   '@noble/ciphers@1.3.0': {}
 
+  '@noble/curves@1.2.0':
+    dependencies:
+      '@noble/hashes': 1.3.2
+
   '@noble/curves@1.9.1':
     dependencies:
       '@noble/hashes': 1.8.0
@@ -3919,6 +4076,8 @@ snapshots:
   '@noble/curves@2.2.0':
     dependencies:
       '@noble/hashes': 2.2.0
+
+  '@noble/hashes@1.3.2': {}
 
   '@noble/hashes@1.8.0': {}
 
@@ -4050,13 +4209,13 @@ snapshots:
       tinyglobby: 0.2.16
       yargs: 17.7.2
 
-  '@react-native/community-cli-plugin@0.85.2':
+  '@react-native/community-cli-plugin@0.85.2(bufferutil@4.1.0)(utf-8-validate@5.0.10)':
     dependencies:
-      '@react-native/dev-middleware': 0.85.2
+      '@react-native/dev-middleware': 0.85.2(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       debug: 4.4.3
       invariant: 2.2.4
-      metro: 0.84.3
-      metro-config: 0.84.3
+      metro: 0.84.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      metro-config: 0.84.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       metro-core: 0.84.3
       semver: 7.7.4
     transitivePeerDependencies:
@@ -4074,7 +4233,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@react-native/dev-middleware@0.85.2':
+  '@react-native/dev-middleware@0.85.2(bufferutil@4.1.0)(utf-8-validate@5.0.10)':
     dependencies:
       '@isaacs/ttlcache': 1.4.1
       '@react-native/debugger-frontend': 0.85.2
@@ -4087,7 +4246,7 @@ snapshots:
       nullthrows: 1.1.1
       open: 7.4.2
       serve-static: 1.16.3
-      ws: 7.5.10
+      ws: 7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -4099,12 +4258,12 @@ snapshots:
 
   '@react-native/normalize-colors@0.85.2': {}
 
-  '@react-native/virtualized-lists@0.85.2(react-native@0.85.2(@babel/core@7.29.0)(react@19.2.5))(react@19.2.5)':
+  '@react-native/virtualized-lists@0.85.2(react-native@0.85.2(@babel/core@7.29.0)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@5.0.10))(react@19.2.5)':
     dependencies:
       invariant: 2.2.4
       nullthrows: 1.1.1
       react: 19.2.5
-      react-native: 0.85.2(@babel/core@7.29.0)(react@19.2.5)
+      react-native: 0.85.2(@babel/core@7.29.0)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@5.0.10)
 
   '@rollup/rollup-android-arm-eabi@4.60.2':
     optional: true
@@ -4185,7 +4344,7 @@ snapshots:
 
   '@scure/bip32@1.7.0':
     dependencies:
-      '@noble/curves': 1.9.1
+      '@noble/curves': 1.9.7
       '@noble/hashes': 1.8.0
       '@scure/base': 1.2.6
 
@@ -4232,6 +4391,10 @@ snapshots:
   '@types/node@22.19.17':
     dependencies:
       undici-types: 6.21.0
+
+  '@types/node@22.7.5':
+    dependencies:
+      undici-types: 6.19.8
 
   '@types/retry@0.12.2': {}
 
@@ -4319,6 +4482,8 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  aes-js@4.0.0-beta.5: {}
+
   agent-base@7.1.4: {}
 
   ajv-formats@3.0.1(ajv@8.20.0):
@@ -4355,6 +4520,13 @@ snapshots:
   assertion-error@2.0.1: {}
 
   asynckit@0.4.0: {}
+
+  axios@0.27.2:
+    dependencies:
+      follow-redirects: 1.16.0(debug@4.4.3)
+      form-data: 4.0.5
+    transitivePeerDependencies:
+      - debug
 
   axios@1.15.2(debug@4.4.3):
     dependencies:
@@ -4422,6 +4594,10 @@ snapshots:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
+
+  bufferutil@4.1.0:
+    dependencies:
+      node-gyp-build: 4.8.4
 
   bytes@3.1.2: {}
 
@@ -4525,6 +4701,11 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  d@1.0.2:
+    dependencies:
+      es5-ext: 0.10.64
+      type: 2.7.3
+
   datastore-core@10.0.4:
     dependencies:
       '@libp2p/logger': 5.2.0
@@ -4617,6 +4798,24 @@ snapshots:
       has-tostringtag: 1.0.2
       hasown: 2.0.3
 
+  es5-ext@0.10.64:
+    dependencies:
+      es6-iterator: 2.0.3
+      es6-symbol: 3.1.4
+      esniff: 2.0.1
+      next-tick: 1.1.0
+
+  es6-iterator@2.0.3:
+    dependencies:
+      d: 1.0.2
+      es5-ext: 0.10.64
+      es6-symbol: 3.1.4
+
+  es6-symbol@3.1.4:
+    dependencies:
+      d: 1.0.2
+      ext: 1.7.0
+
   esbuild@0.21.5:
     optionalDependencies:
       '@esbuild/aix-ppc64': 0.21.5
@@ -4678,11 +4877,36 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
+  esniff@2.0.1:
+    dependencies:
+      d: 1.0.2
+      es5-ext: 0.10.64
+      event-emitter: 0.3.5
+      type: 2.7.3
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
 
   etag@1.8.1: {}
+
+  ethers@6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10):
+    dependencies:
+      '@adraffy/ens-normalize': 1.10.1
+      '@noble/curves': 1.2.0
+      '@noble/hashes': 1.3.2
+      '@types/node': 22.7.5
+      aes-js: 4.0.0-beta.5
+      tslib: 2.7.0
+      ws: 8.17.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  event-emitter@0.3.5:
+    dependencies:
+      d: 1.0.2
+      es5-ext: 0.10.64
 
   event-iterator@2.0.0: {}
 
@@ -4699,6 +4923,10 @@ snapshots:
   expect-type@1.3.0: {}
 
   exponential-backoff@3.1.3: {}
+
+  ext@1.7.0:
+    dependencies:
+      type: 2.7.3
 
   fast-deep-equal@3.1.3: {}
 
@@ -4839,7 +5067,7 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  helia@5.5.1(react-native@0.85.2(@babel/core@7.29.0)(react@19.2.5)):
+  helia@5.5.1(bufferutil@4.1.0)(react-native@0.85.2(@babel/core@7.29.0)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@5.0.10))(utf-8-validate@5.0.10):
     dependencies:
       '@chainsafe/libp2p-noise': 16.1.5
       '@chainsafe/libp2p-yamux': 7.0.4
@@ -4864,8 +5092,8 @@ snapshots:
       '@libp2p/tcp': 10.1.19
       '@libp2p/tls': 2.2.7
       '@libp2p/upnp-nat': 3.1.22
-      '@libp2p/webrtc': 5.2.24(react-native@0.85.2(@babel/core@7.29.0)(react@19.2.5))
-      '@libp2p/websockets': 9.2.19
+      '@libp2p/webrtc': 5.2.24(react-native@0.85.2(@babel/core@7.29.0)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@5.0.10))
+      '@libp2p/websockets': 9.2.19(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       '@multiformats/dns': 1.0.13
       blockstore-core: 5.0.4
       datastore-core: 10.0.4
@@ -5041,6 +5269,8 @@ snapshots:
 
   is-regexp@3.1.0: {}
 
+  is-typedarray@1.0.0: {}
+
   is-wsl@2.2.0:
     dependencies:
       is-docker: 2.2.1
@@ -5049,9 +5279,9 @@ snapshots:
 
   iso-constants@0.1.2: {}
 
-  isows@1.0.7(ws@8.18.3):
+  isows@1.0.7(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)):
     dependencies:
-      ws: 8.18.3
+      ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
 
   it-all@3.0.11: {}
 
@@ -5190,13 +5420,13 @@ snapshots:
     dependencies:
       uint8arrays: 5.1.1
 
-  it-ws@6.1.5:
+  it-ws@6.1.5(bufferutil@4.1.0)(utf-8-validate@5.0.10):
     dependencies:
       '@types/ws': 8.18.1
       event-iterator: 2.0.0
       it-stream-types: 2.0.4
       uint8arrays: 5.1.1
-      ws: 8.20.0
+      ws: 8.20.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -5227,6 +5457,8 @@ snapshots:
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
+
+  js-sha3@0.8.0: {}
 
   js-tokens@4.0.0: {}
 
@@ -5337,12 +5569,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  metro-config@0.84.3:
+  metro-config@0.84.3(bufferutil@4.1.0)(utf-8-validate@5.0.10):
     dependencies:
       connect: 3.7.0
       flow-enums-runtime: 0.0.6
       jest-validate: 29.7.0
-      metro: 0.84.3
+      metro: 0.84.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       metro-cache: 0.84.3
       metro-core: 0.84.3
       metro-runtime: 0.84.3
@@ -5422,14 +5654,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  metro-transform-worker@0.84.3:
+  metro-transform-worker@0.84.3(bufferutil@4.1.0)(utf-8-validate@5.0.10):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/generator': 7.29.1
       '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
       flow-enums-runtime: 0.0.6
-      metro: 0.84.3
+      metro: 0.84.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       metro-babel-transformer: 0.84.3
       metro-cache: 0.84.3
       metro-cache-key: 0.84.3
@@ -5442,7 +5674,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  metro@0.84.3:
+  metro@0.84.3(bufferutil@4.1.0)(utf-8-validate@5.0.10):
     dependencies:
       '@babel/code-frame': 7.29.0
       '@babel/core': 7.29.0
@@ -5468,7 +5700,7 @@ snapshots:
       metro-babel-transformer: 0.84.3
       metro-cache: 0.84.3
       metro-cache-key: 0.84.3
-      metro-config: 0.84.3
+      metro-config: 0.84.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       metro-core: 0.84.3
       metro-file-map: 0.84.3
       metro-resolver: 0.84.3
@@ -5476,13 +5708,13 @@ snapshots:
       metro-source-map: 0.84.3
       metro-symbolicate: 0.84.3
       metro-transform-plugins: 0.84.3
-      metro-transform-worker: 0.84.3
+      metro-transform-worker: 0.84.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       mime-types: 3.0.2
       nullthrows: 1.1.1
       serialize-error: 2.1.0
       source-map: 0.5.7
       throat: 5.0.0
-      ws: 7.5.10
+      ws: 7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       yargs: 17.7.2
     transitivePeerDependencies:
       - bufferutil
@@ -5547,6 +5779,8 @@ snapshots:
 
   netmask@2.1.1: {}
 
+  next-tick@1.1.0: {}
+
   node-abi@3.89.0:
     dependencies:
       semver: 7.7.4
@@ -5556,6 +5790,8 @@ snapshots:
       whatwg-url: 5.0.0
 
   node-forge@1.4.0: {}
+
+  node-gyp-build@4.8.4: {}
 
   node-int64@0.4.0: {}
 
@@ -5578,6 +5814,18 @@ snapshots:
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
+
+  open-jsonrpc-provider@0.2.1(bufferutil@4.1.0)(utf-8-validate@5.0.10):
+    dependencies:
+      axios: 0.27.2
+      reconnecting-websocket: 4.4.0
+      websocket: 1.0.35
+      ws: 8.20.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - supports-color
+      - utf-8-validate
 
   open@7.4.2:
     dependencies:
@@ -5745,34 +5993,34 @@ snapshots:
       minimist: 1.2.8
       strip-json-comments: 2.0.1
 
-  react-devtools-core@6.1.5:
+  react-devtools-core@6.1.5(bufferutil@4.1.0)(utf-8-validate@5.0.10):
     dependencies:
       shell-quote: 1.8.3
-      ws: 7.5.10
+      ws: 7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
   react-is@18.3.1: {}
 
-  react-native-webrtc@124.0.7(react-native@0.85.2(@babel/core@7.29.0)(react@19.2.5)):
+  react-native-webrtc@124.0.7(react-native@0.85.2(@babel/core@7.29.0)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@5.0.10)):
     dependencies:
       base64-js: 1.5.1
       debug: 4.3.4
       event-target-shim: 6.0.2
-      react-native: 0.85.2(@babel/core@7.29.0)(react@19.2.5)
+      react-native: 0.85.2(@babel/core@7.29.0)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - supports-color
 
-  react-native@0.85.2(@babel/core@7.29.0)(react@19.2.5):
+  react-native@0.85.2(@babel/core@7.29.0)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@5.0.10):
     dependencies:
       '@react-native/assets-registry': 0.85.2
       '@react-native/codegen': 0.85.2(@babel/core@7.29.0)
-      '@react-native/community-cli-plugin': 0.85.2
+      '@react-native/community-cli-plugin': 0.85.2(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       '@react-native/gradle-plugin': 0.85.2
       '@react-native/js-polyfills': 0.85.2
       '@react-native/normalize-colors': 0.85.2
-      '@react-native/virtualized-lists': 0.85.2(react-native@0.85.2(@babel/core@7.29.0)(react@19.2.5))(react@19.2.5)
+      '@react-native/virtualized-lists': 0.85.2(react-native@0.85.2(@babel/core@7.29.0)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@5.0.10))(react@19.2.5)
       abort-controller: 3.0.0
       anser: 1.4.10
       ansi-regex: 5.0.1
@@ -5789,7 +6037,7 @@ snapshots:
       pretty-format: 29.7.0
       promise: 8.3.0
       react: 19.2.5
-      react-devtools-core: 6.1.5
+      react-devtools-core: 6.1.5(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       react-refresh: 0.14.2
       regenerator-runtime: 0.13.11
       scheduler: 0.27.0
@@ -5797,7 +6045,7 @@ snapshots:
       stacktrace-parser: 0.1.11
       tinyglobby: 0.2.16
       whatwg-fetch: 3.6.20
-      ws: 7.5.10
+      ws: 7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       yargs: 17.7.2
     transitivePeerDependencies:
       - '@babel/core'
@@ -5816,6 +6064,8 @@ snapshots:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
+
+  reconnecting-websocket@4.4.0: {}
 
   reflect-metadata@0.2.2: {}
 
@@ -6079,6 +6329,8 @@ snapshots:
 
   tslib@1.14.1: {}
 
+  tslib@2.7.0: {}
+
   tslib@2.8.1: {}
 
   tsx@4.21.0:
@@ -6098,6 +6350,12 @@ snapshots:
 
   type-fest@0.7.1: {}
 
+  type@2.7.3: {}
+
+  typedarray-to-buffer@3.1.5:
+    dependencies:
+      is-typedarray: 1.0.0
+
   typescript@5.9.3: {}
 
   uint8-varint@2.0.4:
@@ -6115,6 +6373,8 @@ snapshots:
     dependencies:
       multiformats: 13.4.2
 
+  undici-types@6.19.8: {}
+
   undici-types@6.21.0: {}
 
   undici@6.25.0: {}
@@ -6127,6 +6387,10 @@ snapshots:
       escalade: 3.2.0
       picocolors: 1.1.1
 
+  utf-8-validate@5.0.10:
+    dependencies:
+      node-gyp-build: 4.8.4
+
   utf8-byte-length@1.0.5: {}
 
   utf8-codec@1.0.0: {}
@@ -6137,16 +6401,16 @@ snapshots:
 
   varint@6.0.0: {}
 
-  viem@2.48.4(typescript@5.9.3)(zod@3.25.76):
+  viem@2.48.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76):
     dependencies:
       '@noble/curves': 1.9.1
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
       abitype: 1.2.3(typescript@5.9.3)(zod@3.25.76)
-      isows: 1.0.7(ws@8.18.3)
+      isows: 1.0.7(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       ox: 0.14.20(typescript@5.9.3)(zod@3.25.76)
-      ws: 8.18.3
+      ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -6238,6 +6502,17 @@ snapshots:
 
   webidl-conversions@3.0.1: {}
 
+  websocket@1.0.35:
+    dependencies:
+      bufferutil: 4.1.0
+      debug: 2.6.9
+      es5-ext: 0.10.64
+      typedarray-to-buffer: 3.1.5
+      utf-8-validate: 5.0.10
+      yaeti: 0.0.6
+    transitivePeerDependencies:
+      - supports-color
+
   whatwg-fetch@3.6.20: {}
 
   whatwg-url@5.0.0:
@@ -6266,11 +6541,25 @@ snapshots:
 
   wrappy@1.0.2: {}
 
-  ws@7.5.10: {}
+  ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10):
+    optionalDependencies:
+      bufferutil: 4.1.0
+      utf-8-validate: 5.0.10
 
-  ws@8.18.3: {}
+  ws@8.17.1(bufferutil@4.1.0)(utf-8-validate@5.0.10):
+    optionalDependencies:
+      bufferutil: 4.1.0
+      utf-8-validate: 5.0.10
 
-  ws@8.20.0: {}
+  ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10):
+    optionalDependencies:
+      bufferutil: 4.1.0
+      utf-8-validate: 5.0.10
+
+  ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@5.0.10):
+    optionalDependencies:
+      bufferutil: 4.1.0
+      utf-8-validate: 5.0.10
 
   xml2js@0.6.2:
     dependencies:
@@ -6280,6 +6569,8 @@ snapshots:
   xmlbuilder@11.0.1: {}
 
   y18n@5.0.8: {}
+
+  yaeti@0.0.6: {}
 
   yallist@3.1.1: {}
 

--- a/scripts/pin-to-0g.ts
+++ b/scripts/pin-to-0g.ts
@@ -1,0 +1,112 @@
+#!/usr/bin/env tsx
+/**
+ * Pin every reference skill bundle's manifest.json to 0G storage testnet.
+ *
+ * Reads each skillname-pack/examples/<bundle>/manifest.json, builds its
+ * Merkle tree, submits via the 0G Indexer, and writes the resulting root
+ * hashes to stdout in three formats:
+ *   1. human-readable per-bundle log
+ *   2. JSON object: { slug: rootHash }
+ *   3. comma-separated `slug=root,...` (for the register-skills workflow)
+ *
+ * Prereqs:
+ *   - SEPOLIA_PRIVATE_KEY in env (the same EVM key works on 0G testnet)
+ *   - Operator funded with OG on 0G testnet (faucet: https://faucet.0g.ai)
+ *
+ * Usage:
+ *   pnpm tsx scripts/pin-to-0g.ts             # pin all bundles
+ *   pnpm tsx scripts/pin-to-0g.ts quote-uniswap  # pin one bundle by slug
+ */
+
+import { Indexer, ZgFile } from '@0glabs/0g-ts-sdk'
+import { ethers } from 'ethers'
+import { readdirSync } from 'node:fs'
+import { join } from 'node:path'
+
+const OG_RPC = process.env.OG_RPC_URL ?? 'https://evmrpc-testnet.0g.ai'
+const INDEXER_URL = process.env.OG_INDEXER_URL ?? 'https://indexer-storage-testnet-turbo.0g.ai'
+const PRIVATE_KEY = process.env.SEPOLIA_PRIVATE_KEY
+
+if (!PRIVATE_KEY) {
+  console.error('SEPOLIA_PRIVATE_KEY env var not set (the same key signs on 0G testnet).')
+  process.exit(1)
+}
+
+const onlySlug = process.argv[2]
+
+const provider = new ethers.JsonRpcProvider(OG_RPC)
+const signer = new ethers.Wallet(PRIVATE_KEY, provider)
+const indexer = new Indexer(INDEXER_URL)
+
+console.log('Operator: ', signer.address)
+console.log('OG RPC:   ', OG_RPC)
+console.log('Indexer:  ', INDEXER_URL)
+console.log()
+
+const examplesDir = 'skillname-pack/examples'
+const bundleDirs = readdirSync(examplesDir, { withFileTypes: true })
+  .filter((d) => d.isDirectory())
+  .map((d) => d.name)
+  .filter((slug) => !onlySlug || slug === onlySlug)
+
+if (bundleDirs.length === 0) {
+  console.error(onlySlug ? `No bundle named "${onlySlug}" in ${examplesDir}` : `No bundles in ${examplesDir}`)
+  process.exit(1)
+}
+
+console.log(`Pinning ${bundleDirs.length} bundle(s): ${bundleDirs.join(', ')}\n`)
+
+const roots: Record<string, string> = {}
+
+for (const slug of bundleDirs) {
+  const manifestPath = join(examplesDir, slug, 'manifest.json')
+  process.stdout.write(`[${slug}] `)
+
+  let file: ZgFile | null = null
+  try {
+    file = await ZgFile.fromFilePath(manifestPath)
+    const [tree, treeErr] = await file.merkleTree()
+    if (treeErr || !tree) {
+      console.error(`✗ merkleTree: ${treeErr?.message ?? 'no tree'}`)
+      continue
+    }
+    const localRoot = tree.rootHash()
+    if (!localRoot) {
+      console.error(`✗ rootHash returned null`)
+      continue
+    }
+
+    const [tx, uploadErr] = await indexer.upload(file, OG_RPC, signer)
+    if (uploadErr) {
+      // Some uploads return an error even though the file is already pinned —
+      // surface but keep going if we have a rootHash from the local tree.
+      console.error(`! upload error: ${uploadErr.message}`)
+      console.log(`  using local root: ${localRoot}`)
+      roots[slug] = localRoot
+      continue
+    }
+
+    console.log(`✓ root: ${tx.rootHash}`)
+    console.log(`  tx:   ${tx.txHash}`)
+    roots[slug] = tx.rootHash
+  } catch (e: any) {
+    console.error(`✗ ${e.message ?? e}`)
+  } finally {
+    if (file) await file.close().catch(() => {})
+  }
+}
+
+console.log('\n--- results ---')
+console.log(JSON.stringify(roots, null, 2))
+
+const rootsArg = Object.entries(roots)
+  .map(([k, v]) => `${k}=${v}`)
+  .join(',')
+console.log('\nROOTS=' + rootsArg)
+
+// Also write to GITHUB_OUTPUT if running inside Actions, so the next step
+// can consume `roots` directly without parsing logs.
+if (process.env.GITHUB_OUTPUT) {
+  const fs = await import('node:fs')
+  fs.appendFileSync(process.env.GITHUB_OUTPUT, `roots=${rootsArg}\n`)
+}

--- a/scripts/register-skills.ts
+++ b/scripts/register-skills.ts
@@ -52,33 +52,43 @@ const RESOLVER_ABI = parseAbi([
 interface Args {
   parent: string
   cids: Record<string, string>
+  roots: Record<string, string>
+}
+
+function parsePairs(arg: string): Record<string, string> {
+  const out: Record<string, string> = {}
+  if (!arg) return out
+  for (const pair of arg.split(',')) {
+    const [k, v] = pair.split('=')
+    if (k && v) out[k.trim()] = v.trim()
+  }
+  return out
 }
 
 function parseArgs(): Args {
   const args = process.argv.slice(2)
   let parent = ''
   let cidsArg = ''
+  let rootsArg = ''
   for (let i = 0; i < args.length; i++) {
     if (args[i] === '--parent') parent = args[++i]
     else if (args[i] === '--cids') cidsArg = args[++i]
+    else if (args[i] === '--roots') rootsArg = args[++i]
   }
   if (!parent) {
     console.error('Missing --parent <ensName>')
-    console.error('Usage: pnpm tsx scripts/register-skills.ts --parent <name> [--cids <slug=cid,...>]')
+    console.error('Usage:')
+    console.error('  pnpm tsx scripts/register-skills.ts --parent <name>')
+    console.error('  pnpm tsx scripts/register-skills.ts --parent <name> --roots <slug=0xroot,...>      # 0G primary')
+    console.error('  pnpm tsx scripts/register-skills.ts --parent <name> --cids <slug=bafy...,...>     # IPFS')
+    console.error('  pnpm tsx scripts/register-skills.ts --parent <name> --roots ... --cids ...        # both')
     process.exit(1)
   }
-  const cids: Record<string, string> = {}
-  if (cidsArg) {
-    for (const pair of cidsArg.split(',')) {
-      const [k, v] = pair.split('=')
-      if (k && v) cids[k.trim()] = v.trim()
-    }
-  }
-  return { parent, cids }
+  return { parent, cids: parsePairs(cidsArg), roots: parsePairs(rootsArg) }
 }
 
 async function main(): Promise<void> {
-  const { parent, cids } = parseArgs()
+  const { parent, cids, roots } = parseArgs()
 
   const PRIVATE_KEY = process.env.SEPOLIA_PRIVATE_KEY as Hex | undefined
   const RPC_URL = process.env.SEPOLIA_RPC_URL ?? 'https://rpc.sepolia.org'
@@ -156,19 +166,28 @@ async function main(): Promise<void> {
       continue
     }
 
-    // 2. Set text records (only if CID provided)
+    // 2. Set text records.
+    // Precedence for the canonical xyz.manifest.skill record:
+    //   --roots (0G) takes priority over --cids (IPFS) — 0G is the project's
+    //   primary storage layer per the prize alignment. If --cids is also
+    //   provided, it lands on xyz.manifest.skill.ipfs as a dual-pin record.
+    const root = roots[slug]
     const cid = cids[slug]
-    if (!cid) {
-      console.log(`  · no CID provided, skipping text records`)
+    if (!root && !cid) {
+      console.log(`  · no --roots or --cids for ${slug}, skipping text records`)
       continue
     }
 
     const subNode = namehash(fullName)
-    const records: Array<[string, string]> = [
-      ['xyz.manifest.skill', `ipfs://${cid}`],
-      ['xyz.manifest.skill.version', manifest.version],
-      ['xyz.manifest.skill.schema', 'https://manifest.eth/schemas/skill-v1.json'],
-    ]
+    const records: Array<[string, string]> = []
+    if (root) {
+      records.push(['xyz.manifest.skill', `0g://${root}`])
+      if (cid) records.push(['xyz.manifest.skill.ipfs', `ipfs://${cid}`])
+    } else {
+      records.push(['xyz.manifest.skill', `ipfs://${cid}`])
+    }
+    records.push(['xyz.manifest.skill.version', manifest.version])
+    records.push(['xyz.manifest.skill.schema', 'https://manifest.eth/schemas/skill-v1.json'])
 
     for (const [key, value] of records) {
       try {

--- a/skillname-pack/packages/sdk/src/index.ts
+++ b/skillname-pack/packages/sdk/src/index.ts
@@ -168,11 +168,9 @@ export async function resolveSkill(
     )
   }
 
-  // 2. Strip ipfs:// prefix
-  const cid = cidRaw.startsWith('ipfs://') ? cidRaw.slice(7) : cidRaw
-
-  // 3. Fetch + verify
-  const bundle = await fetchAndVerify(cid, options)
+  // 2. Fetch + verify (URI scheme decides storage backend: ipfs:// vs 0g://)
+  const bundle = await fetchAndVerify(cidRaw, options)
+  const cid = cidRaw // preserved verbatim in ResolveResult for traceability
 
   // 4. Validate against schema v1
   const { valid, errors } = validateBundle(bundle)
@@ -225,10 +223,33 @@ async function getVerifiedFetch(): Promise<VerifiedFetchFn | null> {
   return _verifiedFetch
 }
 
+const OG_INDEXER_URL = 'https://indexer-storage-testnet-turbo.0g.ai'
+
 async function fetchAndVerify(
-  cid: string,
+  uri: string,
   options: ResolveOptions
 ): Promise<SkillBundle> {
+  // 0G storage: 0g://<rootHash> — fetched as a single file via the indexer.
+  if (uri.startsWith('0g://')) {
+    const root = uri.slice(5)
+    return fetchVia0G(root, options)
+  }
+
+  // IPFS: ipfs://<cid> — fetched as a directory, manifest.json at root.
+  const cid = uri.startsWith('ipfs://') ? uri.slice(7) : uri
+  return fetchViaIpfs(cid, options)
+}
+
+async function fetchVia0G(rootHash: string, _options: ResolveOptions): Promise<SkillBundle> {
+  const url = `${OG_INDEXER_URL}/file?root=${rootHash}`
+  const res = await fetch(url, { headers: { Accept: 'application/json' } })
+  if (!res.ok) {
+    throw new Error(`0G fetch failed for root ${rootHash}: HTTP ${res.status}`)
+  }
+  return (await res.json()) as SkillBundle
+}
+
+async function fetchViaIpfs(cid: string, options: ResolveOptions): Promise<SkillBundle> {
   // Default path: @helia/verified-fetch auto-verifies the CID content hash.
   if (!options.skipVerification) {
     try {
@@ -245,15 +266,12 @@ async function fetchAndVerify(
     }
   }
 
-  // Fallback: plain HTTP gateway fetch. Faster but does not verify the hash —
-  // only used when skipVerification is set, or when helia init / fetch failed.
+  // Fallback: plain HTTP gateway fetch. Faster but does not verify the hash.
   const gateways = options.ipfsGateways ?? DEFAULT_GATEWAYS
   for (const gateway of gateways) {
     try {
       const url = `${gateway}${cid}/manifest.json`
-      const res = await fetch(url, {
-        headers: { Accept: 'application/json' },
-      })
+      const res = await fetch(url, { headers: { Accept: 'application/json' } })
       if (!res.ok) continue
       return (await res.json()) as SkillBundle
     } catch (e) {


### PR DESCRIPTION
Pivots storage primary from IPFS to 0G to align with the 0G Framework prize. IPFS becomes an optional dual-pin record.

### Changes
- New `scripts/pin-to-0g.ts` — uses `@0glabs/0g-ts-sdk` to upload manifests, emits root hashes.
- SDK `fetchAndVerify()` learns `0g://<root>` scheme, fetches via `indexer-storage-testnet-turbo.0g.ai/file?root=<root>`. IPFS path unchanged.
- `register-skills.ts` accepts `--roots` (precedence over `--cids`). When both supplied, IPFS lands on `xyz.manifest.skill.ipfs` as dual-pin.
- New `.github/workflows/pin-and-register.yml` — one click does pin + register.

### Your move after merge
1. Make sure `0x3Fb7c18EBBBa1A9b54692C2655F9Df0317f68e95` has 0G testnet OG (faucet: https://faucet.0g.ai).
2. Trigger `Pin to 0G + register skills on Sepolia` workflow with `parent=skilltest.eth` and `slug=quote-uniswap` (start with one bundle to verify the flow).
3. After it completes, the SDK should resolve `quote.skilltest.eth` end-to-end through 0G.

Refs #10.