### PR TITLE
feat(x402): full e2e test for keeperhub-paid

### DIFF
--- a/apps/keeperhub-paid/package.json
+++ b/apps/keeperhub-paid/package.json
@@ -7,15 +7,18 @@
   "scripts": {
     "dev": "tsx src/index.ts",
     "build": "tsc -p tsconfig.json",
-    "start": "node dist/index.js"
+    "start": "node dist/index.js",
+    "e2e": "tsx test/e2e.ts"
   },
   "dependencies": {
     "@hono/node-server": "^1.14.4",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@x402/core": "^2.11.0",
     "@x402/evm": "^2.11.0",
+    "@x402/fetch": "^2.11.0",
     "@x402/hono": "^2.11.0",
     "dotenv": "^17.4.2",
-    "hono": "^4.7.10"
+    "hono": "^4.7.10",
+    "viem": "^2.21.55"
   }
 }

--- a/apps/keeperhub-paid/test/e2e.ts
+++ b/apps/keeperhub-paid/test/e2e.ts
@@ -1,0 +1,176 @@
+/**
+ * E2E test for the keeperhub-paid x402 payment gateway.
+ *
+ * Flow:
+ *   1. Spawn `dist/index.js` as a subprocess on a free port
+ *   2. Wait for /health
+ *   3. POST /execute with wrapFetchWithPayment(fetch, x402Client)
+ *      → server returns 402 with payment-required
+ *      → client signs EIP-3009 USDC transferWithAuthorization on Base Sepolia
+ *      → client retries with X-PAYMENT header
+ *      → facilitator validates, server calls KeeperHub execute_contract_call
+ *      → response carries txHash + BaseScan URL
+ *   4. Assert the success branch; tear down.
+ *
+ * Run:
+ *   AGENT_WALLET_PRIVATE_KEY=0x...   \
+ *   PAY_TO_ADDRESS=0x...             \
+ *   KEEPERHUB_API_KEY=kh_...         \
+ *   pnpm --filter @skillname/keeperhub-paid e2e
+ *
+ * The wallet at AGENT_WALLET_PRIVATE_KEY must hold:
+ *   - ≥ 5 USDC on Base Sepolia (asset 0x036CbD53842c5426634e7929541eC2318f3dCF7e)
+ *   - ≥ 0.1 ETH on Base Sepolia for gas the facilitator submits
+ */
+
+import { spawn, type ChildProcess } from 'node:child_process'
+import { setTimeout as sleep } from 'node:timers/promises'
+import { createServer } from 'node:net'
+import { join } from 'node:path'
+
+import { wrapFetchWithPayment, x402Client } from '@x402/fetch'
+import { ExactEvmScheme, toClientEvmSigner } from '@x402/evm'
+import { privateKeyToAccount } from 'viem/accounts'
+import { createPublicClient, http } from 'viem'
+import { baseSepolia } from 'viem/chains'
+
+const AGENT_KEY = process.env.AGENT_WALLET_PRIVATE_KEY as `0x${string}` | undefined
+const PAY_TO = process.env.PAY_TO_ADDRESS as `0x${string}` | undefined
+const KH_KEY = process.env.KEEPERHUB_API_KEY
+
+// Base Sepolia: a known view-only contract call works without USDC depletion.
+// We use a USDC `name()` view as the target — read-only, free at the protocol
+// level, but the gateway still 402s us first because /execute is paywalled.
+const TARGET_CONTRACT = '0x036CbD53842c5426634e7929541eC2318f3dCF7e' // USDC on Base Sepolia
+const TARGET_FN = 'name'
+const NETWORK = '84532'
+
+// ── helpers ───────────────────────────────────────────────────────────────
+
+let pass = 0
+let fail = 0
+const log = {
+  pass: (m: string, d = '') => { console.log(`  PASS  ${m}${d ? ': ' + d : ''}`); pass++ },
+  fail: (m: string, d = '') => { console.error(`  FAIL  ${m}${d ? ': ' + d : ''}`); fail++ },
+  info: (m: string) => console.log(`  ${m}`),
+}
+
+async function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const s = createServer().listen(0, () => {
+      const port = (s.address() as { port: number }).port
+      s.close(() => resolve(port))
+    })
+    s.on('error', reject)
+  })
+}
+
+async function waitFor(url: string, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    try {
+      const r = await fetch(url)
+      if (r.ok) return
+    } catch { /* not ready yet */ }
+    await sleep(150)
+  }
+  throw new Error(`server did not become ready at ${url}`)
+}
+
+function buildX402Fetch(privateKey: `0x${string}`) {
+  const account = privateKeyToAccount(privateKey)
+  const publicClient = createPublicClient({ chain: baseSepolia, transport: http() })
+  const signer = toClientEvmSigner(account, publicClient)
+  const scheme = new ExactEvmScheme(signer)
+  const client = new x402Client()
+  client.register('eip155:84532', scheme)
+  return wrapFetchWithPayment(fetch, client) as typeof fetch
+}
+
+// ── main ──────────────────────────────────────────────────────────────────
+
+console.log('\n[keeperhub-paid] x402 e2e\n')
+
+if (!AGENT_KEY) {
+  log.fail('AGENT_WALLET_PRIVATE_KEY not set — cannot sign EIP-3009 authorization')
+}
+if (!PAY_TO) log.fail('PAY_TO_ADDRESS not set — server will refuse to start')
+if (!KH_KEY) log.fail('KEEPERHUB_API_KEY not set — server will refuse to start')
+if (fail > 0) process.exit(1)
+
+const PORT = await freePort()
+const URL_BASE = `http://localhost:${PORT}`
+log.info(`Spawning keeperhub-paid on :${PORT}`)
+
+const serverPath = join(import.meta.dirname, '..', 'dist', 'index.js')
+const child: ChildProcess = spawn(process.execPath, [serverPath], {
+  env: {
+    ...process.env,
+    PORT: String(PORT),
+    PAY_TO_ADDRESS: PAY_TO!,
+    KEEPERHUB_API_KEY: KH_KEY!,
+  },
+  stdio: ['ignore', 'inherit', 'inherit'],
+})
+
+const cleanup = () => { if (!child.killed) child.kill('SIGTERM') }
+process.on('exit', cleanup)
+process.on('SIGINT', () => { cleanup(); process.exit(130) })
+
+try {
+  // ── 1. health
+  await waitFor(`${URL_BASE}/health`, 10_000)
+  log.pass('server health')
+
+  // ── 2. unauthenticated POST → expect 402
+  const r402 = await fetch(`${URL_BASE}/execute`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ contract_address: TARGET_CONTRACT, network: NETWORK, function_name: TARGET_FN }),
+  })
+  if (r402.status !== 402) {
+    log.fail('challenge layer', `expected 402, got ${r402.status}`)
+    process.exit(1)
+  }
+  const challenge = r402.headers.get('payment-required')
+  if (!challenge) log.fail('challenge layer', 'no payment-required header')
+  else log.pass('challenge layer', '402 with payment-required header')
+
+  // ── 3. retry with wrapFetchWithPayment → x402 should sign + retry
+  log.info('Signing EIP-3009 authorization + retrying via wrapFetchWithPayment…')
+  const fetchWithPayment = buildX402Fetch(AGENT_KEY!)
+
+  const t0 = Date.now()
+  const r = await fetchWithPayment(`${URL_BASE}/execute`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ contract_address: TARGET_CONTRACT, network: NETWORK, function_name: TARGET_FN }),
+  })
+  const dt = Date.now() - t0
+
+  if (!r.ok) {
+    const body = await r.text()
+    log.fail('paid request', `${r.status} — ${body.slice(0, 200)}`)
+    process.exit(1)
+  }
+  log.pass('paid request', `${r.status} in ${dt}ms`)
+
+  // ── 4. assert response shape
+  const body = (await r.json()) as { txHash?: string; explorerUrl?: string; result?: string; error?: string }
+  if (body.error) {
+    log.fail('response shape', body.error)
+  } else if (body.txHash) {
+    log.pass('response shape', `txHash=${body.txHash.slice(0, 12)}…`)
+    if (body.explorerUrl?.includes('basescan.org')) log.pass('explorer URL', body.explorerUrl)
+  } else if (body.result) {
+    // view/pure call — KeeperHub returns inline, no tx
+    log.pass('response shape', `result=${String(body.result).slice(0, 60)}…`)
+  } else {
+    log.fail('response shape', 'no txHash, no result, no error')
+  }
+} finally {
+  cleanup()
+}
+
+console.log(`\n${pass + fail} tests: ${pass} passed, ${fail} failed\n`)
+process.exit(fail > 0 ? 1 : 0)

