### PR TITLE
feat(#3): dependency graph walker + bridge integration

### DIFF
--- a/skillname-pack/examples/score-gitcoin/manifest.json
+++ b/skillname-pack/examples/score-gitcoin/manifest.json
@@ -32,12 +32,15 @@
         "properties": {
           "address": { "type": "string" },
           "score": { "type": "string" },
-          "status": { "type": "string", "enum": ["DONE", "PROCESSING", "ERROR"] }
+          "status": {
+            "type": "string",
+            "enum": ["DONE", "PROCESSING", "ERROR"]
+          }
         }
       },
       "execution": {
         "type": "http",
-        "endpoint": "https://api.passport.xyz/v2/stamps/{scorerId}/score/{address}",
+        "endpoint": "https://api.passport.xyz/v2/stamps/335/score",
         "method": "GET"
       }
     }

--- a/skillname-pack/packages/bridge/src/server.ts
+++ b/skillname-pack/packages/bridge/src/server.ts
@@ -177,6 +177,9 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
         });
       }
 
+      // Notify client that tool list has changed so it re-fetches tools/list
+      await server.sendToolListChanged();
+
       const rootResult = root.result;
       const verified = rootResult.ensip25?.bound ? "✓ verified" : "unverified";
       const depCount = flat.length - 1;

--- a/skillname-pack/packages/bridge/src/server.ts
+++ b/skillname-pack/packages/bridge/src/server.ts
@@ -22,25 +22,30 @@
  *   → Claude can immediately call it
  */
 
-import { Server } from '@modelcontextprotocol/sdk/server/index.js'
-import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
   type Tool as MCPTool,
-} from '@modelcontextprotocol/sdk/types.js'
-import 'dotenv/config'
-import { resolveSkill, type ResolveResult, type Tool } from '@skillname/sdk'
-import { executeVia0GCompute, listProviders } from './0gcompute.js'
-import { executeViaKeeperHub } from './keeperhub.js'
+} from "@modelcontextprotocol/sdk/types.js";
+import "dotenv/config";
+import {
+  resolveSkill,
+  walkImports,
+  type ResolveResult,
+  type Tool,
+} from "@skillname/sdk";
+import { executeVia0GCompute, listProviders } from "./0gcompute.js";
+import { executeViaKeeperHub } from "./keeperhub.js";
 
 // -------------------------------------------------------------------------
 // KeeperHub / x402 config — picked up at startup (Issue #13)
 // -------------------------------------------------------------------------
 
-const KEEPERHUB_API_KEY = process.env.KEEPERHUB_API_KEY ?? ''
-const AGENT_WALLET_PRIVATE_KEY = process.env.AGENT_WALLET_PRIVATE_KEY ?? ''
-const PAY_TO_ADDRESS = process.env.PAY_TO_ADDRESS ?? ''
+const KEEPERHUB_API_KEY = process.env.KEEPERHUB_API_KEY ?? "";
+const AGENT_WALLET_PRIVATE_KEY = process.env.AGENT_WALLET_PRIVATE_KEY ?? "";
+const PAY_TO_ADDRESS = process.env.PAY_TO_ADDRESS ?? "";
 
 // -------------------------------------------------------------------------
 // Structured stderr logging.
@@ -49,221 +54,297 @@ const PAY_TO_ADDRESS = process.env.PAY_TO_ADDRESS ?? ''
 // -------------------------------------------------------------------------
 
 const log = {
-  in:   (msg: string) => process.stderr.write(`→ ${msg}\n`),
-  out:  (msg: string) => process.stderr.write(`← ${msg}\n`),
-  ok:   (msg: string) => process.stderr.write(`✓ ${msg}\n`),
-  err:  (msg: string) => process.stderr.write(`✗ ${msg}\n`),
+  in: (msg: string) => process.stderr.write(`→ ${msg}\n`),
+  out: (msg: string) => process.stderr.write(`← ${msg}\n`),
+  ok: (msg: string) => process.stderr.write(`✓ ${msg}\n`),
+  err: (msg: string) => process.stderr.write(`✗ ${msg}\n`),
   info: (msg: string) => process.stderr.write(`· ${msg}\n`),
-}
+};
 
 // -------------------------------------------------------------------------
 // State
 // -------------------------------------------------------------------------
 
 interface ImportedSkill {
-  ensName: string
-  result: ResolveResult
-  importedAt: number
+  ensName: string;
+  result: ResolveResult;
+  importedAt: number;
 }
 
-const imported: Map<string, ImportedSkill> = new Map()
+const imported: Map<string, ImportedSkill> = new Map();
 
