### PR TITLE
chore: verify-issue-10 script + D8 logs entry

### DIFF
--- a/apps/web/logs/index.html
+++ b/apps/web/logs/index.html
@@ -587,9 +587,28 @@
         <section class="day-section" id="day-8">
           <div class="day-header">
             <div class="day-num">D8</div>
-            <div class="day-name">skill explorer · ENSIP draft · review queue</div>
+            <div class="day-name">skill explorer · ENSIP draft · review queue · #10 closed</div>
             <div class="label">2026·05·01 · THU · TODAY</div>
           </div>
+
+          <article class="card entry">
+            <div class="hover-flag">ISSUE #10</div>
+            <div class="entry-time">09:55 · CLOSED</div>
+            <div class="entry-title">All 5 <code>*.skilltest.eth</code> subnames now resolve — atomic ENS resolution complete</div>
+            <ul>
+              <li>Discovered only <code>quote.skilltest.eth</code> had <code>xyz.manifest.skill</code> set; <code>hello</code> / <code>swap</code> / <code>score</code> / <code>weather</code> were registered but text-record empty</li>
+              <li>Wrote <code>scripts/verify-issue-10.cjs</code> to assert text records exist on all 5 names; reads from a public Sepolia RPC, no SDK build needed</li>
+              <li>Re-dispatched <code>pin-and-register</code> for the four missing slugs against <code>main</code>; sequenced through the workflow's concurrency group (<code>cancel-in-progress: false</code> drops older queued runs in favor of the latest)</li>
+              <li>Final state: 5/5 resolve cleanly with <code>0g://0x…</code> URIs and <code>v=1.0.0</code> on every name</li>
+              <li>Confirmed schema validator + <code>@helia/verified-fetch</code> are already wired in <code>packages/sdk/src/index.ts</code> at lines 14, 182, 217–227 — the issue body's "currently commented out" note was stale</li>
+            </ul>
+            <div class="proof-label label">image (proof of work):</div>
+            <div class="proof-grid">
+              <div class="proof">verify-issue-10 output</div>
+              <div class="proof">issue #10 resolution comment</div>
+            </div>
+            <a class="entry-link" href="https://github.com/hien-p/Skillname/issues/10#issuecomment-4357561270" target="_blank">view issue </a>
+          </article>
 
           <article class="card entry">
             <div class="hover-flag">PR #43</div>

--- a/scripts/verify-issue-10.cjs
+++ b/scripts/verify-issue-10.cjs
@@ -1,0 +1,47 @@
+'use strict'
+// Verify issue #10 acceptance criteria are actually satisfied on-chain.
+// Reads xyz.manifest.skill text record on each Sepolia subname and reports.
+
+const { ethers } = require('ethers')
+
+const RPC = process.env.SEPOLIA_RPC_URL || 'https://rpc.sepolia.org'
+const NAMES = [
+  'hello.skilltest.eth',
+  'quote.skilltest.eth',
+  'swap.skilltest.eth',
+  'score.skilltest.eth',
+  'weather.skilltest.eth',
+]
+
+;(async () => {
+  const provider = new ethers.JsonRpcProvider(RPC)
+
+  console.log(`RPC: ${RPC}`)
+  console.log(`Checking xyz.manifest.skill text record on:\n`)
+
+  let pass = 0, fail = 0
+  for (const name of NAMES) {
+    try {
+      const resolver = await provider.getResolver(name)
+      if (!resolver) {
+        console.log(`  ${name.padEnd(28)} ✗  no resolver`)
+        fail++
+        continue
+      }
+      const uri = await resolver.getText('xyz.manifest.skill')
+      const ver = await resolver.getText('xyz.manifest.skill.version')
+      if (uri) {
+        console.log(`  ${name.padEnd(28)} ✓  uri=${uri.slice(0, 36)}…  v=${ver || '—'}`)
+        pass++
+      } else {
+        console.log(`  ${name.padEnd(28)} ✗  text record empty`)
+        fail++
+      }
+    } catch (e) {
+      console.log(`  ${name.padEnd(28)} ✗  ${e.message}`)
+      fail++
+    }
+  }
+  console.log(`\n${pass}/${NAMES.length} resolve cleanly`)
+  process.exit(fail > 0 ? 1 : 0)
+})()


### PR DESCRIPTION
## Summary

Bundles two artifacts from today's #10 closure:

### \`scripts/verify-issue-10.cjs\`

Reads \`xyz.manifest.skill\` + \`xyz.manifest.skill.version\` on the 5 \`*.skilltest.eth\` subnames over a public Sepolia RPC and reports per-name status. Pure CJS, no SDK build needed.

\`\`\`bash
SEPOLIA_RPC_URL=https://1rpc.io/sepolia node scripts/verify-issue-10.cjs
\`\`\`

Used today to confirm 5/5 resolve cleanly after re-dispatching \`pin-and-register\` for the four missing slugs.

### \`apps/web/logs/index.html\` — D8 entry

Cards for issue #10's closure inside the existing D8 section. Calls out the discovery (1/5 set), the concurrency-group quirk that cancelled older queued runs, and that the validator + helia integration were already wired despite the issue body's stale note.

## Verification

\`\`\`
hello.skilltest.eth     ✓  uri=0g://0x80f14113e5134c82607480c621018…  v=1.0.0
quote.skilltest.eth     ✓  uri=0g://0x468278ec733900d0cad615ca759ad…  v=1.0.0
swap.skilltest.eth      ✓  uri=0g://0xcce985f7b4cf5d0ad15ad9ad4a805…  v=1.0.0
score.skilltest.eth     ✓  uri=0g://0xe3f66078c5d69237bd100456ff236…  v=1.0.0
weather.skilltest.eth   ✓  uri=0g://0x4198036e11fdca85ba964ed6bc6e6…  v=1.0.0

5/5 resolve cleanly
\`\`\`

## Related

Closes #1 (original atomic-resolution roadmap item, tracked under issue #10 which was already closed earlier).