### PR TITLE
fix(ci): enable OG_AUTO_INIT_LEDGER=1 for e2e

### DIFF
--- a/.github/workflows/e2e-0gcompute.yml
+++ b/.github/workflows/e2e-0gcompute.yml
@@ -42,4 +42,9 @@ jobs:
           # no separate secret needed; same EVM account works on Galileo chain.
           SEPOLIA_PRIVATE_KEY: ${{ secrets.SEPOLIA_PRIVATE_KEY }}
           OG_RPC_URL: https://evmrpc-testnet.0g.ai
+          # Auto-create the ledger + per-provider sub-account on first failure
+          # so CI doesn't need a manual `setup-0g-ledger.ts` run before the
+          # very first e2e. Only triggers on "Sub-account not found"; subsequent
+          # runs reuse the on-chain account and don't spend additional OG.
+          OG_AUTO_INIT_LEDGER: "1"
         run: pnpm --filter @skillname/bridge e2e


### PR DESCRIPTION
## Why

The e2e workflow on staging fails on the first run because wallet \`0x3Fb7c18E…\` has never created a 0G Compute ledger sub-account. Latest run #25198948654:

\`\`\`
PASS  providers found: 2 provider(s), target confirmed
FAIL  inference call: 0G Compute execution failed: Sub-account not found.
      Initialize it by transferring funds via "transfer-fund"
      (run scripts/setup-0g-ledger.ts once, or set OG_AUTO_INIT_LEDGER=1)
\`\`\`

PR #40 already added the auto-init path in \`bridge/src/0gcompute.ts\`. This PR just turns it on in CI.

## Cost

Single-shot: \`addLedger(0.05 OG)\` + \`transferFund(provider, 'inference', 0.02 OG)\` ≈ 0.07 OG total. After that, \`getRequestHeaders\` succeeds and the auto-init branch never runs again — so CI is **not** burning OG per run.

## After this merges

The next push that touches \`bridge/src/0gcompute.ts\`, \`e2e-0gcompute.ts\`, or \`examples/infer-0g/\` triggers the e2e. First run does the on-chain init + inference. Subsequent runs just do inference.

## Test plan

- [ ] Merge → trigger e2e (this PR's diff is in the workflow path filter)
- [ ] Confirm step "Run 0G Compute e2e" reports \`PASS  inference call\`
- [ ] Wallet OG balance drops by ~0.07 OG once, then stable