-const CACHE_TTL_MS = 5 * 60 * 1000 // 5 min
+const CACHE_TTL_MS = 5 * 60 * 1000; // 5 min
 
 // -------------------------------------------------------------------------
 // MCP server
 // -------------------------------------------------------------------------
 
 const server = new Server(
-  { name: 'skillname', version: '0.0.1' },
-  { capabilities: { tools: {} } }
-)
+  { name: "skillname", version: "0.0.1" },
+  { capabilities: { tools: {} } },
+);
 
 // Built-in: skill_import — replaces the old manifest_load
 const SKILL_IMPORT_TOOL: MCPTool = {
-  name: 'skill_import',
+  name: "skill_import",
   description:
     'Import a skill by ENS name. Resolves the name via ENS text records, fetches the bundle from IPFS, and registers its function(s) as MCP tools. Use this whenever the user mentions an ENS name like "import quote.uniswap.eth", "use swap.uniswap.eth", or "load skills from foo.eth".',
   inputSchema: {
-    type: 'object',
+    type: "object",
     properties: {
       ensName: {
-        type: 'string',
-        description: 'ENS name to import, e.g. "quote.uniswap.eth" or "score.gitcoin.eth"',
+        type: "string",
+        description:
+          'ENS name to import, e.g. "quote.uniswap.eth" or "score.gitcoin.eth"',
       },
       chain: {
-        type: 'string',
-        enum: ['mainnet', 'sepolia'],
-        default: 'sepolia',
-        description: 'Chain to resolve ENS on (default: sepolia for hackathon)',
+        type: "string",
+        enum: ["mainnet", "sepolia"],
+        default: "sepolia",
+        description: "Chain to resolve ENS on (default: sepolia for hackathon)",
       },
     },
-    required: ['ensName'],
+    required: ["ensName"],
   },
-}
+};
 
 const SKILL_LIST_TOOL: MCPTool = {
-  name: 'skill_list_imported',
+  name: "skill_list_imported",
   description:
-    'List every skill currently imported and the function(s) it registered. Useful for confirming what is available before calling a tool.',
-  inputSchema: { type: 'object', properties: {} },
-}
+    "List every skill currently imported and the function(s) it registered. Useful for confirming what is available before calling a tool.",
+  inputSchema: { type: "object", properties: {} },
+};
 
 const ZG_LIST_PROVIDERS_TOOL: MCPTool = {
-  name: 'zg_list_providers',
+  name: "zg_list_providers",
   description:
-    'List available AI inference providers on 0G Compute Network. Returns provider addresses, models (e.g. qwen3.6-plus, GLM-5-FP8), and endpoints. Use to discover providers before importing a 0g-compute skill.',
-  inputSchema: { type: 'object', properties: {} },
-}
+    "List available AI inference providers on 0G Compute Network. Returns provider addresses, models (e.g. qwen3.6-plus, GLM-5-FP8), and endpoints. Use to discover providers before importing a 0g-compute skill.",
+  inputSchema: { type: "object", properties: {} },
+};
 
 // -------------------------------------------------------------------------
 // Tool listing — built-ins + dynamically imported skills
 // -------------------------------------------------------------------------
 
 server.setRequestHandler(ListToolsRequestSchema, async () => {
-  const dynamicTools: MCPTool[] = []
+  const dynamicTools: MCPTool[] = [];
 
   for (const [, s] of imported) {
     for (const t of s.result.bundle.tools) {
       dynamicTools.push({
         name: `${s.result.bundle.name}__${t.name}`,
         description: `[${s.ensName}] ${t.description}`,
-        inputSchema: t.inputSchema as MCPTool['inputSchema'],
-      })
+        inputSchema: t.inputSchema as MCPTool["inputSchema"],
+      });
     }
   }
 
   return {
-    tools: [SKILL_IMPORT_TOOL, SKILL_LIST_TOOL, ZG_LIST_PROVIDERS_TOOL, ...dynamicTools],
-  }
-})
+    tools: [
+      SKILL_IMPORT_TOOL,
+      SKILL_LIST_TOOL,
+      ZG_LIST_PROVIDERS_TOOL,
+      ...dynamicTools,
+    ],
+  };
+});
 
 // -------------------------------------------------------------------------
 // Tool dispatch
 // -------------------------------------------------------------------------
 
 server.setRequestHandler(CallToolRequestSchema, async (req) => {
-  const name = req.params.name
-  const args = req.params.arguments ?? {}
+  const name = req.params.name;
+  const args = req.params.arguments ?? {};
 
   // -- Built-in: import a skill --
-  if (name === 'skill_import') {
-    const ensName = args.ensName as string
-    const chain = (args.chain as 'mainnet' | 'sepolia') ?? 'sepolia'
-    const t0 = Date.now()
-    log.in(`skill_import ${ensName} (${chain})`)
+  if (name === "skill_import") {
+    const ensName = args.ensName as string;
+    const chain = (args.chain as "mainnet" | "sepolia") ?? "sepolia";
+    const t0 = Date.now();
+    log.in(`skill_import ${ensName} (${chain})`);
 
     try {
-      const result = await resolveSkill(ensName, { chain })
-      imported.set(ensName, { ensName, result, importedAt: Date.now() })
+      // Walk the full dependency graph (breadth-first, max depth 5)
+      const { root, flat } = await walkImports(ensName, { chain });
 
-      const verified = result.ensip25?.bound ? '✓ verified' : 'unverified'
-      const toolsList = result.bundle.tools
-        .map((t) => `  · ${result.bundle.name}__${t.name}: ${t.description}`)
-        .join('\n')
+      // Register all resolved skills (root + transitive deps)
+      for (const result of flat) {
+        imported.set(result.ensName, {
+          ensName: result.ensName,
+          result,
+          importedAt: Date.now(),
+        });
+      }
 
-      const dt = Date.now() - t0
-      log.ok(`imported ${ensName} (${verified}) in ${dt}ms`)
-      log.info(`registered ${result.bundle.tools.length} tool(s) from ${result.cid.slice(0, 16)}…`)
+      const rootResult = root.result;
+      const verified = rootResult.ensip25?.bound ? "✓ verified" : "unverified";
+      const depCount = flat.length - 1;
+
+      // Build tools list across all resolved skills
+      const toolLines: string[] = [];
+      for (const result of flat) {
+        for (const t of result.bundle.tools) {
+          toolLines.push(
+            `  · ${result.bundle.name}__${t.name}: ${t.description}`,
+          );
+        }
+      }
+
+      const dt = Date.now() - t0;
+      const totalTools = flat.reduce(
+        (sum, r) => sum + r.bundle.tools.length,
+        0,
+      );
+      log.ok(`imported ${ensName} (${verified}) in ${dt}ms`);
+      log.info(`registered ${totalTools} tool(s) from ${flat.length} skill(s)`);
+      if (depCount > 0) {
+        log.info(
+          `dependencies: ${flat
+            .slice(1)
+            .map((r) => r.ensName)
+            .join(", ")}`,
+        );
+      }
+
+      const depLine =
+        depCount > 0
+          ? `\nDependencies (${depCount}): ${flat
+              .slice(1)
+              .map((r) => r.ensName)
+              .join(", ")}\n`
+          : "";
 
       return {
         content: [
           {
-            type: 'text',
+            type: "text",
             text:
-              `Imported ${result.bundle.tools.length} tool(s) from ${ensName} (${verified})\n` +
-              `Version: ${result.version ?? 'unspecified'}\n` +
-              `CID: ${result.cid}\n\n` +
-              `Tools:\n${toolsList}`,
+              `Imported ${totalTools} tool(s) from ${ensName} (${verified})\n` +
+              `Version: ${rootResult.version ?? "unspecified"}\n` +
+              `CID: ${rootResult.cid}\n` +
+              depLine +
+              `\nTools:\n${toolLines.join("\n")}`,
           },
         ],
-      }
+      };
     } catch (e: any) {
-      log.err(`import ${ensName} failed: ${e.message}`)
+      log.err(`import ${ensName} failed: ${e.message}`);
       return {
-        content: [{ type: 'text', text: `Failed to import ${ensName}: ${e.message}` }],
+        content: [
+          { type: "text", text: `Failed to import ${ensName}: ${e.message}` },
+        ],
         isError: true,
-      }
+      };
     }
   }
 
   // -- Built-in: list imported --
-  if (name === 'skill_list_imported') {
-    log.in('skill_list_imported')
-    const lines: string[] = []
+  if (name === "skill_list_imported") {
+    log.in("skill_list_imported");
+    const lines: string[] = [];
     for (const [ens, s] of imported) {
-      const age = Math.floor((Date.now() - s.importedAt) / 1000)
-      lines.push(`${ens} (v${s.result.version ?? '?'}, ${age}s ago):`)
+      const age = Math.floor((Date.now() - s.importedAt) / 1000);
+      lines.push(`${ens} (v${s.result.version ?? "?"}, ${age}s ago):`);
       for (const t of s.result.bundle.tools) {
-        lines.push(`  · ${s.result.bundle.name}__${t.name}`)
+        lines.push(`  · ${s.result.bundle.name}__${t.name}`);
       }
     }
     return {
       content: [
-        { type: 'text', text: lines.length ? lines.join('\n') : 'No skills imported yet. Use skill_import to bring one in.' },
+        {
+          type: "text",
+          text: lines.length
+            ? lines.join("\n")
+            : "No skills imported yet. Use skill_import to bring one in.",
+        },
       ],
-    }
+    };
   }
 
   // -- Built-in: list 0G Compute providers --
-  if (name === 'zg_list_providers') {
-    log.in('zg_list_providers')
+  if (name === "zg_list_providers") {
+    log.in("zg_list_providers");
     try {
-      const providers = await listProviders()
+      const providers = await listProviders();
       if (providers.length === 0) {
-        return { content: [{ type: 'text', text: 'No 0G Compute providers found on testnet.' }] }
+        return {
+          content: [
+            { type: "text", text: "No 0G Compute providers found on testnet." },
+          ],
+        };
       }
-      const lines = providers.map((p) => `${p.address}  model: ${p.model || '(unknown)'}  url: ${p.url || '(unknown)'}`)
-      log.ok(`found ${providers.length} 0G Compute provider(s)`)
-      return { content: [{ type: 'text', text: `0G Compute providers (${providers.length}):\n${lines.join('\n')}` }] }
+      const lines = providers.map(
+        (p) =>
+          `${p.address}  model: ${p.model || "(unknown)"}  url: ${p.url || "(unknown)"}`,
+      );
+      log.ok(`found ${providers.length} 0G Compute provider(s)`);
+      return {
+        content: [
+          {
+            type: "text",
+            text: `0G Compute providers (${providers.length}):\n${lines.join("\n")}`,
+          },
+        ],
+      };
     } catch (e: any) {
-      log.err(`zg_list_providers failed: ${e.message}`)
-      return { content: [{ type: 'text', text: `Failed to list providers: ${e.message}` }], isError: true }
+      log.err(`zg_list_providers failed: ${e.message}`);
+      return {
+        content: [
+          { type: "text", text: `Failed to list providers: ${e.message}` },
+        ],
+        isError: true,
+      };
     }
   }
 
   // -- Dynamic: dispatch by namespace --
-  const sep = name.indexOf('__')
+  const sep = name.indexOf("__");
   if (sep === -1) {
-    log.err(`unknown tool: ${name}`)
+    log.err(`unknown tool: ${name}`);
     return {
-      content: [{ type: 'text', text: `Unknown tool: ${name}` }],
+      content: [{ type: "text", text: `Unknown tool: ${name}` }],
       isError: true,
-    }
+    };
   }
 
-  const bundleName = name.slice(0, sep)
-  const toolName = name.slice(sep + 2)
-  log.in(`${name} (looking up ${bundleName}/${toolName})`)
+  const bundleName = name.slice(0, sep);
+  const toolName = name.slice(sep + 2);
+  log.in(`${name} (looking up ${bundleName}/${toolName})`);
 
-  let skill: ImportedSkill | undefined
+  let skill: ImportedSkill | undefined;
   for (const s of imported.values()) {
     if (s.result.bundle.name === bundleName) {
-      skill = s
-      break
+      skill = s;
+      break;
     }
   }
   if (!skill) {
-    log.err(`bundle "${bundleName}" not imported`)
+    log.err(`bundle "${bundleName}" not imported`);
     return {
       content: [
-        { type: 'text', text: `Skill "${bundleName}" not imported. Use skill_import first.` },
+        {
+          type: "text",
+          text: `Skill "${bundleName}" not imported. Use skill_import first.`,
+        },
       ],
       isError: true,
-    }
+    };
   }
 
