### PR TITLE
fix(0g): bump ledger minimum deposit from 0.05 to 3 OG

### DIFF
--- a/scripts/setup-0g-ledger.ts
+++ b/scripts/setup-0g-ledger.ts
@@ -33,7 +33,8 @@ const KEY = process.env.OG_COMPUTE_PRIVATE_KEY ?? process.env.SEPOLIA_PRIVATE_KE
 
 const DEFAULT_PROVIDER = '0xa48f01287233509FD694a22Bf840225062E67836'
 // Total deposit into the master ledger (OG, as a number per SDK signature).
-const LEDGER_DEPOSIT = 0.05
+// 0G Compute enforces a 3 OG minimum — smaller values are rejected.
+const LEDGER_DEPOSIT = 3
 // Per-provider sub-account allocation (wei-style bigint, 18 decimals).
 const PROVIDER_FUND = ethers.parseEther('0.02')
 
@@ -55,8 +56,9 @@ const targetProvider = process.argv[2] ?? DEFAULT_PROVIDER
 
   const balance = await provider.getBalance(wallet.address)
   console.log(`OG balance: ${ethers.formatEther(balance)} OG`)
-  if (balance < ethers.parseEther('0.03')) {
-    console.error('Need at least ~0.03 OG. Top up at https://faucet.0g.ai')
+  // 3 OG ledger min + 0.02 OG sub-account + ~0.05 gas headroom
+  if (balance < ethers.parseEther('3.1')) {
+    console.error('Need at least ~3.1 OG. Hackathon faucet: https://0g-faucet-hackathon.vercel.app/ (promo: OPEN-AGENT)')
     process.exit(1)
   }
 

--- a/skillname-pack/packages/bridge/src/0gcompute.ts
+++ b/skillname-pack/packages/bridge/src/0gcompute.ts
@@ -40,7 +40,9 @@ const OG_AUTO_INIT_LEDGER = process.env.OG_AUTO_INIT_LEDGER === '1'
 const SUB_ACCOUNT_MISSING = /sub-account not found|account does not exist|transfer-fund/i
 
 // Per-call init defaults (only used when OG_AUTO_INIT_LEDGER=1).
-const AUTO_LEDGER_DEPOSIT = 0.05 // OG, master ledger
+// 0G Compute requires a minimum 3 OG to create a ledger.
+// Smaller deposits get rejected with: "Minimum balance to create a ledger is 3 0G"
+const AUTO_LEDGER_DEPOSIT = 3 // OG, master ledger
 const AUTO_PROVIDER_FUND_WEI = 20000000000000000n // 0.02 OG, sub-account
 
 // Avoid hammering the broker if init already ran in this process.


### PR DESCRIPTION
## Why

E2E run #25199035377 confirmed PR #44's auto-init flag is wired correctly (\`OG_AUTO_INIT_LEDGER: 1\` is in the env), but it hit a deeper constraint:

\`\`\`
[Auto-funding] Failed to transfer 2.0000 0G to provider sub-account: Account does not exist
FAIL  inference call: Minimum balance to create a ledger is 3 0G, but got 0.05 0G.
      Please use: broker.ledger.addLedger(3)
\`\`\`

Both \`setup-0g-ledger.ts\` and the auto-init path in \`bridge/src/0gcompute.ts\` were calling \`addLedger(0.05)\`. Bumped to \`3\` to clear the network minimum.

## Wallet funding

The wallet \`0x3Fb7c18E…\` had ~0.08 OG. To run e2e end-to-end the wallet now needs:

- 3 OG (ledger creation minimum)
- 0.02 OG (sub-account allocation)
- ~0.05 OG (gas headroom)

Total: **~3.1 OG**.

The standard Galileo faucet (https://faucet.0g.ai) caps at 0.1 OG/day. The hackathon faucet at https://0g-faucet-hackathon.vercel.app/ with promo code \`OPEN-AGENT\` issues larger amounts. Surfaced this URL in both the script's pre-flight check and PR description.

## Test plan

- [x] Bridge builds clean
- [ ] User funds the wallet to ≥3.1 OG via the hackathon faucet
- [ ] Merge → e2e auto-dispatches (touches \`0gcompute.ts\` which is in the path filter)
- [ ] Step "Run 0G Compute e2e" reports \`PASS  inference call\`