### PR TITLE
feat(#8): CLI resolve, verify, init commands

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,9 @@ importers:
       '@skillname/sdk':
         specifier: workspace:*
         version: link:../sdk
+      dotenv:
+        specifier: ^17.4.2
+        version: 17.4.2
       viem:
         specifier: ^2.21.55
         version: 2.48.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
@@ -1833,6 +1836,10 @@ packages:
 
   dotenv@16.4.7:
     resolution: {integrity: sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==}
+    engines: {node: '>=12'}
+
+  dotenv@17.4.2:
+    resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
     engines: {node: '>=12'}
 
   dunder-proto@1.0.1:
@@ -6468,6 +6475,8 @@ snapshots:
       type-fest: 4.41.0
 
   dotenv@16.4.7: {}
+
+  dotenv@17.4.2: {}
 
   dunder-proto@1.0.1:
     dependencies:

--- a/skillname-pack/packages/cli/package.json
+++ b/skillname-pack/packages/cli/package.json
@@ -7,13 +7,16 @@
   "bin": {
     "skill": "./dist/index.js"
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "dev": "tsx src/index.ts"
   },
   "dependencies": {
     "@skillname/sdk": "workspace:*",
+    "dotenv": "^17.4.2",
     "viem": "^2.21.55"
   }
 }

--- a/skillname-pack/packages/cli/src/commands/init.ts
+++ b/skillname-pack/packages/cli/src/commands/init.ts
@@ -1,0 +1,94 @@
+/**
+ * skill init <name>
+ *
+ * Scaffolds a new skill bundle directory with a manifest.json template.
+ *
+ * Creates:
+ *   <name>/
+ *   ├── manifest.json
+ *   ├── tools/
+ *   ├── prompts/
+ *   └── examples/
+ */
+
+import { writeFileSync, mkdirSync, existsSync } from "node:fs";
+import { join } from "node:path";
+
+export async function init(name: string): Promise<void> {
+  // Validate name
+  if (!/^[a-z0-9-]+$/.test(name)) {
+    console.error(
+      `Invalid name "${name}". Use lowercase letters, numbers, and hyphens only.`,
+    );
+    process.exit(1);
+  }
+
+  const dir = name;
+  if (existsSync(dir)) {
+    console.error(`Directory "${dir}" already exists.`);
+    process.exit(1);
+  }
+
+  console.log(`→ Creating skill bundle: ${name}/`);
+
+  // Create directories
+  mkdirSync(join(dir, "tools"), { recursive: true });
+  mkdirSync(join(dir, "prompts"), { recursive: true });
+  mkdirSync(join(dir, "examples"), { recursive: true });
+
+  // Create manifest.json
+  const manifest = {
+    $schema: "https://manifest.eth/schemas/skill-v1.json",
+    name,
+    ensName: `${name}.eth`,
+    version: "1.0.0",
+    description: "",
+    author: "0x0000000000000000000000000000000000000000",
+    createdAt: new Date().toISOString(),
+    license: "MIT",
+    tools: [
+      {
+        name: "my_tool",
+        description: "Describe what this tool does",
+        inputSchema: {
+          type: "object",
+          properties: {
+            input: {
+              type: "string",
+              description: "Describe the input",
+            },
+          },
+          required: ["input"],
+        },
+        execution: {
+          type: "http",
+          endpoint: "https://api.example.com/v1/action",
+          method: "POST",
+        },
+      },
+    ],
+    trust: {
+      ensip25: { enabled: false },
+    },
+  };
+
+  writeFileSync(
+    join(dir, "manifest.json"),
+    JSON.stringify(manifest, null, 2) + "\n",
+  );
+
+  console.log(`  ✓ ${dir}/manifest.json`);
+  console.log(`  ✓ ${dir}/tools/`);
+  console.log(`  ✓ ${dir}/prompts/`);
+  console.log(`  ✓ ${dir}/examples/`);
+  console.log();
+  console.log(`Next steps:`);
+  console.log(
+    `  1. Edit ${dir}/manifest.json — set ensName, description, tool config`,
+  );
+  console.log(`  2. skill verify ${name}.eth  — validate against schema`);
+  console.log(
+    `  3. skill publish ${dir}/ ${name}.eth  — pin to IPFS + set ENS records`,
+  );
+  console.log();
+}

