### PR TITLE
feat(#4): x402 payment gateway + KeeperHub MCP client

### DIFF
--- a/apps/keeperhub-paid/package.json
+++ b/apps/keeperhub-paid/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@skillname/keeperhub-paid",
+  "version": "0.0.1",
+  "description": "x402 payment gateway in front of KeeperHub MCP",
+  "license": "MIT",
+  "type": "module",
+  "scripts": {
+    "dev": "tsx src/index.ts",
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "@hono/node-server": "^1.14.4",
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "@x402/core": "^2.11.0",
+    "@x402/evm": "^2.11.0",
+    "@x402/hono": "^2.11.0",
+    "dotenv": "^17.4.2",
+    "hono": "^4.7.10"
+  }
+}

--- a/apps/keeperhub-paid/src/index.ts
+++ b/apps/keeperhub-paid/src/index.ts
@@ -1,0 +1,176 @@
+/**
+ * apps/keeperhub-paid — x402 payment gateway in front of KeeperHub
+ *
+ * Architecture:
+ *   Bridge → POST /execute (no payment)
+ *         ← 402 + payment requirements
+ *   Bridge → sign EIP-3009 USDC → POST /execute with PAYMENT-SIGNATURE
+ *         → validate via x402.org/facilitator
+ *         → call KeeperHub execute_contract_call
+ *         ← { txHash, explorerUrl }
+ *
+ * Env:
+ *   PAY_TO_ADDRESS      wallet that receives USDC (required)
+ *   KEEPERHUB_API_KEY   kh_... (required)
+ *   PORT                default 3001
+ */
+
+import "dotenv/config";
+import { Hono } from "hono";
+import { serve } from "@hono/node-server";
+import { paymentMiddleware } from "@x402/hono";
+import { x402ResourceServer } from "@x402/core/server";
+import { HTTPFacilitatorClient } from "@x402/core/server";
+import { ExactEvmScheme } from "@x402/evm/exact/server";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+
+const PORT = parseInt(process.env.PORT ?? "3001", 10);
+const PAY_TO = process.env.PAY_TO_ADDRESS;
+const KH_API_KEY = process.env.KEEPERHUB_API_KEY;
+
+if (!PAY_TO) throw new Error("PAY_TO_ADDRESS env var not set");
+if (!KH_API_KEY) throw new Error("KEEPERHUB_API_KEY env var not set");
+
+// ── KeeperHub MCP client ──────────────────────────────────────────────────
+let _kh: Client | null = null;
+
+async function getKeeperHub(): Promise<Client> {
+  if (_kh) return _kh;
+  const client = new Client(
+    { name: "keeperhub-paid", version: "0.0.1" },
+    { capabilities: {} },
+  );
+  await client.connect(
+    new StreamableHTTPClientTransport(
+      new URL("https://app.keeperhub.com/mcp"),
+      {
+        requestInit: { headers: { Authorization: `Bearer ${KH_API_KEY}` } },
+      },
+    ),
+  );
+  _kh = client;
+  return client;
+}
+
+function khText(res: Awaited<ReturnType<Client["callTool"]>>): string {
+  return (res.content as Array<{ type: string; text?: string }>)
+    .filter((c) => c.type === "text")
+    .map((c) => c.text ?? "")
+    .join("\n");
+}
+
+// ── x402 resource server ──────────────────────────────────────────────────
+// Testnet facilitator — no CDP key required
+const facilitator = new HTTPFacilitatorClient({
+  url: "https://x402.org/facilitator",
+});
+const resourceServer = new x402ResourceServer(facilitator).register(
+  "eip155:84532",
+  new ExactEvmScheme(),
+);
+
+// ── Hono app ──────────────────────────────────────────────────────────────
+const app = new Hono();
+
+const routes = {
+  "/execute": {
+    accepts: [
+      {
+        scheme: "exact" as const,
+        price: "$0.05",
+        network: "eip155:84532" as const,
+        payTo: PAY_TO as `0x${string}`,
+      },
+    ],
+    description: "Execute a smart contract call via KeeperHub",
+    mimeType: "application/json",
+  },
+};
+
+app.use("/execute", paymentMiddleware(routes, resourceServer));
+
+app.post("/execute", async (c) => {
+  const body = await c.req.json<{
+    contract_address: string;
+    network: string;
+    function_name: string;
+    function_args?: string;
+    abi?: string;
+  }>();
+
+  try {
+    const kh = await getKeeperHub();
+
+    const args: Record<string, string> = {
+      contract_address: body.contract_address,
+      network: body.network,
+      function_name: body.function_name,
+    };
+    if (body.function_args) args.function_args = body.function_args;
+    if (body.abi) args.abi = body.abi;
+
+    const res = await kh.callTool({
+      name: "execute_contract_call",
+      arguments: args,
+    });
+    const text = khText(res);
+
+    // Poll if execution ID returned
+    const idMatch = text.match(
+      /([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})/i,
+    );
+    if (!idMatch) return c.json({ result: text });
+
+    const executionId = idMatch[1];
+    const txHash = await pollExecution(kh, executionId);
+
+    return c.json({
+      txHash,
+      explorerUrl: `https://sepolia.basescan.org/tx/${txHash}`,
+    });
+  } catch (e: any) {
+    return c.json({ error: e.message }, 500);
+  }
+});
+
+app.get("/health", (c) => c.json({ status: "ok", payTo: PAY_TO }));
+
+// ── Poll execution status ─────────────────────────────────────────────────
+async function pollExecution(kh: Client, executionId: string): Promise<string> {
+  const deadline = Date.now() + 60_000;
+  while (Date.now() < deadline) {
+    await sleep(2_000);
+    const status = khText(
+      await kh.callTool({
+        name: "get_direct_execution_status",
+        arguments: { execution_id: executionId },
+      }),
+    );
+    if (status.toLowerCase().includes("complet")) {
+      const match = status.match(/0x[a-fA-F0-9]{64}/);
+      if (match) return match[0];
+      const logs = khText(
+        await kh.callTool({
+          name: "get_execution_logs",
+          arguments: { executionId },
+        }),
+      );
+      const logMatch = logs.match(/0x[a-fA-F0-9]{64}/);
+      if (logMatch) return logMatch[0];
+      throw new Error("Completed but no tx hash found");
+    }
+    if (status.toLowerCase().includes("fail"))
+      throw new Error(`Execution failed: ${status}`);
+  }
+  throw new Error("Execution timed out");
+}
+
+function sleep(ms: number) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+// ── Start ─────────────────────────────────────────────────────────────────
+serve({ fetch: app.fetch, port: PORT }, () => {
+  console.log(`keeperhub-paid ready on :${PORT}`);
+});