-  const tool = skill.result.bundle.tools.find((t) => t.name === toolName)
+  const tool = skill.result.bundle.tools.find((t) => t.name === toolName);
   if (!tool) {
-    log.err(`tool ${toolName} not in ${bundleName}`)
+    log.err(`tool ${toolName} not in ${bundleName}`);
     return {
-      content: [{ type: 'text', text: `Tool ${toolName} not in skill ${bundleName}` }],
+      content: [
+        { type: "text", text: `Tool ${toolName} not in skill ${bundleName}` },
+      ],
       isError: true,
-    }
+    };
   }
 
-  return await executeRouted(tool, args, skill)
-})
+  return await executeRouted(tool, args, skill);
+});
 
 // -------------------------------------------------------------------------
 // Execution router
@@ -272,104 +353,131 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
 async function executeRouted(
   tool: Tool,
   args: Record<string, unknown>,
-  skill: ImportedSkill
+  skill: ImportedSkill,
 ) {
-  log.info(`exec.type = ${tool.execution.type}`)
+  log.info(`exec.type = ${tool.execution.type}`);
   switch (tool.execution.type) {
-    case 'local':
-      return executeLocal(tool, args, skill)
-    case 'keeperhub':
-      return executeKeeperHub(tool, args, skill)
-    case 'http':
-      return executeHttp(tool, args, skill)
-    case '0g-compute':
-      return execute0GCompute(tool, args)
+    case "local":
+      return executeLocal(tool, args, skill);
+    case "keeperhub":
+      return executeKeeperHub(tool, args, skill);
+    case "http":
+      return executeHttp(tool, args, skill);
+    case "0g-compute":
+      return execute0GCompute(tool, args);
     default:
-      log.err(`unsupported execution: ${(tool.execution as any).type}`)
+      log.err(`unsupported execution: ${(tool.execution as any).type}`);
       return {
         content: [
-          { type: 'text', text: `Unsupported execution type: ${(tool.execution as any).type}` },
+          {
+            type: "text",
+            text: `Unsupported execution type: ${(tool.execution as any).type}`,
+          },
         ],
         isError: true,
-      }
+      };
   }
 }
 
-async function executeLocal(tool: Tool, args: Record<string, unknown>, _skill: ImportedSkill) {
+async function executeLocal(
+  tool: Tool,
+  args: Record<string, unknown>,
+  _skill: ImportedSkill,
+) {
   // Hackathon stub: real impl loads handler from bundle and executes.
   return {
     content: [
       {
-        type: 'text',
+        type: "text",
         text: `[stub] Local execution for ${tool.name} with args: ${JSON.stringify(args)}`,
       },
     ],
-  }
+  };
 }
 
-async function executeKeeperHub(tool: Tool, args: Record<string, unknown>, _skill: ImportedSkill) {
+async function executeKeeperHub(
+  tool: Tool,
+  args: Record<string, unknown>,
+  _skill: ImportedSkill,
+) {
   if (!KEEPERHUB_API_KEY) {
-    log.err(`KEEPERHUB_API_KEY not set`)
+    log.err(`KEEPERHUB_API_KEY not set`);
     return {
-      content: [{ type: 'text', text: `KeeperHub not configured. Set KEEPERHUB_API_KEY and restart the bridge.` }],
+      content: [
+        {
+          type: "text",
+          text: `KeeperHub not configured. Set KEEPERHUB_API_KEY and restart the bridge.`,
+        },
+      ],
       isError: true,
-    }
+    };
   }
 
-  log.info(`keeperhub → ${tool.name}`)
+  log.info(`keeperhub → ${tool.name}`);
   try {
-    const result = await executeViaKeeperHub(tool, args)
-    log.ok(`keeperhub done: ${result.text.split('\n')[1] ?? ''}`)
+    const result = await executeViaKeeperHub(tool, args);
+    log.ok(`keeperhub done: ${result.text.split("\n")[1] ?? ""}`);
     return {
-      content: [{ type: 'text', text: result.text }],
+      content: [{ type: "text", text: result.text }],
       isError: result.isError,
-    }
+    };
   } catch (e: any) {
-    log.err(`keeperhub error: ${e.message}`)
+    log.err(`keeperhub error: ${e.message}`);
     return {
-      content: [{ type: 'text', text: `KeeperHub execution failed: ${e.message}` }],
+      content: [
+        { type: "text", text: `KeeperHub execution failed: ${e.message}` },
+      ],
       isError: true,
-    }
+    };
   }
 }
 
