### PR TITLE
fix(ci): build schema before sdk in e2e workflow

### DIFF
--- a/.github/workflows/e2e-0gcompute.yml
+++ b/.github/workflows/e2e-0gcompute.yml
@@ -31,8 +31,10 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build SDK (bridge depends on it)
-        run: pnpm --filter @skillname/sdk build
+      - name: Build schema → sdk (bridge depends on both)
+        run: |
+          pnpm --filter @skillname/schema build
+          pnpm --filter @skillname/sdk build
 
       - name: Run 0G Compute e2e
         env:


### PR DESCRIPTION
## Why

CI failed on \`pnpm --filter @skillname/sdk build\`:

\`\`\`
src/index.ts(14,44): error TS2307: Cannot find module '@skillname/schema'
src/index.ts(184,41): error TS7006: Parameter 'e' implicitly has an 'any' type.
\`\`\`

Root cause: schema's \`dist/\` didn't exist yet, so TS couldn't resolve \`@skillname/schema\` types. The implicit-any on line 184 was a downstream consequence — once \`validateBundle\`'s return type is missing, the \`errors\` array becomes \`any[]\`.

## Fix

Build schema first, then sdk. Single fix solves both errors.

## Test

Local: \`pnpm --filter @skillname/schema build && pnpm --filter @skillname/sdk build\` → clean.