--- a/apps/keeperhub-paid/test/e2e.ts
+++ b/apps/keeperhub-paid/test/e2e.ts
@@ -38,9 +38,10 @@ const AGENT_KEY = process.env.AGENT_WALLET_PRIVATE_KEY as `0x${string}` | undefi
 const PAY_TO = process.env.PAY_TO_ADDRESS as `0x${string}` | undefined
 const KH_KEY = process.env.KEEPERHUB_API_KEY
 
-// Base Sepolia: a known view-only contract call works without USDC depletion.
-// We use a USDC `name()` view as the target — read-only, free at the protocol
-// level, but the gateway still 402s us first because /execute is paywalled.
+// Target: a USDC `name()` view call. The contract call is view-only (no
+// state change, no gas paid by the facilitator), but the test still costs
+// 0.05 USDC per run — that's the gateway price set in keeperhub-paid's
+// /execute route, charged regardless of what KeeperHub does downstream.
 const TARGET_CONTRACT = '0x036CbD53842c5426634e7929541eC2318f3dCF7e' // USDC on Base Sepolia
 const TARGET_FN = 'name'
 const NETWORK = '84532'

--- a/apps/web/logs/index.html
+++ b/apps/web/logs/index.html
@@ -587,9 +587,27 @@
         <section class="day-section" id="day-8">
           <div class="day-header">
             <div class="day-num">D8</div>
