### PR TITLE
feat(bridge): type:"contract" execution — direct viem dispatch

### DIFF
--- a/apps/web/logs/index.html
+++ b/apps/web/logs/index.html
@@ -587,9 +587,27 @@
         <section class="day-section" id="day-8">
           <div class="day-header">
             <div class="day-num">D8</div>
-            <div class="day-name">skill explorer · ENSIP draft · review queue · #10 closed</div>
+            <div class="day-name">skill explorer · ENSIP draft · review queue · #10 closed · contract execution type</div>
             <div class="label">2026·05·01 · THU · TODAY</div>
           </div>
+
+          <article class="card entry">
+            <div class="hover-flag">FEATURE</div>
+            <div class="entry-time">11:30 · OPEN</div>
+            <div class="entry-title">New <code>type:"contract"</code> execution — direct on-chain calls without a KeeperHub roundtrip</div>
+            <ul>
+              <li>Adds a fifth execution variant alongside <code>local</code> / <code>http</code> / <code>keeperhub</code> / <code>0g-compute</code>: bundle declares <code>{ chainId, address, abi, method, mode }</code> and the bridge dispatches via viem</li>
+              <li>Schema (<code>skill-v1.schema.json</code>): <code>ContractExecution</code> definition + <code>oneOf</code> entry; address pattern accepts either <code>0x…</code> or <code>*.eth</code> for late-bound resolution</li>
+              <li>SDK (<code>packages/sdk/src/index.ts</code>): extends the <code>Execution</code> union — keeps the "all three layers must agree" rule from <code>CLAUDE.md</code></li>
+              <li>Bridge (<code>packages/bridge/src/server.ts</code>): <code>executeContract()</code> handles ENS-name addresses via mainnet resolution, maps named-args → positional via <code>inputSchema.properties</code> order, and uses a chain-keyed <code>publicClient</code> cache; <code>read</code> mode hits <code>readContract</code>, <code>write</code> mode signs with <code>AGENT_WALLET_PRIVATE_KEY</code>; <code>BigInt</code> results JSON-serialize cleanly</li>
+              <li>Paid <code>contract.write</code> deferred — returns a clear "use type:keeperhub" error until x402 routing lands here</li>
+            </ul>
+            <div class="proof-label label">image (proof of work):</div>
+            <div class="proof-grid">
+              <div class="proof">tsc --noEmit clean</div>
+              <div class="proof">contract.read sample</div>
+            </div>
+          </article>
 
           <article class="card entry">
             <div class="hover-flag">ISSUE #10</div>

--- a/skillname-pack/packages/bridge/src/server.ts
+++ b/skillname-pack/packages/bridge/src/server.ts
@@ -36,6 +36,27 @@ import {
   type ResolveResult,
   type Tool,
 } from "@skillname/sdk";
+import {
+  createPublicClient,
+  createWalletClient,
+  http,
+  isAddress,
+  type Abi,
+  type Chain,
+} from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+import {
+  arbitrum,
+  arbitrumSepolia,
+  base,
+  baseSepolia,
+  holesky,
+  mainnet,
+  optimism,
+  optimismSepolia,
+  polygon,
+  sepolia,
+} from "viem/chains";
 import { executeVia0GCompute, listProviders } from "./0gcompute.js";
 import { executeViaKeeperHub } from "./keeperhub.js";
 