-async function executeHttp(tool: Tool, args: Record<string, unknown>, _skill: ImportedSkill) {
-  const exec = tool.execution as Extract<Tool['execution'], { type: 'http' }>
-  const t0 = Date.now()
-  log.out(`${exec.method ?? 'POST'} ${exec.endpoint}`)
+async function executeHttp(
+  tool: Tool,
+  args: Record<string, unknown>,
+  _skill: ImportedSkill,
+) {
+  const exec = tool.execution as Extract<Tool["execution"], { type: "http" }>;
+  const t0 = Date.now();
+  log.out(`${exec.method ?? "POST"} ${exec.endpoint}`);
 
   // For GET, send args as query string; for everything else, JSON body.
-  let url = exec.endpoint
-  let init: RequestInit = { method: exec.method ?? 'POST' }
-  if ((exec.method ?? 'POST') === 'GET') {
-    const qs = new URLSearchParams()
+  let url = exec.endpoint;
+  let init: RequestInit = { method: exec.method ?? "POST" };
+  if ((exec.method ?? "POST") === "GET") {
+    const qs = new URLSearchParams();
     for (const [k, v] of Object.entries(args)) {
-      if (v !== undefined && v !== null) qs.set(k, String(v))
+      if (v !== undefined && v !== null) qs.set(k, String(v));
     }
-    url += (url.includes('?') ? '&' : '?') + qs.toString()
+    url += (url.includes("?") ? "&" : "?") + qs.toString();
   } else {
-    init.headers = { 'Content-Type': 'application/json' }
-    init.body = JSON.stringify(args)
+    init.headers = { "Content-Type": "application/json" };
+    init.body = JSON.stringify(args);
   }
 
-  const res = await fetch(url, init)
-  const text = await res.text()
-  log.ok(`${res.status} in ${Date.now() - t0}ms`)
+  const res = await fetch(url, init);
+  const text = await res.text();
+  log.ok(`${res.status} in ${Date.now() - t0}ms`);
   return {
-    content: [{ type: 'text', text }],
+    content: [{ type: "text", text }],
     isError: !res.ok,
-  }
+  };
 }
 
 async function execute0GCompute(tool: Tool, args: Record<string, unknown>) {
-  const exec = tool.execution as Extract<Tool['execution'], { type: '0g-compute' }>
-  log.info(`0G Compute → provider ${exec.providerAddress} model ${exec.model ?? 'qwen3.6-plus'}`)
-  const result = await executeVia0GCompute(tool, args)
-  log.ok(`0G Compute done (provider ${result.provider})`)
+  const exec = tool.execution as Extract<
+    Tool["execution"],
+    { type: "0g-compute" }
+  >;
+  log.info(
+    `0G Compute → provider ${exec.providerAddress} model ${exec.model ?? "qwen3.6-plus"}`,
+  );
+  const result = await executeVia0GCompute(tool, args);
+  log.ok(`0G Compute done (provider ${result.provider})`);
   return {
-    content: [{ type: 'text', text: result.text }],
+    content: [{ type: "text", text: result.text }],
     isError: result.isError,
-  }
+  };
 }
 
 // -------------------------------------------------------------------------
@@ -377,12 +485,12 @@ async function execute0GCompute(tool: Tool, args: Record<string, unknown>) {
 // -------------------------------------------------------------------------
 
 async function main() {
-  const transport = new StdioServerTransport()
-  await server.connect(transport)
-  log.ok('skillname bridge ready · stdio · MCP')
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  log.ok("skillname bridge ready · stdio · MCP");
 }
 
 main().catch((e) => {
-  log.err(`fatal: ${e.message ?? e}`)
-  process.exit(1)
-})
+  log.err(`fatal: ${e.message ?? e}`);
+  process.exit(1);
+});

--- a/skillname-pack/packages/bridge/src/server.ts
+++ b/skillname-pack/packages/bridge/src/server.ts
@@ -122,6 +122,28 @@ const ZG_LIST_PROVIDERS_TOOL: MCPTool = {
   inputSchema: { type: "object", properties: {} },
 };
 
+const SKILL_CALL_TOOL: MCPTool = {
+  name: "skill_call",
+  description:
+    'Call an imported skill tool by name. After importing a skill with skill_import, use this tool to execute any of its registered functions. For example, after importing quote.skilltest.eth, call skill_call with toolName "quote-uniswap__get_quote" and the appropriate arguments. ALWAYS use this tool to call imported skill functions — do not use tool_search.',
+  inputSchema: {
+    type: "object",
+    properties: {
+      toolName: {
+        type: "string",
+        description:
+          'The full name of the imported tool to call, e.g. "quote-uniswap__get_quote" or "weather-tomorrow__forecast"',
+      },
+      arguments: {
+        type: "object",
+        description: "Arguments to pass to the tool, matching its inputSchema",
+        additionalProperties: true,
+      },
+    },
+    required: ["toolName", "arguments"],
+  },
+};
+
 // -------------------------------------------------------------------------
 // Tool listing — built-ins + dynamically imported skills
 // -------------------------------------------------------------------------
@@ -133,7 +155,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
     for (const t of s.result.bundle.tools) {
       dynamicTools.push({
         name: `${s.result.bundle.name}__${t.name}`,
-        description: `[${s.ensName}] ${t.description}`,
+        description: `[skill: ${s.ensName}] ${t.description} — Call this tool directly by name.`,
         inputSchema: t.inputSchema as MCPTool["inputSchema"],
       });
     }
@@ -143,6 +165,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
     tools: [
       SKILL_IMPORT_TOOL,
       SKILL_LIST_TOOL,
+      SKILL_CALL_TOOL,
       ZG_LIST_PROVIDERS_TOOL,
       ...dynamicTools,
     ],
@@ -227,7 +250,10 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
               `Version: ${rootResult.version ?? "unspecified"}\n` +
               `CID: ${rootResult.cid}\n` +
               depLine +
-              `\nTools:\n${toolLines.join("\n")}`,
+              `\nTools now available (call these directly by name):\n${toolLines.join("\n")}\n\n` +
+              `IMPORTANT: These tools are now registered and ready to call. ` +
+              `Use them directly by their full name (e.g. ${flat[0].bundle.name}__${flat[0].bundle.tools[0].name}). ` +
+              `Do NOT use tool_search — call the tool directly.`,
           },
         ],
       };
@@ -263,6 +289,64 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
         },
       ],
     };