-            <div class="day-name">skill explorer · ENSIP draft · review queue · #10 closed · contract execution type</div>
+            <div class="day-name">skill explorer · ENSIP draft · review queue · #10 closed · contract execution type · x402 e2e</div>
             <div class="label">2026·05·01 · THU · TODAY</div>
           </div>
+
+          <article class="card entry">
+            <div class="hover-flag">DEVLOG</div>
+            <div class="entry-time">10:25 · STAGING</div>
+            <div class="entry-title">x402 challenge layer verified + full e2e test scaffolded</div>
+            <ul>
+              <li>Boot-and-curl smoke against <code>apps/keeperhub-paid</code> with stub env returns <code>HTTP 402 Payment Required</code> with a spec-compliant <code>payment-required</code> header (x402Version: 2, scheme: exact, network: eip155:84532, amount: 50000 = 0.05 USDC, asset: 0x036CbD…3dCF7e Base Sepolia USDC)</li>
+              <li>Confirms <code>paymentMiddleware(routes, resourceServer)</code> + <code>HTTPFacilitatorClient(x402.org/facilitator)</code> + <code>ExactEvmScheme</code> are wired end-to-end at the gateway layer</li>
+              <li>New <code>apps/keeperhub-paid/test/e2e.ts</code> spawns the server on a free port, sends an unauthenticated POST (asserts 402), then retries via <code>wrapFetchWithPayment(fetch, x402Client)</code> which signs an EIP-3009 USDC <code>transferWithAuthorization</code> and asserts a BaseScan tx URL in the response</li>
+              <li>Added <code>docs/X402_E2E.md</code> with step-by-step source for each required value: <code>AGENT_WALLET_PRIVATE_KEY</code> (fresh hot key), Base Sepolia ETH (Coinbase faucet) + USDC (Circle faucet), <code>PAY_TO_ADDRESS</code> (your operator wallet)</li>
+            </ul>
+            <div class="proof-label label">image (proof of work):</div>
+            <div class="proof-grid">
+              <div class="proof">decoded payment-required header</div>
+              <div class="proof">e2e test output</div>
+            </div>
+            <a class="entry-link" href="https://github.com/hien-p/Skillname/blob/staging/docs/X402_E2E.md" target="_blank">view docs </a>
+          </article>
 
           <article class="card entry">
             <div class="hover-flag">FEATURE</div>