--- a/skillname-pack/packages/cli/src/commands/resolve.ts
+++ b/skillname-pack/packages/cli/src/commands/resolve.ts
@@ -1,0 +1,108 @@
+/**
+ * skill resolve <ensName>
+ *
+ * Resolves an ENS name to its skill bundle via the SDK, then prints
+ * a human-readable summary or raw JSON.
+ *
+ * Examples:
+ *   skill resolve quote.uniswap.eth
+ *   skill resolve quote.uniswap.eth --chain mainnet --json
+ */
+
+import { resolveSkill, type ResolveResult } from "@skillname/sdk";
+
+export interface ResolveOptions {
+  chain: "mainnet" | "sepolia";
+  json: boolean;
+}
+
+export async function resolve(
+  ensName: string,
+  opts: ResolveOptions,
+): Promise<void> {
+  const t0 = Date.now();
+
+  console.error(`→ Resolving ${ensName} on ${opts.chain}…`);
+
+  let result: ResolveResult;
+  try {
+    result = await resolveSkill(ensName, {
+      chain: opts.chain,
+    });
+  } catch (e: any) {
+    console.error(`✗ ${e.message}`);
+    process.exit(1);
+  }
+
+  const dt = Date.now() - t0;
+
+  if (opts.json) {
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+
+  // Human-readable output
+  const b = result.bundle;
+  const verified = result.ensip25?.bound ? "✓ verified" : "· unverified";
+
+  console.log();
+  console.log(`  ${b.ensName}  (${verified})`);
+  console.log(`  ${"─".repeat(50)}`);
+  console.log(`  Name:        ${b.name}`);
+  console.log(`  Version:     ${result.version ?? b.version}`);
+  if (b.description) {
+    console.log(`  Description: ${b.description}`);
+  }
+  if (b.author) {
+    console.log(`  Author:      ${b.author}`);
+  }
+  if (b.license) {
+    console.log(`  License:     ${b.license}`);
+  }
+  console.log(`  CID:         ${result.cid}`);
+  if (result.schema) {
+    console.log(`  Schema:      ${result.schema}`);
+  }
+  console.log();
+
+  // Tools
+  console.log(`  Tools (${b.tools.length}):`);
+  for (const tool of b.tools) {
+    const exec = tool.execution;
+    let execLabel = exec.type;
+    if (exec.type === "keeperhub" && "payment" in exec && exec.payment) {
+      execLabel += ` · ${exec.payment.price} ${exec.payment.token}`;
+    }
+    if (exec.type === "http" && "endpoint" in exec) {
+      execLabel += ` · ${exec.method ?? "POST"}`;
+    }
+    console.log(`    · ${b.name}__${tool.name}  [${execLabel}]`);
+    console.log(`      ${tool.description}`);
+  }
+
+  // Trust
+  if (result.ensip25) {
+    console.log();
+    console.log(`  Trust:`);
+    console.log(
+      `    ENSIP-25:  ${result.ensip25.bound ? "bound ✓" : "not bound"}`,
+    );
+    if (result.ensip25.registry) {
+      console.log(`    Registry:  ${result.ensip25.registry}`);
+      console.log(`    Agent ID:  ${result.ensip25.agentId}`);
+    }
+  }
+
+  // Dependencies
+  if (b.dependencies && b.dependencies.length > 0) {
+    console.log();
+    console.log(`  Dependencies (${b.dependencies.length}):`);
+    for (const dep of b.dependencies) {
+      console.log(`    · ${dep}`);
+    }
+  }
+
+  console.log();
+  console.log(`  Resolved in ${dt}ms`);
+  console.log();
+}

--- a/skillname-pack/packages/cli/src/commands/verify.ts
+++ b/skillname-pack/packages/cli/src/commands/verify.ts
@@ -1,0 +1,107 @@
+/**
+ * skill verify <ensName>
+ *
+ * Resolves a skill and runs validation checks:
+ *   1. ENS text record exists
+ *   2. CID fetches successfully
+ *   3. Bundle validates against schema v1
+ *   4. ENSIP-25 trust binding (if declared)
+ *   5. Atomic check: exactly 1 tool
+ */
+
+import { resolveSkill } from "@skillname/sdk";
+
+export interface VerifyOptions {
+  chain: "mainnet" | "sepolia";
+}
+
+export async function verify(
+  ensName: string,
+  opts: VerifyOptions,
+): Promise<void> {
+  let failures = 0;
+
+  function check(label: string, ok: boolean, detail?: string) {
+    if (ok) {
+      console.log(`  ✓ ${label}`);
+    } else {
+      failures++;
+      console.log(`  ✗ ${label}${detail ? `  — ${detail}` : ""}`);
+    }
+  }
+
+  console.log();
+  console.log(`  Verifying ${ensName} on ${opts.chain}`);
+  console.log(`  ${"─".repeat(50)}`);
+
+  // Step 1-3: resolve (includes ENS read, IPFS fetch, schema validation)
+  let result;
+  try {
+    result = await resolveSkill(ensName, { chain: opts.chain });
+    check("ENS text record found", true);
+    check("CID fetched from IPFS", true);
+    check("Schema v1 validation passed", true);
+  } catch (e: any) {
+    const msg = e.message ?? String(e);
+    if (msg.includes("No skill manifest")) {
+      check("ENS text record found", false, msg);
+    } else if (msg.includes("Failed to fetch")) {
+      check("ENS text record found", true);
+      check("CID fetched from IPFS", false, msg);
+    } else if (msg.includes("schema validation")) {
+      check("ENS text record found", true);
+      check("CID fetched from IPFS", true);
+      check("Schema v1 validation passed", false, msg);
+    } else {
+      check("Resolution", false, msg);
+    }
+    console.log();
+    console.log(`  ${failures} check(s) failed.`);
+    console.log();
+    process.exit(1);
+  }
+
+  // Step 4: ENSIP-25
+  const b = result.bundle;
+  if (b.trust?.erc8004) {
+    check("ENSIP-25 trust declared", true);
+    check(
+      "ENSIP-25 binding verified",
+      result.ensip25?.bound === true,
+      result.ensip25?.bound
+        ? undefined
+        : 'agent-registration text record not set to "1"',
+    );
+  } else {
+    console.log(`  · ENSIP-25 trust not declared (optional)`);
+  }
+
+  // Step 5: Atomic check
+  check(
+    `Atomic skill (${b.tools.length} tool)`,
+    b.tools.length === 1,
+    b.tools.length !== 1 ? `expected 1 tool, got ${b.tools.length}` : undefined,
+  );
+
+  // Step 6: Name conventions
+  const nameOk = /^[a-z0-9-]+$/.test(b.name);
+  check(`Bundle name "${b.name}" matches pattern`, nameOk);
+
+  const ensOk = /^([a-z0-9-]+\.)+eth$/.test(b.ensName);
+  check(`ENS name "${b.ensName}" matches pattern`, ensOk);
+
+  for (const tool of b.tools) {
+    const toolOk = /^[a-z][a-z0-9_]*$/.test(tool.name);
+    check(`Tool name "${tool.name}" matches pattern`, toolOk);
+  }
+
+  // Summary
+  console.log();
+  if (failures === 0) {
+    console.log(`  All checks passed. ✓`);
+  } else {
+    console.log(`  ${failures} check(s) failed.`);
+  }
+  console.log();
+  process.exit(failures > 0 ? 1 : 0);
+}

--- a/skillname-pack/packages/cli/src/index.ts
+++ b/skillname-pack/packages/cli/src/index.ts
@@ -1,7 +1,130 @@
 #!/usr/bin/env node
-// Stub CLI. Real verbs (init / publish / resolve / verify / lock) land in issue #17.
+/**
+ * @skillname/cli
+ *
+ * CLI for the skillname ENS skill registry.
+ *
+ * Usage:
+ *   skill resolve <ensName> [--chain mainnet|sepolia] [--json]
+ *   skill verify  <ensName> [--chain mainnet|sepolia]
+ *   skill init    <name>
+ *   skill publish <dir> <ensName>
+ *   skill lock    <ensName>
+ */
 
-const cmd = process.argv[2]
-console.error('skill — stub. issue #17 wires the real commands.')
-if (cmd) console.error(`requested: ${cmd}`)
-process.exit(cmd ? 0 : 1)
+import { resolve } from "./commands/resolve.js";
+import { verify } from "./commands/verify.js";
+import { init } from "./commands/init.js";
+
+const HELP = `
+skill — ENS-native skill registry CLI
+
+Commands:
+  resolve <ensName>   Resolve an ENS name to its skill bundle
+  verify  <ensName>   Validate schema + ENSIP-25 trust for a skill
+  init    <name>      Scaffold a new skill bundle directory
+  publish <dir> <ens> Publish a bundle to IPFS + set ENS text records
+  lock    <ensName>   Generate a lockfile from skill imports
+
+Options:
+  --chain <chain>     Chain to resolve on (mainnet | sepolia, default: sepolia)
+  --json              Output raw JSON instead of formatted text
+  --help, -h          Show this help
+
+Examples:
+  skill resolve quote.uniswap.eth
+  skill resolve quote.uniswap.eth --chain mainnet --json
+  skill verify swap.uniswap.eth
+  skill init my-skill
+`.trim();
+
+function parseArgs(argv: string[]) {
+  const args = argv.slice(2);
+  const command = args[0];
+  const positional: string[] = [];
+  const flags: Record<string, string | boolean> = {};
+
+  for (let i = 1; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === "--help" || arg === "-h") {
+      flags.help = true;
+    } else if (arg === "--json") {
+      flags.json = true;
+    } else if (arg === "--chain" && i + 1 < args.length) {
+      flags.chain = args[++i];
+    } else if (arg.startsWith("--")) {
+      // Unknown flag — skip
+      console.error(`Unknown flag: ${arg}`);
+    } else {
+      positional.push(arg);
+    }
+  }
+
+  return { command, positional, flags };
+}
+
+async function main() {
+  const { command, positional, flags } = parseArgs(process.argv);
+
+  if (!command || flags.help) {
+    console.log(HELP);
+    process.exit(0);
+  }
+
+  switch (command) {
+    case "resolve":
+      if (!positional[0]) {
+        console.error(
+          "Usage: skill resolve <ensName> [--chain mainnet|sepolia] [--json]",
+        );
+        process.exit(1);
+      }
+      await resolve(positional[0], {
+        chain: (flags.chain as "mainnet" | "sepolia") ?? "sepolia",
+        json: !!flags.json,
+      });
+      break;
+
+    case "verify":
+      if (!positional[0]) {
+        console.error(
+          "Usage: skill verify <ensName> [--chain mainnet|sepolia]",
+        );
+        process.exit(1);
+      }
+      await verify(positional[0], {
+        chain: (flags.chain as "mainnet" | "sepolia") ?? "sepolia",
+      });
+      break;
+
+    case "init":
+      if (!positional[0]) {
+        console.error("Usage: skill init <name>");
+        process.exit(1);
+      }
+      await init(positional[0]);
+      break;
+
+    case "publish":
+      console.error("skill publish — not yet implemented. See issue #17.");
+      process.exit(1);
+      break;
+
+    case "lock":
+      console.error(
+        "skill lock — not yet implemented. Depends on skill.imports (#3).",
+      );
+      process.exit(1);
+      break;
+
+    default:
+      console.error(`Unknown command: ${command}`);
+      console.log(HELP);
+      process.exit(1);
+  }
+}
+
+main().catch((e) => {
+  console.error(`Error: ${e.message}`);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Implement three CLI commands for `@skillname/cli`, replacing the stub.

## Commands

### `skill resolve <ensName>`
- Calls SDK `resolveSkill()` with `--chain` option (default: sepolia)
- Prints formatted summary: name, version, CID, tools list, trust status
- `--json` flag for raw JSON output (pipe-friendly)

### `skill verify <ensName>`
- Runs validation checks: ENS record exists, CID fetches, schema v1 passes
- Checks ENSIP-25 trust binding if declared
- Atomic check: exactly 1 tool per bundle
- Name pattern validation for bundle, ENS, and tool names

### `skill init <name>`
- Scaffolds `<name>/` with `manifest.json`, `tools/`, `prompts/`, `examples/`
- Template manifest with placeholder tool (http execution type)
- Prints next steps

### Stubs
- `publish` — not yet implemented (needs Storacha + ENS write)
- `lock` — not yet implemented (depends on #3 skill.imports)

## Tested
- `skill` (no args) → help text ✓
- `skill init test-skill` → scaffolds directory ✓
- `skill resolve quote.uniswap.eth` → fails gracefully (ENS not registered) ✓
- `pnpm build` → compiles clean ✓