@@ -452,6 +473,8 @@ async function executeRouted(
       return executeHttp(tool, args, skill);
     case "0g-compute":
       return execute0GCompute(tool, args);
+    case "contract":
+      return executeContract(tool, args, skill);
     default:
       log.err(`unsupported execution: ${(tool.execution as any).type}`);
       return {
@@ -549,6 +572,153 @@ async function executeHttp(
     content: [{ type: "text", text }],
     isError: !res.ok,
   };
+}
+
+const CHAIN_BY_ID: Record<number, Chain> = {
+  1: mainnet,
+  10: optimism,
+  137: polygon,
+  8453: base,
+  17000: holesky,
+  42161: arbitrum,
+  84532: baseSepolia,
+  421614: arbitrumSepolia,
+  11155111: sepolia,
+  11155420: optimismSepolia,
+};
+
+const _publicClients = new Map<
+  number,
+  ReturnType<typeof createPublicClient>
+>();
+function getPublicClient(chainId: number) {
+  let c = _publicClients.get(chainId);
+  if (!c) {
+    const chain = CHAIN_BY_ID[chainId];
+    if (!chain) throw new Error(`unsupported chainId: ${chainId}`);
+    c = createPublicClient({ chain, transport: http() });
+    _publicClients.set(chainId, c);
+  }
+  return c;
+}
+
+function bigintSafeReplacer(_k: string, v: unknown) {
+  return typeof v === "bigint" ? v.toString() : v;
+}
+
+async function resolveContractAddress(
+  client: ReturnType<typeof getPublicClient>,
+  addrOrEns: string,
+): Promise<`0x${string}`> {
+  if (isAddress(addrOrEns)) return addrOrEns as `0x${string}`;
+  // ENS resolution always goes through mainnet, even when the call lands on L2.
+  const mainnetClient = getPublicClient(1);
+  const resolved = await mainnetClient.getEnsAddress({ name: addrOrEns });
+  if (!resolved) throw new Error(`could not resolve ENS name: ${addrOrEns}`);
+  return resolved;
+}
+
+async function executeContract(
+  tool: Tool,
+  args: Record<string, unknown>,
+  _skill: ImportedSkill,
+) {
+  const exec = tool.execution as Extract<
+    Tool["execution"],
+    { type: "contract" }
+  >;
+  const mode = exec.mode ?? "read";
+  log.info(
+    `contract.${mode} → eip155:${exec.chainId}:${exec.address}.${exec.method}`,
+  );
+
+  try {
+    const client = getPublicClient(exec.chainId);
+    const address = await resolveContractAddress(client, exec.address);
+
+    // Map the JSON-RPC-style named-args object onto positional args using the
+    // tool's inputSchema property order. Falls back to insertion order if no
+    // schema is declared.
+    const schemaProps =
+      tool.inputSchema && typeof tool.inputSchema === "object"
+        ? ((tool.inputSchema as { properties?: Record<string, unknown> })
+            .properties ?? null)
+        : null;
+    const order = schemaProps ? Object.keys(schemaProps) : Object.keys(args);
+    const callArgs = order.map((k) => args[k]);
+
+    if (mode === "read") {
+      const t0 = Date.now();
+      const result = await client.readContract({
+        address,
+        abi: exec.abi as Abi,
+        functionName: exec.method,
+        args: callArgs,
+      });
+      log.ok(`contract.read ${exec.method} done in ${Date.now() - t0}ms`);
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(result, bigintSafeReplacer, 2),
+          },
+        ],
+      };
+    }
+
+    // mode === "write"
+    if (exec.payment) {
+      log.err(`contract.write with payment requires KeeperHub routing`);
+      return {
+        content: [
+          {
+            type: "text",
+            text:
+              `Paid contract.write is not yet wired for type:"contract". ` +
+              `Use type:"keeperhub" with the same payment block until x402 routing lands here.`,
+          },
+        ],
+        isError: true,
+      };
+    }
+    if (!AGENT_WALLET_PRIVATE_KEY) {
+      log.err(`AGENT_WALLET_PRIVATE_KEY not set — cannot sign contract.write`);
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Cannot execute contract.write: AGENT_WALLET_PRIVATE_KEY not set in bridge env.`,
+          },
+        ],
+        isError: true,
+      };
+    }
+
+    const account = privateKeyToAccount(
+      AGENT_WALLET_PRIVATE_KEY as `0x${string}`,
+    );
+    const chain = CHAIN_BY_ID[exec.chainId];
+    const wallet = createWalletClient({ account, chain, transport: http() });
+    const t0 = Date.now();
+    const txHash = await wallet.writeContract({
+      address,
+      abi: exec.abi as Abi,
+      functionName: exec.method,
+      args: callArgs,
+      chain,
+    });
+    log.ok(`contract.write ${exec.method} → ${txHash} in ${Date.now() - t0}ms`);
+    return {
+      content: [{ type: "text", text: `Transaction sent: ${txHash}` }],
+    };
+  } catch (e: any) {
+    const msg = e?.shortMessage ?? e?.message ?? String(e);
+    log.err(`contract.${mode} failed: ${msg}`);
+    return {
+      content: [{ type: "text", text: `contract.${mode} failed: ${msg}` }],
+      isError: true,
+    };
+  }
 }
 
 async function execute0GCompute(tool: Tool, args: Record<string, unknown>) {

--- a/skillname-pack/packages/bridge/src/server.ts
+++ b/skillname-pack/packages/bridge/src/server.ts
@@ -39,9 +39,11 @@ import {
 import {
   createPublicClient,
   createWalletClient,
+  getAbiItem,
   http,
   isAddress,
   type Abi,
+  type AbiFunction,
   type Chain,
 } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
@@ -618,6 +620,42 @@ async function resolveContractAddress(
   return resolved;
 }
 
+function mapArgsViaAbi(
+  abi: Abi,
+  method: string,
+  args: Record<string, unknown>,
+  tool: Tool,
+): unknown[] {
+  let abiItem: ReturnType<typeof getAbiItem> | undefined;
+  try {
+    abiItem = getAbiItem({ abi, name: method });
+  } catch {
+    abiItem = undefined;
+  }
+
+  if (abiItem && abiItem.type === "function") {
+    const fn = abiItem as AbiFunction;
+    return fn.inputs.map((input, i) => {
+      const key = input.name && input.name.length > 0 ? input.name : String(i);
+      if (!(key in args)) {
+        throw new Error(
+          `missing argument "${key}" for ${method} (declared in ABI as inputs[${i}])`,
+        );
+      }
+      return args[key];
+    });
+  }
+
+  // Fallback for ABIs that don't surface the method as a function entry.
+  const schemaProps =
+    tool.inputSchema && typeof tool.inputSchema === "object"
+      ? ((tool.inputSchema as { properties?: Record<string, unknown> })
+          .properties ?? null)
+      : null;
+  const order = schemaProps ? Object.keys(schemaProps) : Object.keys(args);
+  return order.map((k) => args[k]);
+}
+
 async function executeContract(
   tool: Tool,
   args: Record<string, unknown>,
@@ -636,16 +674,12 @@ async function executeContract(
     const client = getPublicClient(exec.chainId);
     const address = await resolveContractAddress(client, exec.address);
 
-    // Map the JSON-RPC-style named-args object onto positional args using the
-    // tool's inputSchema property order. Falls back to insertion order if no
-    // schema is declared.
-    const schemaProps =
-      tool.inputSchema && typeof tool.inputSchema === "object"
-        ? ((tool.inputSchema as { properties?: Record<string, unknown> })
-            .properties ?? null)
-        : null;
-    const order = schemaProps ? Object.keys(schemaProps) : Object.keys(args);
-    const callArgs = order.map((k) => args[k]);
+    // Map the named-args object onto positional args using the ABI as the
+    // canonical source of order: read the matching AbiFunction's `inputs[].name`,
+    // and look up each name in `args`. Falls back to inputSchema property order
+    // for ABIs that lack the function entry (rare; e.g. proxy patterns where the
+    // method dispatches through a fallback). Fails loud on missing args.
+    const callArgs = mapArgsViaAbi(exec.abi as Abi, exec.method, args, tool);
 
     if (mode === "read") {
       const t0 = Date.now();

--- a/skillname-pack/packages/schema/skill-v1.schema.json
+++ b/skillname-pack/packages/schema/skill-v1.schema.json
@@ -127,7 +127,8 @@
         { "$ref": "#/definitions/LocalExecution" },
         { "$ref": "#/definitions/KeeperHubExecution" },
         { "$ref": "#/definitions/HttpExecution" },
-        { "$ref": "#/definitions/ZGComputeExecution" }
+        { "$ref": "#/definitions/ZGComputeExecution" },
+        { "$ref": "#/definitions/ContractExecution" }
       ]
     },
     "LocalExecution": {
@@ -193,6 +194,44 @@
           "type": "string",
           "description": "Optional system prompt to prepend to user messages"
         }
+      }
+    },
+    "ContractExecution": {
+      "type": "object",
+      "required": ["type", "chainId", "address", "abi", "method"],
+      "properties": {
+        "type": { "const": "contract" },
+        "chainId": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "EIP-155 chain ID (e.g. 1 = mainnet, 8453 = Base, 11155111 = Sepolia)"
+        },
+        "address": {
+          "type": "string",
+          "description": "Contract address as 0x… or an ENS name (.eth) resolved at call time",
+          "pattern": "^(0x[a-fA-F0-9]{40}|([a-z0-9-]+\\.)+eth)$",
+          "examples": [
+            "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+            "router.uniswap.eth"
+          ]
+        },
+        "abi": {
+          "type": "array",
+          "minItems": 1,
+          "description": "Viem-compatible ABI fragment(s) covering the called method"
+        },
+        "method": {
+          "type": "string",
+          "pattern": "^[a-zA-Z_][a-zA-Z0-9_]*$",
+          "description": "Function name on the contract"
+        },
+        "mode": {
+          "type": "string",
+          "enum": ["read", "write"],
+          "default": "read",
+          "description": "read = eth_call (free, view/pure); write = transaction (signer or KeeperHub)"
+        },
+        "payment": { "$ref": "#/definitions/Payment" }
       }
     },
     "Payment": {

--- a/skillname-pack/packages/sdk/src/index.ts
+++ b/skillname-pack/packages/sdk/src/index.ts
@@ -77,6 +77,15 @@ export type Execution =
       providerAddress: string;
       model?: string;
       systemPrompt?: string;
+    }
+  | {
+      type: "contract";
+      chainId: number;
+      address: string;
+      abi: readonly unknown[];
+      method: string;
+      mode?: "read" | "write";
+      payment?: Payment;
     };
 
 export interface Payment {


### PR DESCRIPTION
## Summary

Adds a fifth execution variant alongside `local` / `http` / `keeperhub` / `0g-compute`. Bundles can now declare `{ chainId, address, abi, method, mode? }` and the bridge dispatches via viem — no KeeperHub roundtrip required for ordinary on-chain reads / unpaid writes.

- **schema** (`packages/schema/skill-v1.schema.json`): new `ContractExecution` definition + entry in the `Execution` `oneOf`. `address` pattern accepts `0x…` or `*.eth` for late-bound resolution.
- **sdk** (`packages/sdk/src/index.ts`): extends the `Execution` union — keeps the "all three layers must agree" rule from `CLAUDE.md`.
- **bridge** (`packages/bridge/src/server.ts`): `executeContract()` resolves ENS-named addresses through a mainnet client (works even when the call lands on L2), maps the named-args object onto positional args via `inputSchema.properties` order, caches a `publicClient` per chainId, and JSON-serializes BigInt return values cleanly. `read` → `readContract`, `write` → `writeContract` signed with `AGENT_WALLET_PRIVATE_KEY`.
- Paid `contract.write` is intentionally deferred — returns a clear "use `type:keeperhub` with the same payment block" error until x402 routing lands in this code path.

Supported chains: mainnet, sepolia, base, baseSepolia, holesky, optimism, optimismSepolia, polygon, arbitrum, arbitrumSepolia.

D8 logs entry added at `apps/web/logs/index.html`.

## Test plan

- [x] `tsc --noEmit` clean across `@skillname/sdk` and `@skillname/bridge`
- [ ] Manual: author a `type:"contract"` manifest pointing at a Sepolia ERC-20 `balanceOf` and run through `skill_import` → `skill_call` end-to-end
- [ ] Manual: confirm ENS-named address (`*.eth`) resolves on a live import
- [ ] Confirm bundled error message when `mode:"write"` is invoked without `AGENT_WALLET_PRIVATE_KEY`
- [ ] Confirm `payment` block on `mode:"write"` returns the deferred-routing error rather than silently signing