--- a/apps/keeperhub-paid/tsconfig.json
+++ b/apps/keeperhub-paid/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/package.json
+++ b/package.json
@@ -29,6 +29,13 @@
     "vitest": "^2.1.8"
   },
   "dependencies": {
-    "@0glabs/0g-serving-broker": "^0.7.5"
+    "@0glabs/0g-serving-broker": "^0.7.5",
+    "@hono/node-server": "^2.0.0",
+    "@x402/core": "^2.11.0",
+    "@x402/evm": "^2.11.0",
+    "@x402/fetch": "^2.11.0",
+    "@x402/hono": "^2.11.0",
+    "dotenv": "^17.4.2",
+    "hono": "^4.12.15"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,27 @@ importers:
       '@0glabs/0g-serving-broker':
         specifier: ^0.7.5
         version: 0.7.5(@types/circomlibjs@0.1.6)(@types/crypto-js@4.2.2)(circomlibjs@0.1.7(bufferutil@4.1.0)(utf-8-validate@5.0.10))(crypto-js@4.2.0)(ethers@6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+      '@hono/node-server':
+        specifier: ^2.0.0
+        version: 2.0.0(hono@4.12.15)
+      '@x402/core':
+        specifier: ^2.11.0
+        version: 2.11.0
+      '@x402/evm':
+        specifier: ^2.11.0
+        version: 2.11.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@x402/fetch':
+        specifier: ^2.11.0
+        version: 2.11.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@x402/hono':
+        specifier: ^2.11.0
+        version: 2.11.0(bufferutil@4.1.0)(ethers@6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(hono@4.12.15)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      dotenv:
+        specifier: ^17.4.2
+        version: 17.4.2
+      hono:
+        specifier: ^4.12.15
+        version: 4.12.15
     devDependencies:
       '@0glabs/0g-ts-sdk':
         specifier: ^0.3.3
@@ -40,17 +61,53 @@ importers:
         specifier: ^2.1.8
         version: 2.1.9(@types/node@22.19.17)(terser@5.46.2)
 
+  apps/keeperhub-paid:
+    dependencies:
+      '@hono/node-server':
+        specifier: ^1.14.4
+        version: 1.19.14(hono@4.12.15)
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(zod@3.25.76)
+      '@x402/core':
+        specifier: ^2.11.0
+        version: 2.11.0
+      '@x402/evm':
+        specifier: ^2.11.0
+        version: 2.11.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@x402/hono':
+        specifier: ^2.11.0
+        version: 2.11.0(bufferutil@4.1.0)(ethers@6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(hono@4.12.15)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      dotenv:
+        specifier: ^17.4.2
+        version: 17.4.2
+      hono:
+        specifier: ^4.7.10
+        version: 4.12.15
+
   skillname-pack/packages/bridge:
     dependencies:
       '@0glabs/0g-serving-broker':
         specifier: ^0.7.5
         version: 0.7.5(@types/circomlibjs@0.1.6)(@types/crypto-js@4.2.2)(circomlibjs@0.1.7(bufferutil@4.1.0)(utf-8-validate@5.0.10))(crypto-js@4.2.0)(ethers@6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       '@modelcontextprotocol/sdk':
-        specifier: ^0.6.1
-        version: 0.6.1
+        specifier: ^1.29.0
+        version: 1.29.0(zod@3.25.76)
       '@skillname/sdk':
         specifier: workspace:*
         version: link:../sdk
+      '@x402/evm':
+        specifier: ^2.11.0
+        version: 2.11.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@x402/fetch':
+        specifier: ^2.11.0
+        version: 2.11.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      dotenv:
+        specifier: ^17.4.2
+        version: 17.4.2
+      viem:
+        specifier: ^2.21.55
+        version: 2.48.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
 
   skillname-pack/packages/cli:
     dependencies:
@@ -641,6 +698,18 @@ packages:
   '@helia/verified-fetch@2.6.19':
     resolution: {integrity: sha512-XbtftfLP5OlYno+n1mEu4SWN72yzDB++ukEoo0t7Jz161YHHPeJY6aKXGJS8P0GyMCxGSiYP36uCiHqSt1Vphw==}
 
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
+  '@hono/node-server@2.0.0':
+    resolution: {integrity: sha512-n3GfHwwCvHCkGmOwKfxUPOlbfzuO64Sbc5XC4NGPIXxkuOnJrdgExdRKmHfF924r914WRJPT397GdqLvdYTeyQ==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      hono: ^4
+
   '@ipld/car@5.4.3':
     resolution: {integrity: sha512-+6QHy+9sLov1K28PmazHyqEmD5oDeMWa3mwxst8rt5OsP7CmEexwYDOflGSjPDOUWgHQ4WabQnBSZfXKvZ0DUw==}
     engines: {node: '>=16.0.0', npm: '>=7.0.0'}
@@ -797,8 +866,15 @@ packages:
   '@libp2p/websockets@9.2.19':
     resolution: {integrity: sha512-+g2qI9Lgvyofoc6GFztPoPVZV+z/lg9pIUfneHht6j88Y7tH3NrAQ7Ki+9lqS5XBX2h1O1bHULWbCaVYCj9TZg==}
 
-  '@modelcontextprotocol/sdk@0.6.1':
-    resolution: {integrity: sha512-OkVXMix3EIbB5Z6yife2XTrSlOnVvCLR1Kg91I4pYFEsV9RbnoyQVScXCuVhGaZHOnTZgso8lMQN1Po2TadGKQ==}
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@multiformats/dns@1.0.13':
     resolution: {integrity: sha512-yr4bxtA3MbvJ+2461kYIYMsiiZj/FIqKI64hE4SdvWJUdWF9EtZLar38juf20Sf5tguXKFUruluswAO6JsjS2w==}
@@ -1151,6 +1227,20 @@ packages:
   '@scure/bip39@1.6.0':
     resolution: {integrity: sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==}
 
+  '@signinwithethereum/siwe-parser@4.2.0':
+    resolution: {integrity: sha512-e3edh8XpZrEjbzVYc0BZ4ySFOa8RKTZOQTafSf1E6ejCB5XcBH93jEpYmjzry1EEocgMNq4KlB3YunsFNCXakQ==}
+
+  '@signinwithethereum/siwe@4.2.0':
+    resolution: {integrity: sha512-6W+oyKgMFUZRJI4o9P9mTMzrokkXfu3tq1/CfOJj9QrMqyPqujJqv1xnxUAqDQwWVyCA8TMg0Fxk/+gXrDg2Nw==}
+    peerDependencies:
+      ethers: ^5.7.0 || ^6.13.0
+      viem: ^2.7.0
+    peerDependenciesMeta:
+      ethers:
+        optional: true
+      viem:
+        optional: true
+
   '@sinclair/typebox@0.27.10':
     resolution: {integrity: sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==}
 
@@ -1303,6 +1393,27 @@ packages:
     engines: {node: '>=18'}
     deprecated: Web3.storage became storacha.network, please upgrade to @storacha/client
 
+  '@x402/core@2.11.0':
+    resolution: {integrity: sha512-aqTfZc/BULrlWnd3I0lsqRQaH4gjJd8CsPcL16XqK2Lx5c6QDm+zCljgUVS1yj9BGJoZeQWTzI5hE+SVFkqMTw==}
+
+  '@x402/evm@2.11.0':
+    resolution: {integrity: sha512-F8uU1txDZA+wc/sEnmaHAyYvoTi/w39r7K3a44MmQHSxECDTEuB3A0FwbxOxUPLN1eyCxTAFKEiqlGe3bwybKA==}
+
+  '@x402/extensions@2.11.0':
+    resolution: {integrity: sha512-S0SOoUsx4WtWqiWZuqslSzhopW/JcrEbnEC5l2sIQH/TABWzR0DgJLy36C43tD6TOJc0tEPN9bHuD+V8DYWomA==}
+
+  '@x402/fetch@2.11.0':
+    resolution: {integrity: sha512-sDkoq1ZZt10/UVa75bCXTbWkXMbPOOQpkdSxWB0ybHtlmqT7PM6hU4DVCov4iL792W1Oi38VtxfUw5EkvdvYtw==}
+
+  '@x402/hono@2.11.0':
+    resolution: {integrity: sha512-myPsDNMeCLqQgk0O1Rbdx2kdpVNRumnnwiV3fTgSbiQzxiTWDc5IU/7fEWPSsXNbLtt9kB6eXWT9VxEkcJJolg==}
+    peerDependencies:
+      '@x402/paywall': ^2.11.0
+      hono: ^4.0.0
+    peerDependenciesMeta:
+      '@x402/paywall':
+        optional: true
+
   abitype@1.2.3:
     resolution: {integrity: sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==}
     peerDependencies:
@@ -1402,6 +1513,9 @@ packages:
   any-signal@4.2.0:
     resolution: {integrity: sha512-LndMvYuAPf4rC195lk7oSFuHOYFpOszIYrNYv0gHAvz+aEhE9qPZLhmrIz5pXP2BSsPOXvsuHDXEGaiQhIh9wA==}
     engines: {node: '>=16.0.0', npm: '>=7.0.0'}
+
+  apg-js@4.4.0:
+    resolution: {integrity: sha512-fefmXFknJmtgtNEXfPwZKYkMFX4Fyeyz+fNF6JWp87biGOPslJbCBVU158zvKRZfHBKnJDy8CMM40oLFGkXT8Q==}
 
   asap@2.0.6:
     resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
@@ -1720,6 +1834,10 @@ packages:
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
 
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
+
   create-ecdh@4.0.4:
     resolution: {integrity: sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==}
 
@@ -1986,6 +2104,14 @@ packages:
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
+  eventsource-parser@3.0.8:
+    resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
   evp_bytestokey@1.0.3:
     resolution: {integrity: sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==}
 
@@ -2000,8 +2126,18 @@ packages:
   exponential-backoff@3.1.3:
     resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
 
+  express-rate-limit@8.4.1:
+    resolution: {integrity: sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
   express@5.1.0:
     resolution: {integrity: sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==}
+    engines: {node: '>= 18'}
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
     engines: {node: '>= 18'}
 
   ext@1.7.0:
@@ -2228,6 +2364,10 @@ packages:
   hmac-drbg@1.0.1:
     resolution: {integrity: sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==}
 
+  hono@4.12.15:
+    resolution: {integrity: sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==}
+    engines: {node: '>=16.9.0'}
+
   http-cookie-agent@6.0.8:
     resolution: {integrity: sha512-qnYh3yLSr2jBsTYkw11elq+T361uKAJaZ2dR4cfYZChw1dt9uL5t3zSUwehoqqVb4oldk1BpkXKm2oat8zV+oA==}
     engines: {node: '>=18.0.0'}
@@ -2289,6 +2429,10 @@ packages:
 
   invariant@2.2.4:
     resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
+
+  ip-address@10.1.0:
+    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+    engines: {node: '>= 12'}
 
   ip-regex@5.0.0:
     resolution: {integrity: sha512-fOCG6lhoKKakwv+C6KdsOnGvgXnmgfmp0myi3bcNwj3qfwPAxRKWEuFhvEFF7ceYIz6+1jRZ+yguLFAmUNPEfw==}
@@ -2556,6 +2700,12 @@ packages:
   jest-worker@29.7.0:
     resolution: {integrity: sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jose@5.10.0:
+    resolution: {integrity: sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==}
+
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
 
   js-sha3@0.8.0:
     resolution: {integrity: sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==}
@@ -2872,6 +3022,10 @@ packages:
     resolution: {integrity: sha512-J7554Ef8bzmKaDY365Afq6PF+qtdnY/d5PKUQFrsKlZHV/N3OGZewVrvDrQDyX5V5NJjTpcAKtlrFZcDr+HvpQ==}
     engines: {node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0}
 
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
@@ -2984,6 +3138,10 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -3515,6 +3673,9 @@ packages:
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
+  tweetnacl@1.0.3:
+    resolution: {integrity: sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==}
+
   type-fest@0.7.1:
     resolution: {integrity: sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==}
     engines: {node: '>=8'}
@@ -3845,6 +4006,11 @@ packages:
   yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
+
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
@@ -4691,6 +4857,14 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  '@hono/node-server@1.19.14(hono@4.12.15)':
+    dependencies:
+      hono: 4.12.15
+
+  '@hono/node-server@2.0.0(hono@4.12.15)':
+    dependencies:
+      hono: 4.12.15
+
   '@ipld/car@5.4.3':
     dependencies:
       '@ipld/dag-cbor': 9.2.6
@@ -5229,11 +5403,27 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@modelcontextprotocol/sdk@0.6.1':
+  '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
     dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.15)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.8
+      express: 5.2.1
+      express-rate-limit: 8.4.1(express@5.2.1)
+      hono: 4.12.15
+      jose: 6.2.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
       raw-body: 3.0.2
       zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
+    transitivePeerDependencies:
+      - supports-color
 
   '@multiformats/dns@1.0.13':
     dependencies:
@@ -5624,6 +5814,18 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/base': 1.2.6
 
+  '@signinwithethereum/siwe-parser@4.2.0':
+    dependencies:
+      '@noble/hashes': 1.8.0
+      apg-js: 4.4.0
+
+  '@signinwithethereum/siwe@4.2.0(ethers@6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(viem@2.48.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))':
+    dependencies:
+      '@signinwithethereum/siwe-parser': 4.2.0
+    optionalDependencies:
+      ethers: 6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      viem: 2.48.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+
   '@sinclair/typebox@0.27.10': {}
 
   '@sindresorhus/fnv1a@3.1.0': {}
@@ -5876,6 +6078,59 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
+  '@x402/core@2.11.0':
+    dependencies:
+      zod: 3.25.76
+
+  '@x402/evm@2.11.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@x402/core': 2.11.0
+      viem: 2.48.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - bufferutil
+      - typescript
+      - utf-8-validate
+
+  '@x402/extensions@2.11.0(bufferutil@4.1.0)(ethers@6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(typescript@5.9.3)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@noble/curves': 1.9.7
+      '@scure/base': 1.2.6
+      '@signinwithethereum/siwe': 4.2.0(ethers@6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(viem@2.48.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
+      '@x402/core': 2.11.0
+      ajv: 8.20.0
+      jose: 5.10.0
+      tweetnacl: 1.0.3
+      viem: 2.48.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - bufferutil
+      - ethers
+      - typescript
+      - utf-8-validate
+
+  '@x402/fetch@2.11.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@x402/core': 2.11.0
+      viem: 2.48.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - bufferutil
+      - typescript
+      - utf-8-validate
+
+  '@x402/hono@2.11.0(bufferutil@4.1.0)(ethers@6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(hono@4.12.15)(typescript@5.9.3)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@x402/core': 2.11.0
+      '@x402/extensions': 2.11.0(bufferutil@4.1.0)(ethers@6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(typescript@5.9.3)(utf-8-validate@5.0.10)
+      hono: 4.12.15
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - bufferutil
+      - ethers
+      - typescript
+      - utf-8-validate
+
   abitype@1.2.3(typescript@5.9.3)(zod@3.25.76):
     optionalDependencies:
       typescript: 5.9.3
@@ -5950,6 +6205,8 @@ snapshots:
   any-signal@3.0.1: {}
 
   any-signal@4.2.0: {}
+
+  apg-js@4.4.0: {}
 
   asap@2.0.6: {}
 
@@ -6346,6 +6603,11 @@ snapshots:
 
   core-util-is@1.0.3: {}
 
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
+
   create-ecdh@4.0.4:
     dependencies:
       bn.js: 4.12.3
@@ -6708,6 +6970,12 @@ snapshots:
 
   eventemitter3@5.0.4: {}
 
+  eventsource-parser@3.0.8: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.0.8
+
   evp_bytestokey@1.0.3:
     dependencies:
       md5.js: 1.3.5
@@ -6719,6 +6987,11 @@ snapshots:
 
   exponential-backoff@3.1.3: {}
 
+  express-rate-limit@8.4.1(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.1.0
+
   express@5.1.0:
     dependencies:
       accepts: 2.0.0
@@ -6728,6 +7001,39 @@ snapshots:
       cookie: 0.7.2
       cookie-signature: 1.2.2
       debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.1
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.2.2
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -7014,6 +7320,8 @@ snapshots:
       minimalistic-assert: 1.0.1
       minimalistic-crypto-utils: 1.0.1
 
+  hono@4.12.15: {}
+
   http-cookie-agent@6.0.8(tough-cookie@5.1.2)(undici@6.25.0):
     dependencies:
       agent-base: 7.1.4
@@ -7078,6 +7386,8 @@ snapshots:
   invariant@2.2.4:
     dependencies:
       loose-envify: 1.4.0
+
+  ip-address@10.1.0: {}
 
   ip-regex@5.0.0: {}
 
@@ -7440,6 +7750,10 @@ snapshots:
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
+
+  jose@5.10.0: {}
+
+  jose@6.2.3: {}
 
   js-sha3@0.8.0: {}
 
@@ -7835,6 +8149,8 @@ snapshots:
     dependencies:
       flow-enums-runtime: 0.0.6
 
+  object-assign@4.1.1: {}
+
   object-inspect@1.13.4: {}
 
   on-finished@2.3.0:
@@ -7959,6 +8275,8 @@ snapshots:
   picomatch@2.3.2: {}
 
   picomatch@4.0.4: {}
+
+  pkce-challenge@5.0.1: {}
 
   possible-typed-array-names@1.1.0: {}
 
@@ -8632,6 +8950,8 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
+  tweetnacl@1.0.3: {}
+
   type-fest@0.7.1: {}
 
   type-fest@2.19.0: {}
@@ -8947,5 +9267,9 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+
+  zod-to-json-schema@3.25.2(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
 
   zod@3.25.76: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,3 @@
 packages:
   - "skillname-pack/packages/*"
+  - "apps/*"

--- a/scripts/pin-to-0g.ts
+++ b/scripts/pin-to-0g.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env tsx
+import 'dotenv/config'
 /**
  * Pin reference skill bundle manifest(s) to 0G Galileo testnet via the
  * official Go CLI (0g-storage-client). Wrapping the binary instead of

--- a/skillname-pack/packages/bridge/package.json
+++ b/skillname-pack/packages/bridge/package.json
@@ -18,7 +18,11 @@
   },
   "dependencies": {
     "@0glabs/0g-serving-broker": "^0.7.5",
-    "@modelcontextprotocol/sdk": "^0.6.1",
-    "@skillname/sdk": "workspace:*"
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "@skillname/sdk": "workspace:*",
+    "@x402/evm": "^2.11.0",
+    "@x402/fetch": "^2.11.0",
+    "dotenv": "^17.4.2",
+    "viem": "^2.21.55"
   }
 }

--- a/skillname-pack/packages/bridge/src/keeperhub.ts
+++ b/skillname-pack/packages/bridge/src/keeperhub.ts
@@ -1,0 +1,254 @@
+/**
+ * KeeperHub MCP client.
+ *
+ * Bridge acts as a MCP client to KeeperHub's hosted server at
+ * https://app.keeperhub.com/mcp, calling execute_contract_call directly.
+ *
+ * Flow:
+ *   1. Connect with KEEPERHUB_API_KEY Bearer token
+ *   2. Call execute_contract_call → returns executionId
+ *   3. Poll get_direct_execution_status until completed | failed
+ *   4. Extract txHash → return BaseScan link
+ */
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { wrapFetchWithPayment, x402Client } from "@x402/fetch";
+import { ExactEvmScheme, toClientEvmSigner } from "@x402/evm";
+import { privateKeyToAccount } from "viem/accounts";
+import { createPublicClient, http } from "viem";
+import { baseSepolia } from "viem/chains";
+import type { Tool } from "@skillname/sdk";
+
+const KEEPERHUB_PAID_URL =
+  process.env.KEEPERHUB_PAID_URL ?? "http://localhost:3001";
+
+// ── x402 client (lazy init) ───────────────────────────────────────────────
+let _x402Fetch: typeof fetch | null = null;
+
+function getX402Fetch(): typeof fetch {
+  if (_x402Fetch) return _x402Fetch;
+
+  const pk = process.env.AGENT_WALLET_PRIVATE_KEY as `0x${string}` | undefined;
+  if (!pk)
+    throw new Error(
+      "AGENT_WALLET_PRIVATE_KEY not set — needed for paid skill calls",
+    );
+
+  const account = privateKeyToAccount(pk);
+  const publicClient = createPublicClient({
+    chain: baseSepolia,
+    transport: http(),
+  });
+  const signer = toClientEvmSigner(account, publicClient);
+
+  const scheme = new ExactEvmScheme(signer);
+  const client = new x402Client();
+  client.register("eip155:84532", scheme);
+
+  _x402Fetch = wrapFetchWithPayment(fetch, client) as typeof fetch;
+  return _x402Fetch;
+}
+
+const KH_MCP_URL = "https://app.keeperhub.com/mcp";
+const POLL_INTERVAL_MS = 2_000;
+const POLL_TIMEOUT_MS = 60_000;
+
+const BASESCAN: Record<number, string> = {
+  8453: "https://basescan.org/tx/",
+  84532: "https://sepolia.basescan.org/tx/",
+};
+
+// ── Singleton client ───────────────────────────────────────────────────────
+let _client: Client | null = null;
+
+async function getClient(): Promise<Client> {
+  if (_client) return _client;
+
+  const apiKey = process.env.KEEPERHUB_API_KEY;
+  if (!apiKey) throw new Error("KEEPERHUB_API_KEY env var not set");
+
+  const client = new Client(
+    { name: "skillname-bridge", version: "0.0.1" },
+    { capabilities: {} },
+  );
+
+  await client.connect(
+    new StreamableHTTPClientTransport(new URL(KH_MCP_URL), {
+      requestInit: { headers: { Authorization: `Bearer ${apiKey}` } },
+    }),
+  );
+
+  _client = client;
+  return client;
+}
+
+// ── Public entry point ─────────────────────────────────────────────────────
+export async function executeViaKeeperHub(
+  tool: Tool,
+  args: Record<string, unknown>,
+): Promise<{ text: string; isError?: boolean }> {
+  const exec = tool.execution as Extract<
+    Tool["execution"],
+    { type: "keeperhub" }
+  >;
+  const chainId = exec.chainId ?? 84532;
+
+  // Paid path: route through keeperhub-paid x402 server
+  if (exec.payment) {
+    return executeViaPaidServer(tool, args, exec, chainId);
+  }
+
+  // Free path: call KeeperHub MCP directly
+  const client = await getClient();
+
+  // Build execute_contract_call arguments from the skill's execution config + caller args.
+  // exec.contractAddress / exec.functionName come from the manifest;
+  // function_args are the tool call inputs ordered as a JSON array.
+  const callArgs: Record<string, string> = {
+    network: String(chainId),
+    contract_address: (exec as any).contractAddress ?? "",
+    function_name: exec.tool ?? (exec as any).functionName ?? "",
+    function_args: JSON.stringify(Object.values(args)),
+  };
+
+  if ((exec as any).abi) callArgs.abi = (exec as any).abi;
+
+  // Call KeeperHub — returns execution ID for state-changing calls
+  const res = await callTool(client, "execute_contract_call", callArgs);
+
+  // View/pure functions return the result directly (no txHash)
+  if (!res.toLowerCase().includes("execution")) {
+    return { text: res };
+  }
+
+  // Extract execution ID and poll
+  const idMatch =
+    res.match(/"?(?:execution_?id|id)"?\s*[:\s]+([a-z0-9_-]{6,})/i) ??
+    res.match(
+      /([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})/i,
+    );
+  if (!idMatch) {
+    // No execution ID — treat raw response as result
+    return { text: res };
+  }
+
+  const executionId = idMatch[1];
+  const txHash = await pollExecution(client, executionId);
+  const explorer = BASESCAN[chainId] ?? "https://sepolia.basescan.org/tx/";
+
+  return {
+    text:
+      `✓ Transaction confirmed\n` +
+      `Tx:       ${txHash}\n` +
+      `Explorer: ${explorer}${txHash}`,
+  };
+}
+
+// ── x402 paid path ─────────────────────────────────────────────────────────
+async function executeViaPaidServer(
+  tool: Tool,
+  args: Record<string, unknown>,
+  exec: Extract<Tool["execution"], { type: "keeperhub" }>,
+  chainId: number,
+): Promise<{ text: string; isError?: boolean }> {
+  const fetchWithPayment = getX402Fetch();
+  const explorer = BASESCAN[chainId] ?? "https://sepolia.basescan.org/tx/";
+
+  const body = {
+    contract_address: (exec as any).contractAddress ?? "",
+    network: String(chainId),
+    function_name: exec.tool ?? (exec as any).functionName ?? "",
+    function_args: JSON.stringify(Object.values(args)),
+  };
+
+  const res = await fetchWithPayment(`${KEEPERHUB_PAID_URL}/execute`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+  if (!res.ok) {
+    const err = await res.text();
+    return {
+      text: `keeperhub-paid error ${res.status}: ${err}`,
+      isError: true,
+    };
+  }
+
+  const data = (await res.json()) as {
+    txHash?: string;
+    explorerUrl?: string;
+    result?: string;
+    error?: string;
+  };
+
+  if (data.error) return { text: data.error, isError: true };
+  if (data.txHash) {
+    return {
+      text:
+        `✓ Transaction confirmed (x402 paid)\n` +
+        `Tx:       ${data.txHash}\n` +
+        `Explorer: ${data.explorerUrl ?? explorer + data.txHash}`,
+    };
+  }
+  return { text: data.result ?? JSON.stringify(data) };
+}
+
+// ── Poll execution status ──────────────────────────────────────────────────
+async function pollExecution(
+  client: Client,
+  executionId: string,
+): Promise<string> {
+  const deadline = Date.now() + POLL_TIMEOUT_MS;
+
+  while (Date.now() < deadline) {
+    await sleep(POLL_INTERVAL_MS);
+
+    const status = await callTool(client, "get_direct_execution_status", {
+      execution_id: executionId,
+    });
+
+    if (status.toLowerCase().includes("complet")) {
+      // Extract 0x... tx hash (64 hex chars)
+      const txMatch = status.match(/0x[a-fA-F0-9]{64}/);
+      if (txMatch) return txMatch[0];
+
+      // If completed but no hash visible, fetch logs
+      const logs = await callTool(client, "get_execution_logs", {
+        executionId,
+      });
+      const logMatch = logs.match(/0x[a-fA-F0-9]{64}/);
+      if (logMatch) return logMatch[0];
+
+      throw new Error(
+        `Execution completed but no tx hash found. Logs: ${logs.slice(0, 300)}`,
+      );
+    }
+
+    if (status.toLowerCase().includes("fail")) {
+      throw new Error(`KeeperHub execution failed: ${status.slice(0, 300)}`);
+    }
+  }
+
+  throw new Error(
+    `KeeperHub execution timed out after ${POLL_TIMEOUT_MS / 1000}s (id: ${executionId})`,
+  );
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+async function callTool(
+  client: Client,
+  name: string,
+  args: Record<string, unknown>,
+): Promise<string> {
+  const res = await client.callTool({ name, arguments: args });
+  return (res.content as Array<{ type: string; text?: string }>)
+    .filter((c) => c.type === "text")
+    .map((c) => c.text ?? "")
+    .join("\n");
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}

--- a/skillname-pack/packages/bridge/src/server.ts
+++ b/skillname-pack/packages/bridge/src/server.ts
@@ -29,8 +29,10 @@ import {
   ListToolsRequestSchema,
   type Tool as MCPTool,
 } from '@modelcontextprotocol/sdk/types.js'
+import 'dotenv/config'
 import { resolveSkill, type ResolveResult, type Tool } from '@skillname/sdk'
 import { executeVia0GCompute, listProviders } from './0gcompute.js'
+import { executeViaKeeperHub } from './keeperhub.js'
 
 // -------------------------------------------------------------------------
 // KeeperHub / x402 config — picked up at startup (Issue #13)
@@ -306,47 +308,28 @@ async function executeLocal(tool: Tool, args: Record<string, unknown>, _skill: I
 }
 
 async function executeKeeperHub(tool: Tool, args: Record<string, unknown>, _skill: ImportedSkill) {
-  // Issue #13: route to KeeperHub MCP + handle x402 challenge.
-  const exec = tool.execution as Extract<Tool['execution'], { type: 'keeperhub' }>
-
-  const hasConfig = KEEPERHUB_API_KEY && AGENT_WALLET_PRIVATE_KEY && PAY_TO_ADDRESS
-  const target = exec.tool ?? exec.workflowId ?? '(unknown)'
-
-  if (!hasConfig) {
-    log.err(`KeeperHub env not configured (KEEPERHUB_API_KEY / AGENT_WALLET_PRIVATE_KEY / PAY_TO_ADDRESS)`)
+  if (!KEEPERHUB_API_KEY) {
+    log.err(`KEEPERHUB_API_KEY not set`)
     return {
-      content: [
-        {
-          type: 'text',
-          text: `KeeperHub not configured. Set KEEPERHUB_API_KEY, AGENT_WALLET_PRIVATE_KEY, PAY_TO_ADDRESS and restart the bridge.`,
-        },
-      ],
+      content: [{ type: 'text', text: `KeeperHub not configured. Set KEEPERHUB_API_KEY and restart the bridge.` }],
       isError: true,
     }
   }
 
-  if (exec.payment) {
-    log.info(`x402 payment required: ${exec.payment.price} ${exec.payment.token} on ${exec.payment.network}`)
-    // TODO (Issue #13): EIP-3009 transferWithAuthorization → retry with X-PAYMENT header
+  log.info(`keeperhub → ${tool.name}`)
+  try {
+    const result = await executeViaKeeperHub(tool, args)
+    log.ok(`keeperhub done: ${result.text.split('\n')[1] ?? ''}`)
     return {
-      content: [
-        {
-          type: 'text',
-          text: `[#13 wip] KeeperHub call to ${target} needs ${exec.payment.price} ${exec.payment.token} on ${exec.payment.network}. x402 flow implementation in progress. Args: ${JSON.stringify(args)}`,
-        },
-      ],
+      content: [{ type: 'text', text: result.text }],
+      isError: result.isError,
     }
-  }
-
-  log.info(`routing to KeeperHub: ${target}`)
-  // TODO (Issue #13): call KeeperHub API with KEEPERHUB_API_KEY
-  return {
-    content: [
-      {
-        type: 'text',
-        text: `[#13 wip] KeeperHub call to ${target}. Args: ${JSON.stringify(args)}`,
-      },
-    ],
+  } catch (e: any) {
+    log.err(`keeperhub error: ${e.message}`)
+    return {
+      content: [{ type: 'text', text: `KeeperHub execution failed: ${e.message}` }],
+      isError: true,
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

Wire x402 payment flow end-to-end: bridge → keeperhub-paid server → KeeperHub MCP.

## Changes

### New: `apps/keeperhub-paid/`
- Hono HTTP server with `@x402/hono` payment middleware
- Returns 402 challenge → validates EIP-3009 USDC payment → calls KeeperHub `execute_contract_call`
- Polls execution status → returns BaseScan tx link

### New: `bridge/src/keeperhub.ts`
- x402 client-side: `wrapFetchWithPayment` auto-handles 402 from keeperhub-paid
- Agent wallet signs EIP-3009 USDC authorization on Base Sepolia
- Free path calls KeeperHub MCP directly, paid path routes through keeperhub-paid

### Fixed: x402 API type errors
- `HTTPFacilitatorClient` (class, not function)
- `ExactEvmScheme` server vs client variants (different constructors)
- `toClientEvmSigner(account, publicClient)` correct signature
- `wrapFetchWithPayment(fetch, client)` 2-arg API

### Updated: bridge `server.ts`
- Renamed `manifest_load` → `skill_import`, `manifest_list_loaded` → `skill_list_imported`
- Added keeperhub execution router

### Config
- Added `apps/*` to `pnpm-workspace.yaml`
- Added x402 + hono root dependencies
- Added `@x402/evm`, `@x402/fetch`, `viem` to bridge deps

## What was tested
- `pnpm build` — all 5 packages compile clean (schema, sdk, bridge, cli, keeperhub-paid)
- Zero TypeScript diagnostics across all modified files

## Still open (Issue #4 sub-tasks)
- [ ] CDP facilitator integration (real API key)
- [ ] Pre-fund agent wallet on Base Sepolia
- [ ] E2E test: bridge → keeperhub-paid → KeeperHub → BaseScan tx
- [ ] BaseScan tx confirmation in demo flow