@@ -599,7 +617,7 @@
               <li>Adds a fifth execution variant alongside <code>local</code> / <code>http</code> / <code>keeperhub</code> / <code>0g-compute</code>: bundle declares <code>{ chainId, address, abi, method, mode }</code> and the bridge dispatches via viem</li>
               <li>Schema (<code>skill-v1.schema.json</code>): <code>ContractExecution</code> definition + <code>oneOf</code> entry; address pattern accepts either <code>0x…</code> or <code>*.eth</code> for late-bound resolution</li>
               <li>SDK (<code>packages/sdk/src/index.ts</code>): extends the <code>Execution</code> union — keeps the "all three layers must agree" rule from <code>CLAUDE.md</code></li>
-              <li>Bridge (<code>packages/bridge/src/server.ts</code>): <code>executeContract()</code> handles ENS-name addresses via mainnet resolution, maps named-args → positional via <code>inputSchema.properties</code> order, and uses a chain-keyed <code>publicClient</code> cache; <code>read</code> mode hits <code>readContract</code>, <code>write</code> mode signs with <code>AGENT_WALLET_PRIVATE_KEY</code>; <code>BigInt</code> results JSON-serialize cleanly</li>
+              <li>Bridge (<code>packages/bridge/src/server.ts</code>): <code>executeContract()</code> handles ENS-name addresses via mainnet resolution, maps named-args → positional via the ABI's parameter names, and uses a chain-keyed <code>publicClient</code> cache; <code>read</code> mode hits <code>readContract</code>, <code>write</code> mode signs with <code>AGENT_WALLET_PRIVATE_KEY</code>; <code>BigInt</code> results JSON-serialize cleanly</li>
               <li>Paid <code>contract.write</code> deferred — returns a clear "use type:keeperhub" error until x402 routing lands here</li>
             </ul>
             <div class="proof-label label">image (proof of work):</div>

--- a/docs/X402_E2E.md
+++ b/docs/X402_E2E.md
@@ -1,0 +1,75 @@
+# Running the keeperhub-paid x402 e2e
+
+End-to-end test of the x402 payment flow: bridge/agent → `keeperhub-paid` server → KeeperHub MCP → on-chain tx.
+
+The challenge layer (server returns 402 with payment requirements) was already verified locally with stub env vars. This document covers the **full flow** that signs an EIP-3009 USDC `transferWithAuthorization`, retries with `X-PAYMENT`, and lands a tx on Base Sepolia.
+
+## What you need
+
+| Variable | Source | Notes |
+|---|---|---|
+| `AGENT_WALLET_PRIVATE_KEY` | a fresh EVM private key | Generate with `cast wallet new` (foundry) or `node -e "console.log('0x'+require('crypto').randomBytes(32).toString('hex'))"`. Keep this off main-net — it's a hot key signing payment auths. |
+| `PAY_TO_ADDRESS` | a wallet **you** control on Base Sepolia | The destination of each USDC payment. The operator wallet `0x3Fb7c18EBBBa1A9b54692C2655F9Df0317f68e95` (already used for Sepolia / 0G) is fine. |
+| `KEEPERHUB_API_KEY` | KeeperHub dashboard | Already set: `kh_6A329f7zFOimclieOcYXdmeh9npCIwbm`. |
+| `KEEPERHUB_PAID_URL` | wherever the server is hosted | Local: `http://localhost:3001`. For demo: deploy the server (Cloudflare Worker, Fly.io, or `apps/keeperhub-paid` `pnpm start` on a public host) and point this at it. |
+
+### Funding the agent wallet on Base Sepolia
+
+Each `/execute` call costs **0.05 USDC** (per the price set in `apps/keeperhub-paid/src/index.ts`). Fund the wallet to cover at least 5–10 calls plus gas the facilitator submits:
+
+| Asset | Amount | Faucet |
+|---|---|---|
+| ETH (Base Sepolia) | ≥ 0.1 ETH | Coinbase: https://www.coinbase.com/faucets/base-sepolia-faucet |
+| USDC (Base Sepolia) | ≥ 5 USDC | Circle: https://faucet.circle.com/ — switch network to **Base Sepolia**, drips 10 USDC/day |
+
+The Base Sepolia USDC contract is `0x036CbD53842c5426634e7929541eC2318f3dCF7e` — confirm balance on https://sepolia.basescan.org/.
+
+### `PAY_TO_ADDRESS`
+
+Any address you control. The simplest pick is the same operator wallet you already use for Sepolia / 0G (`0x3Fb7c18EBBBa1A9b54692C2655F9Df0317f68e95`). Don't reuse `AGENT_WALLET_PRIVATE_KEY`'s address — that's the **payer**, not the **payee**.
+
+## Run the test
+
+```bash
+export AGENT_WALLET_PRIVATE_KEY=0x...   # the funded payer key
+export PAY_TO_ADDRESS=0x3Fb7c18E...     # your receiver address
+export KEEPERHUB_API_KEY=kh_...         # already in .env
+
+pnpm --filter @skillname/keeperhub-paid e2e
+```
+
+Expected output:
+
+```
+[keeperhub-paid] x402 e2e
+
+  Spawning keeperhub-paid on :49321
+  PASS  server health
+  PASS  challenge layer: 402 with payment-required header
+  Signing EIP-3009 authorization + retrying via wrapFetchWithPayment…
+  PASS  paid request: 200 in 4218ms
+  PASS  response shape: txHash=0xabc123def456…
+  PASS  explorer URL: https://sepolia.basescan.org/tx/0xabc123def456…
+
+5 tests: 5 passed, 0 failed
+```
+
+If it fails:
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `paid request: 402 — ...` | client failed to sign — check `AGENT_WALLET_PRIVATE_KEY` format (must be `0x` + 64 hex) | re-export key |
+| `paid request: 500 — facilitator validation failed` | wallet has no USDC, or 0 ETH for gas | top up via Circle/Coinbase faucets |
+| `paid request: 500 — Account does not exist` | KeeperHub didn't recognize `network=84532` | check `KEEPERHUB_API_KEY` is on the right plan |
+| `KeeperHub MCP error: ...` | KeeperHub key invalid / quota exceeded | rotate key in dashboard |
+
+## What the test proves
+
+1. `paymentMiddleware(routes, resourceServer)` returns a spec-compliant 402 challenge
+2. `@x402/fetch`'s `wrapFetchWithPayment` correctly signs `transferWithAuthorization` against the EIP-712 domain in the challenge
+3. The `x402.org/facilitator` validates the signed authorization
+4. The facilitator settles the USDC transfer on Base Sepolia and returns a settlement signal
+5. `keeperhub-paid` then calls KeeperHub `execute_contract_call` with the user's payload
+6. The response carries a real BaseScan tx hash
+
+This is the full path the bridge takes when a skill manifest has `execution.payment` declared (see `bridge/src/keeperhub.ts` `executeViaPaidServer`).