+  }
+
+  // -- Built-in: call an imported skill tool --
+  if (name === "skill_call") {
+    const toolName = args.toolName as string;
+    const toolArgs = (args.arguments as Record<string, unknown>) ?? {};
+    log.in(`skill_call ${toolName}`);
+
+    // Find the tool across all imported skills
+    const sep = toolName.indexOf("__");
+    if (sep === -1) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Invalid tool name "${toolName}". Expected format: <bundle>__<tool> (e.g. quote-uniswap__get_quote)`,
+          },
+        ],
+        isError: true,
+      };
+    }
+
+    const bundleName = toolName.slice(0, sep);
+    const fnName = toolName.slice(sep + 2);
+
+    let skill: ImportedSkill | undefined;
+    for (const s of imported.values()) {
+      if (s.result.bundle.name === bundleName) {
+        skill = s;
+        break;
+      }
+    }
+    if (!skill) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Skill "${bundleName}" not imported. Use skill_import first.`,
+          },
+        ],
+        isError: true,
+      };
+    }
+
+    const tool = skill.result.bundle.tools.find((t) => t.name === fnName);
+    if (!tool) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Tool "${fnName}" not found in skill "${bundleName}". Available: ${skill.result.bundle.tools.map((t) => t.name).join(", ")}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+
+    return await executeRouted(tool, toolArgs, skill);
   }
 
   // -- Built-in: list 0G Compute providers --

--- a/skillname-pack/packages/sdk/src/index.ts
+++ b/skillname-pack/packages/sdk/src/index.ts
@@ -8,10 +8,15 @@
  *   const result = await resolveSkill('quote.uniswap.eth')
  */
 
-import { createPublicClient, http, type Address, type PublicClient } from 'viem'
-import { mainnet, sepolia } from 'viem/chains'
-import { normalize, namehash } from 'viem/ens'
-import { validate as validateBundle } from '@skillname/schema'
+import {
+  createPublicClient,
+  http,
+  type Address,
+  type PublicClient,
+} from "viem";
+import { mainnet, sepolia } from "viem/chains";
+import { normalize, namehash } from "viem/ens";
+import { validate as validateBundle } from "@skillname/schema";
 // @helia/verified-fetch is dynamically imported in getVerifiedFetch() —
 // it pulls libp2p webrtc with native bindings, so we only load it on the
 // first verified fetch call. If the dynamic import fails, the SDK falls
@@ -21,93 +26,95 @@ import { validate as validateBundle } from '@skillname/schema'
 // Types
 // -------------------------------------------------------------------------
 
-export const SKILL_TEXT_KEY = 'xyz.manifest.skill'
-export const SKILL_VERSION_KEY = 'xyz.manifest.skill.version'
-export const SKILL_SCHEMA_KEY = 'xyz.manifest.skill.schema'
-export const SKILL_EXECUTION_KEY = 'xyz.manifest.skill.execution'
-export const SKILL_0G_KEY = 'xyz.manifest.skill.0g'
+export const SKILL_TEXT_KEY = "xyz.manifest.skill";
+export const SKILL_VERSION_KEY = "xyz.manifest.skill.version";
+export const SKILL_SCHEMA_KEY = "xyz.manifest.skill.schema";
+export const SKILL_EXECUTION_KEY = "xyz.manifest.skill.execution";
+export const SKILL_0G_KEY = "xyz.manifest.skill.0g";
+export const SKILL_IMPORTS_KEY = "xyz.manifest.skill.imports";
+export const SKILL_LOCKFILE_KEY = "xyz.manifest.skill.lockfile";
 
 export interface SkillBundle {
-  $schema?: string
-  name: string
-  ensName: string
-  version: string
-  description?: string
-  author?: string
-  createdAt?: string
-  license?: string
-  tools: Tool[]
-  prompts?: string[]
-  resources?: Resource[]
-  examples?: string[]
-  dependencies?: string[]
+  $schema?: string;
+  name: string;
+  ensName: string;
+  version: string;
+  description?: string;
+  author?: string;
+  createdAt?: string;
+  license?: string;
+  tools: Tool[];
+  prompts?: string[];
+  resources?: Resource[];
+  examples?: string[];
+  dependencies?: string[];
   trust?: {
-    ensip25?: { enabled: boolean }
-    erc8004?: { registry: string; agentId: number }
-  }
+    ensip25?: { enabled: boolean };
+    erc8004?: { registry: string; agentId: number };
+  };
 }
 
 export interface Tool {
-  name: string
-  description: string
-  inputSchema: Record<string, unknown>
-  outputSchema?: Record<string, unknown>
-  execution: Execution
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+  outputSchema?: Record<string, unknown>;
+  execution: Execution;
 }
 
 export type Execution =
-  | { type: 'local'; handler: string }
+  | { type: "local"; handler: string }
   | {
-      type: 'keeperhub'
-      workflowId?: string
-      tool?: string
-      chainId?: number
-      payment?: Payment
+      type: "keeperhub";
+      workflowId?: string;
+      tool?: string;
+      chainId?: number;
+      payment?: Payment;
     }
-  | { type: 'http'; endpoint: string; method?: string; payment?: Payment }
+  | { type: "http"; endpoint: string; method?: string; payment?: Payment }
   | {
-      type: '0g-compute'
-      providerAddress: string
-      model?: string
-      systemPrompt?: string
-    }
+      type: "0g-compute";
+      providerAddress: string;
+      model?: string;
+      systemPrompt?: string;
+    };
 
 export interface Payment {
-  protocol: 'x402' | 'mpp'
-  price: string
-  token: string
-  network: string
+  protocol: "x402" | "mpp";
+  price: string;
+  token: string;
+  network: string;
 }
 
 export interface Resource {
-  name: string
-  uri: string
-  description?: string
+  name: string;
+  uri: string;
+  description?: string;
 }
 
 export interface ResolveOptions {
   /** Chain to resolve ENS on. Default: 'sepolia' (hackathon). Use 'mainnet' for production names. */
-  chain?: 'mainnet' | 'sepolia'
+  chain?: "mainnet" | "sepolia";
   /** Custom RPC URL */
-  rpcUrl?: string
+  rpcUrl?: string;
   /** Skip CID hash verification (DO NOT use in prod) */
-  skipVerification?: boolean
+  skipVerification?: boolean;
   /** IPFS gateways to try in order */
-  ipfsGateways?: string[]
+  ipfsGateways?: string[];
 }
 
 export interface ResolveResult {
-  ensName: string
-  cid: string
-  version?: string
-  schema?: string
-  bundle: SkillBundle
-  verified: boolean
+  ensName: string;
+  cid: string;
+  version?: string;
+  schema?: string;
+  bundle: SkillBundle;
+  verified: boolean;
   ensip25?: {
-    bound: boolean
-    registry?: string
-    agentId?: number
-  }
+    bound: boolean;
+    registry?: string;
+    agentId?: number;
+  };
 }
 
 // -------------------------------------------------------------------------
