### PR TITLE
fix(ci): unblock Cloudflare Pages deploy

### DIFF
--- a/.github/workflows/cloudflare-deploy.yml
+++ b/.github/workflows/cloudflare-deploy.yml
@@ -67,6 +67,11 @@ jobs:
       - id: deploy
         name: Deploy to Cloudflare Pages
         uses: cloudflare/wrangler-action@v3
+        env:
+          # wrangler-action runs `pnpm add wrangler` inside the workspace root,
+          # which fails with ERR_PNPM_ADDING_TO_ROOT now that apps/* is a workspace.
+          # This flag tells pnpm to allow it.
+          NPM_CONFIG_IGNORE_WORKSPACE_ROOT_CHECK: "true"
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
## Why

After merging PR #33 (which added \`apps/*\` to \`pnpm-workspace.yaml\`), the Cloudflare Pages deploy started failing:

\`\`\`
[command]/home/runner/setup-pnpm/node_modules/.bin/pnpm add wrangler@3.90.0
ERR_PNPM_ADDING_TO_ROOT  Running this command will add the dependency to the workspace root...
##[error]Action failed
\`\`\`

\`cloudflare/wrangler-action@v3\` auto-installs Wrangler via \`pnpm add\`, which pnpm now refuses because the cwd is a workspace root.

## Fix

Set \`NPM_CONFIG_IGNORE_WORKSPACE_ROOT_CHECK=true\` env var on the deploy step so pnpm allows the install. Scoped to that step only — local dev unaffected.

## Test plan

- [ ] Merge → trigger deploy on staging push → confirm green run