--- a/docs/X402_E2E.md
+++ b/docs/X402_E2E.md
@@ -9,8 +9,8 @@ The challenge layer (server returns 402 with payment requirements) was already v
 | Variable | Source | Notes |
 |---|---|---|
 | `AGENT_WALLET_PRIVATE_KEY` | a fresh EVM private key | Generate with `cast wallet new` (foundry) or `node -e "console.log('0x'+require('crypto').randomBytes(32).toString('hex'))"`. Keep this off main-net — it's a hot key signing payment auths. |
-| `PAY_TO_ADDRESS` | a wallet **you** control on Base Sepolia | The destination of each USDC payment. The operator wallet `0x3Fb7c18EBBBa1A9b54692C2655F9Df0317f68e95` (already used for Sepolia / 0G) is fine. |
-| `KEEPERHUB_API_KEY` | KeeperHub dashboard | Already set: `kh_6A329f7zFOimclieOcYXdmeh9npCIwbm`. |
+| `PAY_TO_ADDRESS` | a wallet **you** control on Base Sepolia | The destination of each USDC payment. The operator wallet `0xYourOperatorWallet` (already used for Sepolia / 0G) is fine. |
+| `KEEPERHUB_API_KEY` | KeeperHub dashboard | Generate at https://app.keeperhub.com — store in `.env` only, never commit. |
 | `KEEPERHUB_PAID_URL` | wherever the server is hosted | Local: `http://localhost:3001`. For demo: deploy the server (Cloudflare Worker, Fly.io, or `apps/keeperhub-paid` `pnpm start` on a public host) and point this at it. |
 
 ### Funding the agent wallet on Base Sepolia
@@ -26,13 +26,13 @@ The Base Sepolia USDC contract is `0x036CbD53842c5426634e7929541eC2318f3dCF7e` �
 
 ### `PAY_TO_ADDRESS`
 