@@ -121,76 +128,92 @@ export interface ResolveResult {
 // -------------------------------------------------------------------------
 
 export const ENS_SEPOLIA = {
-  registry:                '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e',
-  baseRegistrar:           '0x57f1887a8bf19b14fc0df6fd9b2acc9af147ea85',
-  ethRegistrarController:  '0xfb3cE5D01e0f33f41DbB39035dB9745962F1f968',
-  dnsRegistrar:            '0x5a07C75Ae469Bf3ee2657B588e8E6ABAC6741b4f',
-  l1ReverseRegistrar:      '0xA0a1AbcDAe1a2a4A2EF8e9113Ff0e02DD81DC0C6',
-  defaultReverseRegistrar: '0x4F382928805ba0e23B30cFB75fC9E848e82DFD47',
-  nameWrapper:             '0x0635513f179D50A207757E05759CbD106d7dFcE8',
-  publicResolver:          '0xE99638b40E4Fff0129D56f03b55b6bbC4BBE49b5',
-  universalResolver:       '0xeEeEEEeE14D718C2B47D9923Deab1335E144EeEe',
-} as const satisfies Record<string, Address>
+  registry: "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e",
+  baseRegistrar: "0x57f1887a8bf19b14fc0df6fd9b2acc9af147ea85",
+  ethRegistrarController: "0xfb3cE5D01e0f33f41DbB39035dB9745962F1f968",
+  dnsRegistrar: "0x5a07C75Ae469Bf3ee2657B588e8E6ABAC6741b4f",
+  l1ReverseRegistrar: "0xA0a1AbcDAe1a2a4A2EF8e9113Ff0e02DD81DC0C6",
+  defaultReverseRegistrar: "0x4F382928805ba0e23B30cFB75fC9E848e82DFD47",
+  nameWrapper: "0x0635513f179D50A207757E05759CbD106d7dFcE8",
+  publicResolver: "0xE99638b40E4Fff0129D56f03b55b6bbC4BBE49b5",
+  universalResolver: "0xeEeEEEeE14D718C2B47D9923Deab1335E144EeEe",
+} as const satisfies Record<string, Address>;
 
 // -------------------------------------------------------------------------
 // Core resolution
 // -------------------------------------------------------------------------
 
 const DEFAULT_GATEWAYS = [
-  'https://w3s.link/ipfs/',
-  'https://ipfs.io/ipfs/',
-  'https://cloudflare-ipfs.com/ipfs/',
-]
+  "https://w3s.link/ipfs/",
+  "https://ipfs.io/ipfs/",
+  "https://cloudflare-ipfs.com/ipfs/",
+];
 
 export async function resolveSkill(
   ensName: string,
-  options: ResolveOptions = {}
+  options: ResolveOptions = {},
 ): Promise<ResolveResult> {
-  const normalized = normalize(ensName)
+  const normalized = normalize(ensName);
 
   // Default to Sepolia for hackathon — mainnet is opt-in.
-  const chain = options.chain ?? 'sepolia'
+  const chain = options.chain ?? "sepolia";
 
   const client = createPublicClient({
-    chain: chain === 'mainnet' ? mainnet : sepolia,
+    chain: chain === "mainnet" ? mainnet : sepolia,
     transport: http(options.rpcUrl),
-  }) as PublicClient
+  }) as PublicClient;
 
   // Pin the Sepolia Universal Resolver to the current ENS Labs deployment;
   // viem's default may lag. On mainnet, fall through to viem's bundled value.
   const universalResolverAddress: Address | undefined =
-    chain === 'sepolia' ? ENS_SEPOLIA.universalResolver : undefined
+    chain === "sepolia" ? ENS_SEPOLIA.universalResolver : undefined;
 
   // 1. Read text records via Universal Resolver
   const [cidRaw, version, schema] = await Promise.all([
-    client.getEnsText({ name: normalized, key: SKILL_TEXT_KEY, universalResolverAddress }),
-    client.getEnsText({ name: normalized, key: SKILL_VERSION_KEY, universalResolverAddress }),
-    client.getEnsText({ name: normalized, key: SKILL_SCHEMA_KEY, universalResolverAddress }),
-  ])
+    client.getEnsText({
+      name: normalized,
+      key: SKILL_TEXT_KEY,
+      universalResolverAddress,
+    }),
+    client.getEnsText({
+      name: normalized,
+      key: SKILL_VERSION_KEY,
+      universalResolverAddress,
+    }),
+    client.getEnsText({
+      name: normalized,
+      key: SKILL_SCHEMA_KEY,
+      universalResolverAddress,
+    }),
+  ]);
 
   if (!cidRaw) {
     throw new Error(
-      `No skill manifest for ${ensName}. Set ENS text record "${SKILL_TEXT_KEY}" first.`
-    )
+      `No skill manifest for ${ensName}. Set ENS text record "${SKILL_TEXT_KEY}" first.`,
+    );
   }
 
   // 2. Fetch + verify (URI scheme decides storage backend: ipfs:// vs 0g://)
-  const bundle = await fetchAndVerify(cidRaw, options)
-  const cid = cidRaw // preserved verbatim in ResolveResult for traceability
+  const bundle = await fetchAndVerify(cidRaw, options);
+  const cid = cidRaw; // preserved verbatim in ResolveResult for traceability
 
   // 4. Validate against schema v1
-  const { valid, errors } = validateBundle(bundle)
+  const { valid, errors } = validateBundle(bundle);
   if (!valid) {
-    const summary = (errors ?? []).map((e) => `${e.instancePath || '/'} ${e.message}`).join('; ')
-    throw new Error(`Bundle at CID ${cid} failed schema validation: ${summary}`)
+    const summary = (errors ?? [])
+      .map((e) => `${e.instancePath || "/"} ${e.message}`)
+      .join("; ");
+    throw new Error(
+      `Bundle at CID ${cid} failed schema validation: ${summary}`,
+    );
   }
 
   // 5. ENSIP-25 check (optional)
-  let ensip25
+  let ensip25;
   if (bundle.trust?.erc8004) {
     ensip25 = await verifyEnsip25(client, normalized, bundle.trust.erc8004, {
       universalResolverAddress,
-    })
+    });
   }
 
   return {
@@ -201,7 +224,7 @@ export async function resolveSkill(
     bundle,
     verified: !options.skipVerification,
     ensip25,
-  }
+  };
 }
 
 // -------------------------------------------------------------------------