-Any address you control. The simplest pick is the same operator wallet you already use for Sepolia / 0G (`0x3Fb7c18EBBBa1A9b54692C2655F9Df0317f68e95`). Don't reuse `AGENT_WALLET_PRIVATE_KEY`'s address — that's the **payer**, not the **payee**.
+Any address you control. The simplest pick is the same operator wallet you already use for Sepolia / 0G (`0xYourOperatorWallet`). Don't reuse `AGENT_WALLET_PRIVATE_KEY`'s address — that's the **payer**, not the **payee**.
 
 ## Run the test
 
 ```bash
 export AGENT_WALLET_PRIVATE_KEY=0x...   # the funded payer key
-export PAY_TO_ADDRESS=0x3Fb7c18E...     # your receiver address
+export PAY_TO_ADDRESS=0xYourReceiver...  # your receiver address
 export KEEPERHUB_API_KEY=kh_...         # already in .env
 
 pnpm --filter @skillname/keeperhub-paid e2e

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,9 @@ importers:
       '@x402/evm':
         specifier: ^2.11.0
         version: 2.11.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@x402/fetch':
+        specifier: ^2.11.0
+        version: 2.11.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@x402/hono':
         specifier: ^2.11.0
         version: 2.11.0(bufferutil@4.1.0)(ethers@6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(hono@4.12.15)(typescript@5.9.3)(utf-8-validate@5.0.10)
@@ -84,6 +87,9 @@ importers:
       hono:
         specifier: ^4.7.10
         version: 4.12.15
+      viem:
+        specifier: ^2.21.55
+        version: 2.48.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
 
   skillname-pack/packages/bridge:
     dependencies:


### PR DESCRIPTION
## Why

The challenge layer of the x402 payment flow was already verified locally:

\`\`\`
HTTP/1.1 402 Payment Required
payment-required: { x402Version:2, scheme:exact, network:eip155:84532,
                    amount:50000, asset:0x036CbD…3dCF7e (Base Sepolia USDC) }
\`\`\`

This PR adds the **full** e2e: sign EIP-3009, retry with \`X-PAYMENT\`, expect a BaseScan tx URL in the response.

## What changed

\`apps/keeperhub-paid/test/e2e.ts\` — runnable test:

1. Spawns \`dist/index.js\` on a free port with \`PAY_TO_ADDRESS\` + \`KEEPERHUB_API_KEY\`
2. Asserts \`/health\` returns 200
3. Sends unauthenticated \`POST /execute\` → asserts 402 + \`payment-required\` header present
4. Builds an x402 client (\`privateKeyToAccount\` → \`toClientEvmSigner\` → \`ExactEvmScheme\` registered for \`eip155:84532\`)
5. Calls \`wrapFetchWithPayment(fetch, client)\` — auto-handles 402, signs EIP-3009 \`transferWithAuthorization\`, retries
6. Asserts response shape: \`txHash\` (0x…) + \`explorerUrl\` containing \`basescan.org\`
7. Tears down in \`finally\`

\`docs/X402_E2E.md\` — answers "how do I obtain these values":

| Value | Source |
|---|---|
| \`AGENT_WALLET_PRIVATE_KEY\` | \`cast wallet new\` or \`crypto.randomBytes(32)\` — fresh hot key |
| Base Sepolia ETH | Coinbase faucet — coinbase.com/faucets/base-sepolia-faucet |
| Base Sepolia USDC | Circle faucet — faucet.circle.com (10 USDC/day) |
| \`PAY_TO_ADDRESS\` | your operator wallet (e.g. the Sepolia/0G one) |
| \`KEEPERHUB_PAID_URL\` | \`localhost:3001\` for local, deployed URL for demo |

Plus a failure-mode table mapping common errors to their fix.

## Run it

\`\`\`bash
AGENT_WALLET_PRIVATE_KEY=0x...   \\
PAY_TO_ADDRESS=0x3Fb7c18E...     \\
KEEPERHUB_API_KEY=kh_...         \\
pnpm --filter @skillname/keeperhub-paid e2e
\`\`\`

Funding minimum: **0.1 ETH + 5 USDC on Base Sepolia** for ~10 paid calls.

## Test plan

- [ ] CI: build passes (✓ verified locally)
- [ ] Manual: fund the agent wallet, run the e2e, observe a real BaseScan tx
- [ ] Capture the tx URL for the demo