@@ -213,80 +236,93 @@ export async function resolveSkill(
 // load path. If helia is unavailable in the host (browser, edge worker,
 // or environment without native deps), verified fetch is skipped and
 // callers fall through to the public-gateway path.
-type VerifiedFetchFn = (resource: string | URL | Request) => Promise<Response>
-let _verifiedFetch: VerifiedFetchFn | null = null
-let _verifiedFetchAttempted = false
+type VerifiedFetchFn = (resource: string | URL | Request) => Promise<Response>;
+let _verifiedFetch: VerifiedFetchFn | null = null;
+let _verifiedFetchAttempted = false;
 async function getVerifiedFetch(): Promise<VerifiedFetchFn | null> {
-  if (_verifiedFetchAttempted) return _verifiedFetch
-  _verifiedFetchAttempted = true
+  if (_verifiedFetchAttempted) return _verifiedFetch;
+  _verifiedFetchAttempted = true;
   try {
-    const mod = await import('@helia/verified-fetch')
-    _verifiedFetch = (await mod.createVerifiedFetch()) as VerifiedFetchFn
+    const mod = await import("@helia/verified-fetch");
+    _verifiedFetch = (await mod.createVerifiedFetch()) as VerifiedFetchFn;
   } catch (e) {
-    console.warn('verified-fetch unavailable, will use gateway:', (e as Error).message)
-    _verifiedFetch = null
+    console.warn(
+      "verified-fetch unavailable, will use gateway:",
+      (e as Error).message,
+    );
+    _verifiedFetch = null;
   }
-  return _verifiedFetch
+  return _verifiedFetch;
 }
 
-const OG_INDEXER_URL = 'https://indexer-storage-testnet-turbo.0g.ai'
+const OG_INDEXER_URL = "https://indexer-storage-testnet-turbo.0g.ai";
 
 async function fetchAndVerify(
   uri: string,
-  options: ResolveOptions
+  options: ResolveOptions,
 ): Promise<SkillBundle> {
   // 0G storage: 0g://<rootHash> — fetched as a single file via the indexer.
-  if (uri.startsWith('0g://')) {
-    const root = uri.slice(5)
-    return fetchVia0G(root, options)
+  if (uri.startsWith("0g://")) {
+    const root = uri.slice(5);
+    return fetchVia0G(root, options);
   }
 
   // IPFS: ipfs://<cid> — fetched as a directory, manifest.json at root.
-  const cid = uri.startsWith('ipfs://') ? uri.slice(7) : uri
-  return fetchViaIpfs(cid, options)
+  const cid = uri.startsWith("ipfs://") ? uri.slice(7) : uri;
+  return fetchViaIpfs(cid, options);
 }
 
-async function fetchVia0G(rootHash: string, _options: ResolveOptions): Promise<SkillBundle> {
-  const url = `${OG_INDEXER_URL}/file?root=${rootHash}`
-  const res = await fetch(url, { headers: { Accept: 'application/json' } })
+async function fetchVia0G(
+  rootHash: string,
+  _options: ResolveOptions,
+): Promise<SkillBundle> {
+  const url = `${OG_INDEXER_URL}/file?root=${rootHash}`;
+  const res = await fetch(url, { headers: { Accept: "application/json" } });
   if (!res.ok) {
-    throw new Error(`0G fetch failed for root ${rootHash}: HTTP ${res.status}`)
+    throw new Error(`0G fetch failed for root ${rootHash}: HTTP ${res.status}`);
   }
-  return (await res.json()) as SkillBundle
+  return (await res.json()) as SkillBundle;
 }
 
-async function fetchViaIpfs(cid: string, options: ResolveOptions): Promise<SkillBundle> {
+async function fetchViaIpfs(
+  cid: string,
+  options: ResolveOptions,
+): Promise<SkillBundle> {
   // Default path: @helia/verified-fetch auto-verifies the CID content hash.
   if (!options.skipVerification) {
     try {
-      const verifiedFetch = await getVerifiedFetch()
+      const verifiedFetch = await getVerifiedFetch();
       if (verifiedFetch) {
-        const response = await verifiedFetch(`ipfs://${cid}/manifest.json`)
+        const response = await verifiedFetch(`ipfs://${cid}/manifest.json`);
         if (response.ok) {
-          return (await response.json()) as SkillBundle
+          return (await response.json()) as SkillBundle;
         }
-        console.warn(`Verified fetch returned ${response.status}; falling back to gateway`)
+        console.warn(
+          `Verified fetch returned ${response.status}; falling back to gateway`,
+        );
       }
     } catch (e) {
-      console.warn('Verified fetch failed, falling back to gateway:', e)
+      console.warn("Verified fetch failed, falling back to gateway:", e);
     }
   }
 
   // Fallback: plain HTTP gateway fetch. Faster but does not verify the hash.
-  const gateways = options.ipfsGateways ?? DEFAULT_GATEWAYS
+  const gateways = options.ipfsGateways ?? DEFAULT_GATEWAYS;
   for (const gateway of gateways) {
     try {
-      const url = `${gateway}${cid}/manifest.json`
-      const res = await fetch(url, { headers: { Accept: 'application/json' } })
-      if (!res.ok) continue
-      return (await res.json()) as SkillBundle
+      const url = `${gateway}${cid}/manifest.json`;
+      const res = await fetch(url, { headers: { Accept: "application/json" } });
+      if (!res.ok) continue;
+      return (await res.json()) as SkillBundle;
     } catch (e) {
-      console.warn(`Gateway ${gateway} failed:`, e)
-      continue
+      console.warn(`Gateway ${gateway} failed:`, e);
+      continue;
     }
   }
 
-  throw new Error(`Failed to fetch CID ${cid} via verified-fetch or any gateway`)
+  throw new Error(
+    `Failed to fetch CID ${cid} via verified-fetch or any gateway`,
+  );
 }
 
 // -------------------------------------------------------------------------
@@ -303,22 +339,22 @@ export async function verifyEnsip25(
   client: PublicClient,
   ensName: string,
   erc8004: { registry: string; agentId: number },
-  options: { universalResolverAddress?: Address } = {}
+  options: { universalResolverAddress?: Address } = {},
 ): Promise<{ bound: boolean; registry: string; agentId: number }> {
-  const erc7930Encoded = encodeErc7930(erc8004.registry)
-  const key = `agent-registration[${erc7930Encoded}][${erc8004.agentId}]`
+  const erc7930Encoded = encodeErc7930(erc8004.registry);
+  const key = `agent-registration[${erc7930Encoded}][${erc8004.agentId}]`;
 
   const value = await client.getEnsText({
     name: normalize(ensName),
     key,
     universalResolverAddress: options.universalResolverAddress,
-  })
+  });
 
   return {
-    bound: value !== null && value !== '' && value !== '0',
+    bound: value !== null && value !== "" && value !== "0",
     registry: erc8004.registry,
     agentId: erc8004.agentId,
-  }
+  };
 }
 
 /**
@@ -333,21 +369,161 @@ export async function verifyEnsip25(
  *      ver  type len 20 address
  */
 export function encodeErc7930(caip10: string): string {
-  const match = caip10.match(/^eip155:(\d+):(0x[a-fA-F0-9]{40})$/)
-  if (!match) throw new Error(`Invalid CAIP-10: ${caip10}`)
-  const [, chainIdStr, addr] = match
-  const chainId = parseInt(chainIdStr, 10)
+  const match = caip10.match(/^eip155:(\d+):(0x[a-fA-F0-9]{40})$/);
+  if (!match) throw new Error(`Invalid CAIP-10: ${caip10}`);
+  const [, chainIdStr, addr] = match;
+  const chainId = parseInt(chainIdStr, 10);
 
-  const chainIdHex = chainId.toString(16).padStart(2, '0')
-  const chainIdLen = (chainIdHex.length / 2).toString(16).padStart(2, '0')
-  const addrClean = addr.toLowerCase().replace('0x', '')
+  const chainIdHex = chainId.toString(16).padStart(2, "0");
+  const chainIdLen = (chainIdHex.length / 2).toString(16).padStart(2, "0");
+  const addrClean = addr.toLowerCase().replace("0x", "");
 
   // version=0001, chain_type=0001 (eip155), chain_id_len, chain_id, addr_len=14, addr
-  return `0x0001${'0001'}${chainIdLen}${chainIdHex}14${addrClean}`
+  return `0x0001${"0001"}${chainIdLen}${chainIdHex}14${addrClean}`;
+}
+
+// -------------------------------------------------------------------------
+// Dependency graph walker
+// -------------------------------------------------------------------------
+
+export interface DependencyNode {
+  ensName: string;
+  result: ResolveResult;
+  children: DependencyNode[];
+}
+
+export interface WalkImportsOptions extends ResolveOptions {
+  /** Maximum recursion depth (default: 5) */
+  maxDepth?: number;
+}
+
+/**
+ * Walk the dependency graph of a skill by reading `xyz.manifest.skill.imports`
+ * text records and recursively resolving each import.
+ *
+ * - Breadth-first traversal
+ * - Cycle detection (rejects if a name appears twice in the walk)
+ * - Max depth guard (default 5)
+ *
+ * Returns the root node with its full dependency tree, plus a flat list of
+ * all resolved skills (for easy tool registration).
+ */
+export async function walkImports(
+  ensName: string,
+  options: WalkImportsOptions = {},
+): Promise<{ root: DependencyNode; flat: ResolveResult[] }> {
+  const maxDepth = options.maxDepth ?? 5;
+  const chain = options.chain ?? "sepolia";
+
+  const client = createPublicClient({
+    chain: chain === "mainnet" ? mainnet : sepolia,
+    transport: http(options.rpcUrl),
+  }) as PublicClient;
+
+  const universalResolverAddress: Address | undefined =
+    chain === "sepolia" ? ENS_SEPOLIA.universalResolver : undefined;
+
+  const visited = new Set<string>();
+  const flat: ResolveResult[] = [];
+
+  async function walk(name: string, depth: number): Promise<DependencyNode> {
+    const normalized = normalize(name);
+
+    if (visited.has(normalized)) {
+      throw new Error(
+        `Cycle detected: ${normalized} already in dependency chain`,
+      );
+    }
+    if (depth > maxDepth) {
+      throw new Error(
+        `Max dependency depth (${maxDepth}) exceeded at ${normalized}`,
+      );
+    }
+
+    visited.add(normalized);
+
+    // Resolve the skill itself
+    const result = await resolveSkill(name, options);
+    flat.push(result);
+
+    // Read imports text record
+    const importsRaw = await client.getEnsText({
+      name: normalized,
+      key: SKILL_IMPORTS_KEY,
+      universalResolverAddress,
+    });
+
+    // Parse comma-separated ENS names, also check bundle.dependencies
+    const importNames = parseImports(importsRaw, result.bundle.dependencies);
+
+    // Recursively walk children
+    const children: DependencyNode[] = [];
+    for (const childName of importNames) {
+      const childNormalized = normalize(childName);
+      if (visited.has(childNormalized)) {
+        // Already resolved (diamond dependency) — skip, don't error
+        continue;
+      }
+      const child = await walk(childName, depth + 1);
+      children.push(child);
+    }
+
+    return { ensName: normalized, result, children };
+  }
+
+  const root = await walk(ensName, 0);
+  return { root, flat };
+}
+
+/**
+ * Merge imports from ENS text record and bundle.dependencies field.
+ * Text record takes precedence (it's the on-chain source of truth).
+ * Bundle dependencies are a fallback for bundles that declare deps
+ * in the manifest but haven't set the text record yet.
+ */
+function parseImports(
+  textRecordValue: string | null | undefined,
+  bundleDependencies: string[] | undefined,
+): string[] {
+  const names = new Set<string>();
+
+  // Text record: comma-separated ENS names
+  if (textRecordValue) {
+    for (const part of textRecordValue.split(",")) {
+      const trimmed = part.trim();
+      if (trimmed && /^([a-z0-9-]+\.)+eth$/.test(trimmed)) {
+        names.add(trimmed);
+      }
+    }
+  }
+
+  // Bundle dependencies as fallback
+  if (bundleDependencies) {
+    for (const dep of bundleDependencies) {
+      const trimmed = dep.trim();
+      if (trimmed) names.add(trimmed);
+    }
+  }
+
+  return Array.from(names);
+}
+
+/**
+ * Generate a flat lockfile from a dependency walk result.
+ * Each entry pins { ensName, version, cid } for reproducible resolution.
+ */
+export function generateLockfile(
+  flat: ResolveResult[],
+): Array<{ ensName: string; version: string; cid: string }> {
+  return flat.map((r) => ({
+    ensName: r.ensName,
+    version: r.version ?? r.bundle.version,
+    cid: r.cid,
+  }));
 }
 
 // -------------------------------------------------------------------------
 // Export everything
 // -------------------------------------------------------------------------
 
-export { namehash, normalize }
+export { namehash, normalize };


### PR DESCRIPTION
## Summary

Implement `skill.imports` dependency walking — the last Tier 1 MUST item.

## SDK changes

### `walkImports(ensName, options)`
- Breadth-first recursive resolver
- Reads `xyz.manifest.skill.imports` text record (comma-separated ENS names)
- Falls back to `bundle.dependencies` field if text record not set yet
- **Cycle detection**: rejects if a name appears twice in the walk
- **Diamond deps**: skip already-visited names (don't error)
- **Max depth**: default 5, configurable via `maxDepth` option
- Returns `{ root: DependencyNode, flat: ResolveResult[] }`

### `generateLockfile(flat)`
- Produces `{ ensName, version, cid }[]` array from walk results
- Ready to pin to IPFS and set as `xyz.manifest.skill.lockfile`

### New constants
- `SKILL_IMPORTS_KEY = 'xyz.manifest.skill.imports'`
- `SKILL_LOCKFILE_KEY = 'xyz.manifest.skill.lockfile'`

## Bridge changes

`skill_import` now calls `walkImports` instead of `resolveSkill`:
- Registers **all transitive tools** from the full dependency tree
- Output shows dependency count + names
- Log lines show total tools across all resolved skills

## Demo flow (Scene 3)
```
User: Use my-trader.skilltest.eth
Bridge: walkImports → resolves my-trader + quote + swap + score
Claude: Imported 4 tool(s) from my-trader.skilltest.eth
        Dependencies (3): quote.skilltest.eth, swap.skilltest.eth, score.skilltest.eth
        Tools:
          · my-trader__analyze: ...
          · quote-uniswap__get_quote: ...
          · swap-uniswap__execute_swap: ...
          · score-gitcoin__trust_score: ...
```

## Tested
- `pnpm build` — all 5 packages compile clean
- No existing behavior broken (skills without imports resolve as before)