### PR TITLE
feat(#52): SkillLink on-chain skill registry — deployed on Sepolia

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "contracts/lib/forge-std"]
+	path = contracts/lib/forge-std
+	url = https://github.com/foundry-rs/forge-std

--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -1,0 +1,14 @@
+[profile.default]
+src = "src"
+out = "out"
+libs = ["lib"]
+solc = "0.8.24"
+optimizer = true
+optimizer_runs = 200
+
+[rpc_endpoints]
+base_sepolia = "${BASE_SEPOLIA_RPC_URL}"
+sepolia = "https://ethereum-sepolia-rpc.publicnode.com"
+
+[etherscan]
+sepolia = { key = "${ETHERSCAN_API_KEY}" }

--- a/contracts/script/Deploy.s.sol
+++ b/contracts/script/Deploy.s.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Script.sol";
+import "../src/SkillLink.sol";
+
+contract DeploySkillLink is Script {
+    function run() external {
+        uint256 deployerKey = vm.envUint("SEPOLIA_PRIVATE_KEY");
+        vm.startBroadcast(deployerKey);
+
+        SkillLink registry = new SkillLink();
+        console.log("SkillLink deployed at:", address(registry));
+
+        vm.stopBroadcast();
+    }
+}

--- a/contracts/script/DeployComposition.s.sol
+++ b/contracts/script/DeployComposition.s.sol
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Script.sol";
+import "../src/SkillLink.sol";
+import "../src/examples/QuoteUniswap.sol";
+import "../src/examples/QuoteSushi.sol";
+import "../src/examples/BestQuoteAggregator.sol";
+
+/// @title DeployComposition — bootstraps the on-chain skill composition demo
+///
+/// Deploys QuoteUniswap + QuoteSushi + BestQuoteAggregator, registers all three
+/// in the existing SkillLink contract, and runs `getBestQuote("ethereum")` once
+/// to capture the demo evidence.
+///
+/// Required env:
+///   SEPOLIA_PRIVATE_KEY  — owner of the three .skilltest.eth subnames
+///   SKILLLINK_ADDRESS    — already-deployed SkillLink (e.g. 0xE2532C…)
+///
+/// Optional env:
+///   QUOTE_UNISWAP_ENS    — default "quote.uniswap.skilltest.eth"
+///   QUOTE_SUSHI_ENS      — default "quote.sushi.skilltest.eth"
+///   QUOTE_AGGREGATE_ENS  — default "quote.aggregate.skilltest.eth"
+///
+/// Run:
+///   forge script script/DeployComposition.s.sol \
+///     --rpc-url $SEPOLIA_RPC_URL --broadcast --verify
+contract DeployComposition is Script {
+    function run() external {
+        uint256 deployerKey = vm.envUint("SEPOLIA_PRIVATE_KEY");
+        address skillLinkAddr = vm.envAddress("SKILLLINK_ADDRESS");
+
+        string memory uniswapEns = _envOrDefault(
+            "QUOTE_UNISWAP_ENS",
+            "quote.uniswap.skilltest.eth"
+        );
+        string memory sushiEns = _envOrDefault(
+            "QUOTE_SUSHI_ENS",
+            "quote.sushi.skilltest.eth"
+        );
+        string memory aggregateEns = _envOrDefault(
+            "QUOTE_AGGREGATE_ENS",
+            "quote.aggregate.skilltest.eth"
+        );
+
+        bytes32 uniswapNode = _namehash(uniswapEns);
+        bytes32 sushiNode = _namehash(sushiEns);
+        bytes32 aggregateNode = _namehash(aggregateEns);
+
+        SkillLink registry = SkillLink(skillLinkAddr);
+
+        vm.startBroadcast(deployerKey);
+
+        // 1. Deploy the two underlying quote skills
+        QuoteUniswap uni = new QuoteUniswap();
+        QuoteSushi sushi = new QuoteSushi();
+        console.log("QuoteUniswap deployed at:", address(uni));
+        console.log("QuoteSushi   deployed at:", address(sushi));
+
+        // 2. Register both as ENS-named skills with `getQuote(string)` in the allowlist
+        bytes4[] memory sels = new bytes4[](1);
+        sels[0] = QuoteUniswap.getQuote.selector;
+
+        registry.register(uniswapNode, address(uni), sels);
+        registry.register(sushiNode, address(sushi), sels);
+        console.log("Registered quote.uniswap.skilltest.eth -> uni");
+        console.log("Registered quote.sushi.skilltest.eth   -> sushi");
+
+        // 3. Deploy the composition skill that calls both via the registry
+        BestQuoteAggregator agg = new BestQuoteAggregator(
+            registry,
+            uniswapNode,
+            sushiNode
+        );
+        console.log("BestQuoteAggregator deployed at:", address(agg));
+
+        // 4. Register the aggregator as itself a skill — third-party callers can
+        //    invoke `quote.aggregate.skilltest.eth` and the registry will dispatch
+        //    to the aggregator, which in turn dispatches to the two underlying
+        //    skills via the registry. Recursive composition.
+        bytes4[] memory aggSels = new bytes4[](1);
+        aggSels[0] = BestQuoteAggregator.getBestQuote.selector;
+        registry.register(aggregateNode, address(agg), aggSels);
+        console.log("Registered quote.aggregate.skilltest.eth -> agg");
+
+        vm.stopBroadcast();
+
+        // 5. Capture demo evidence — call the aggregator and log the result
+        uint256 best = agg.getBestQuote("ethereum");
+        console.log("Best quote for ethereum (USD, 6dp):", best);
+
+        console.log("---");
+        console.log("Demo command (anyone can run, no key needed):");
+        console.log(
+            "  cast call",
+            skillLinkAddr,
+            "'call(bytes32,bytes)(bytes)'"
+        );
+        console.log("    <namehash(quote.aggregate.skilltest.eth)>");
+        console.log(
+            "    $(cast calldata 'getBestQuote(string)' 'ethereum')"
+        );
+    }
+
+    // ── ENS namehash (ENSIP-1) ───────────────────────────────────────────
+
+    /// @dev Computes the ENS namehash of a dot-separated name, e.g.
+    ///      `_namehash("foo.bar.eth")`.
+    function _namehash(string memory name) internal pure returns (bytes32 node) {
+        bytes memory raw = bytes(name);
+        if (raw.length == 0) return bytes32(0);
+
+        // Walk right-to-left, hashing each label into the rolling node.
+        uint256 end = raw.length;
+        uint256 cursor = raw.length;
+        while (cursor > 0) {
+            cursor--;
+            if (raw[cursor] == 0x2e /* '.' */) {
+                node = keccak256(
+                    abi.encodePacked(node, keccak256(_slice(raw, cursor + 1, end)))
+                );
+                end = cursor;
+            }
+        }
+        node = keccak256(
+            abi.encodePacked(node, keccak256(_slice(raw, 0, end)))
+        );
+    }
+
+    function _slice(bytes memory data, uint256 start, uint256 end)
+        internal
+        pure
+        returns (bytes memory out)
+    {
+        out = new bytes(end - start);
+        for (uint256 i = 0; i < out.length; i++) {
+            out[i] = data[start + i];
+        }
+    }
+
+    function _envOrDefault(string memory key, string memory fallback_)
+        internal
+        view
+        returns (string memory)
+    {
+        try vm.envString(key) returns (string memory v) {
+            return v;
+        } catch {
+            return fallback_;
+        }
+    }
+}

--- a/contracts/src/SkillLink.sol
+++ b/contracts/src/SkillLink.sol
@@ -12,6 +12,12 @@ interface IENS {
     function owner(bytes32 node) external view returns (address);
 }
 
+/// @notice ENS NameWrapper. Wrapped names report their `ENS_REGISTRY.owner()` as
+///         the NameWrapper contract; the real owner is read from `ownerOf(uint256(node))`.
+interface INameWrapper {
+    function ownerOf(uint256 id) external view returns (address);
+}
+
 contract SkillLink {
     // ── Types ────────────────────────────────────────────────────────────
 
@@ -25,8 +31,13 @@ contract SkillLink {
 
     // ── State ────────────────────────────────────────────────────────────
 
-    /// @notice ENS Registry on Sepolia (same address on all EVM chains)
+    /// @notice ENS Registry — same address on every Ethereum chain (mainnet, Sepolia, Holesky).
     IENS public constant ENS_REGISTRY = IENS(0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e);
+
+    /// @notice ENS NameWrapper on Sepolia. Mainnet uses
+    ///         `0xD4416b13d2b3a9aBae7AcD5D6C2BbDBE25686401` — redeploy with that
+    ///         constant when porting to mainnet.
+    INameWrapper public constant NAME_WRAPPER = INameWrapper(0x0635513f179D50A207757E05759CbD106d7dFcE8);
 
     /// @notice namehash → registered skill
     mapping(bytes32 => Skill) public skills;
@@ -73,8 +84,13 @@ contract SkillLink {
     ) external {
         if (selectors_.length == 0) revert NoSelectors();
 
-        // Verify caller owns the ENS name
+        // Verify caller owns the ENS name. For wrapped names, `ENS_REGISTRY.owner(node)`
+        // returns the NameWrapper contract address rather than the actual owner — fall
+        // through to `NameWrapper.ownerOf(uint256(node))` to get the real owner.
         address ensOwner = ENS_REGISTRY.owner(node);
+        if (ensOwner == address(NAME_WRAPPER)) {
+            ensOwner = NAME_WRAPPER.ownerOf(uint256(node));
+        }
         if (msg.sender != ensOwner) {
             revert NotENSOwner(node, msg.sender, ensOwner);
         }

--- a/contracts/src/SkillLink.sol
+++ b/contracts/src/SkillLink.sol
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+/// @title SkillLink — ENS-keyed on-chain skill registry
+/// @notice Maps ENS namehash → implementation contract. Any contract or EOA
+///         can invoke a registered skill by its ENS name. Ownership is verified
+///         via ENS Registry at register time — only the ENS name owner can
+///         register or update a skill's implementation.
+/// @dev    Events are shaped to feed the analytics indexer (#15) directly.
+
+interface IENS {
+    function owner(bytes32 node) external view returns (address);
+}
+
+contract SkillLink {
+    // ── Types ────────────────────────────────────────────────────────────
+
+    struct Skill {
+        address impl;           // implementation contract to delegatecall/call
+        address owner;          // ENS name owner at registration time
+        uint96  registeredAt;   // block.timestamp
+        uint256 selectorBitmap; // packed bitmap of allowed selectors (first 256 slots)
+        bytes4[] selectors;     // full selector list for enumeration
+    }
+
+    // ── State ────────────────────────────────────────────────────────────
+
+    /// @notice ENS Registry on Sepolia (same address on all EVM chains)
+    IENS public constant ENS_REGISTRY = IENS(0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e);
+
+    /// @notice namehash → registered skill
+    mapping(bytes32 => Skill) public skills;
+
+    /// @notice Total number of registered skills
+    uint256 public skillCount;
+
+    // ── Events ───────────────────────────────────────────────────────────
+
+    event SkillRegistered(
+        bytes32 indexed node,
+        address indexed impl,
+        address indexed owner,
+        bytes4[] selectors
+    );
+
+    event SkillCalled(
+        bytes32 indexed node,
+        address indexed sender,
+        bytes4  indexed selector,
+        bool    success,
+        uint256 gasUsed
+    );
+
+    // ── Errors ───────────────────────────────────────────────────────────
+
+    error NotENSOwner(bytes32 node, address sender, address owner);
+    error SkillNotRegistered(bytes32 node);
+    error SelectorNotAllowed(bytes32 node, bytes4 selector);
+    error CallFailed(bytes returnData);
+    error NoSelectors();
+
+    // ── Registration ─────────────────────────────────────────────────────
+
+    /// @notice Register or update a skill implementation for an ENS name.
+    ///         Only the current ENS name owner can call this.
+    /// @param node       namehash of the ENS name (e.g. namehash("quote.skilltest.eth"))
+    /// @param impl       address of the implementation contract
+    /// @param selectors_ function selectors the registry will forward
+    function register(
+        bytes32 node,
+        address impl,
+        bytes4[] calldata selectors_
+    ) external {
+        if (selectors_.length == 0) revert NoSelectors();
+
+        // Verify caller owns the ENS name
+        address ensOwner = ENS_REGISTRY.owner(node);
+        if (msg.sender != ensOwner) {
+            revert NotENSOwner(node, msg.sender, ensOwner);
+        }
+
+        // Build selector bitmap for O(1) lookup
+        uint256 bitmap;
+        for (uint256 i; i < selectors_.length; i++) {
+            uint256 slot = uint256(uint32(selectors_[i])) & 0xFF;
+            bitmap |= (1 << slot);
+        }
+
+        // Track new vs update
+        if (skills[node].impl == address(0)) {
+            skillCount++;
+        }
+
+        skills[node] = Skill({
+            impl: impl,
+            owner: msg.sender,
+            registeredAt: uint96(block.timestamp),
+            selectorBitmap: bitmap,
+            selectors: selectors_
+        });
+
+        emit SkillRegistered(node, impl, msg.sender, selectors_);
+    }
+
+    // ── Invocation ───────────────────────────────────────────────────────
+
+    /// @notice Call a registered skill by ENS namehash.
+    ///         Forwards msg.value and returns the call result.
+    /// @param node ENS namehash of the skill
+    /// @param data ABI-encoded function call (selector + args)
+    /// @return result The return data from the skill implementation
+    function call(bytes32 node, bytes calldata data)
+        external
+        payable
+        returns (bytes memory result)
+    {
+        Skill storage skill = skills[node];
+        if (skill.impl == address(0)) revert SkillNotRegistered(node);
+
+        // Check selector is in the allowlist
+        bytes4 selector = bytes4(data[:4]);
+        if (!_isSelectorAllowed(skill, selector)) {
+            revert SelectorNotAllowed(node, selector);
+        }
+
+        // Forward the call
+        uint256 gasBefore = gasleft();
+        bool success;
+        (success, result) = skill.impl.call{value: msg.value}(data);
+        uint256 gasUsed = gasBefore - gasleft();
+
+        emit SkillCalled(node, msg.sender, selector, success, gasUsed);
+
+        if (!success) revert CallFailed(result);
+    }
+
+    // ── View helpers ─────────────────────────────────────────────────────
+
+    /// @notice Get the selectors registered for a skill
+    function getSelectors(bytes32 node) external view returns (bytes4[] memory) {
+        return skills[node].selectors;
+    }
+
+    /// @notice Check if a selector is allowed for a skill
+    function isSelectorAllowed(bytes32 node, bytes4 selector) external view returns (bool) {
+        return _isSelectorAllowed(skills[node], selector);
+    }
+
+    // ── Internal ─────────────────────────────────────────────────────────
+
+    function _isSelectorAllowed(Skill storage skill, bytes4 selector) internal view returns (bool) {
+        // Fast path: bitmap check
+        uint256 slot = uint256(uint32(selector)) & 0xFF;
+        if (skill.selectorBitmap & (1 << slot) == 0) return false;
+
+        // Bitmap can have false positives (collision on lower 8 bits).
+        // Full check against the selector array.
+        for (uint256 i; i < skill.selectors.length; i++) {
+            if (skill.selectors[i] == selector) return true;
+        }
+        return false;
+    }
+}

--- a/contracts/src/examples/BestQuoteAggregator.sol
+++ b/contracts/src/examples/BestQuoteAggregator.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "../SkillLink.sol";
+
+/// @title BestQuoteAggregator — composition skill that calls two skills via SkillLink
+/// @notice Demonstrates on-chain skill composition: this contract is itself a
+///         registered skill (`quote.aggregate.skilltest.eth`) whose function
+///         dispatches to two other registered skills (`quote.uniswap.skilltest.eth`,
+///         `quote.sushi.skilltest.eth`) through the SkillLink registry, then
+///         picks the higher quote. No direct addresses are hardcoded — all
+///         routing happens by ENS namehash.
+contract BestQuoteAggregator {
+    SkillLink public immutable registry;
+    bytes32 public immutable quoteA;
+    bytes32 public immutable quoteB;
+
+    constructor(SkillLink _registry, bytes32 _quoteA, bytes32 _quoteB) {
+        registry = _registry;
+        quoteA = _quoteA;
+        quoteB = _quoteB;
+    }
+
+    function getBestQuote(string calldata tokenId) external returns (uint256) {
+        bytes memory callData = abi.encodeWithSignature("getQuote(string)", tokenId);
+        bytes memory resultA = registry.call(quoteA, callData);
+        bytes memory resultB = registry.call(quoteB, callData);
+        uint256 a = abi.decode(resultA, (uint256));
+        uint256 b = abi.decode(resultB, (uint256));
+        return a > b ? a : b;
+    }
+}

--- a/contracts/src/examples/QuoteSushi.sol
+++ b/contracts/src/examples/QuoteSushi.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+/// @title QuoteSushi — second reference skill (mock Sushiswap quote)
+/// @notice Returns a slightly-different USD price for the same token ids
+///         so the composition demo has something to choose between.
+contract QuoteSushi {
+    function getQuote(string calldata tokenId) external pure returns (uint256) {
+        bytes32 h = keccak256(bytes(tokenId));
+        if (h == keccak256("ethereum"))     return 2_295e6;  // 5 USD lower than Uniswap
+        if (h == keccak256("bitcoin"))      return 77_050e6; // 50 USD higher
+        if (h == keccak256("usd-coin"))     return 1e6;
+        if (h == keccak256("wrapped-bitcoin")) return 76_900e6;
+        return 0;
+    }
+}

--- a/contracts/src/examples/QuoteUniswap.sol
+++ b/contracts/src/examples/QuoteUniswap.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+/// @title QuoteUniswap — reference skill implementation (mock Uniswap quote)
+/// @notice Returns a hardcoded USD price for a CoinGecko-style token id.
+///         Wired as the impl for `quote.uniswap.skilltest.eth` in the
+///         SkillLink registry composition demo.
+contract QuoteUniswap {
+    function getQuote(string calldata tokenId) external pure returns (uint256) {
+        bytes32 h = keccak256(bytes(tokenId));
+        if (h == keccak256("ethereum"))     return 2_300e6;
+        if (h == keccak256("bitcoin"))      return 77_000e6;
+        if (h == keccak256("usd-coin"))     return 1e6;
+        if (h == keccak256("wrapped-bitcoin")) return 76_950e6;
+        return 0;
+    }
+}

--- a/contracts/test/SkillLink.t.sol
+++ b/contracts/test/SkillLink.t.sol
@@ -1,0 +1,242 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import "../src/SkillLink.sol";
+
+/// @dev Mock ENS Registry that lets us control name ownership in tests
+contract MockENSRegistry {
+    mapping(bytes32 => address) public owner;
+
+    function setOwner(bytes32 node, address _owner) external {
+        owner[node] = _owner;
+    }
+}
+
+/// @dev Mock skill implementation — simple quote oracle
+contract MockQuoteSkill {
+    function getQuote(string calldata tokenId) external pure returns (uint256) {
+        if (keccak256(bytes(tokenId)) == keccak256("ethereum")) return 2300e6;
+        if (keccak256(bytes(tokenId)) == keccak256("bitcoin")) return 77000e6;
+        return 0;
+    }
+
+    function forbidden() external pure returns (uint256) {
+        return 999;
+    }
+}
+
+/// @dev Second mock for composition demo
+contract MockSushiQuote {
+    function getQuote(string calldata) external pure returns (uint256) {
+        return 2295e6; // slightly lower
+    }
+}
+
+/// @dev Aggregator that calls two skills via SkillLink and picks the best
+contract BestQuoteAggregator {
+    SkillLink public registry;
+    bytes32 public quoteA;
+    bytes32 public quoteB;
+
+    constructor(SkillLink _registry, bytes32 _quoteA, bytes32 _quoteB) {
+        registry = _registry;
+        quoteA = _quoteA;
+        quoteB = _quoteB;
+    }
+
+    function getBestQuote(string calldata tokenId) external returns (uint256) {
+        bytes memory callData = abi.encodeWithSignature("getQuote(string)", tokenId);
+        bytes memory resultA = registry.call(quoteA, callData);
+        bytes memory resultB = registry.call(quoteB, callData);
+        uint256 a = abi.decode(resultA, (uint256));
+        uint256 b = abi.decode(resultB, (uint256));
+        return a > b ? a : b;
+    }
+}
+
+contract SkillLinkTest is Test {
+    SkillLink public registry;
+    MockENSRegistry public mockENS;
+    MockQuoteSkill public quoteSkill;
+    MockSushiQuote public sushiSkill;
+
+    address owner = address(0xBEEF);
+    address attacker = address(0xDEAD);
+
+    bytes32 quoteNode = keccak256("quote.skilltest.eth"); // simplified for tests
+    bytes32 sushiNode = keccak256("sushi.skilltest.eth");
+
+    bytes4 getQuoteSel = MockQuoteSkill.getQuote.selector;
+    bytes4 forbiddenSel = MockQuoteSkill.forbidden.selector;
+
+    function setUp() public {
+        // Deploy mock ENS and set ownership
+        mockENS = new MockENSRegistry();
+        mockENS.setOwner(quoteNode, owner);
+        mockENS.setOwner(sushiNode, owner);
+
+        // Deploy SkillLink with mock ENS
+        // We need to etch the mock at the real ENS address
+        registry = new SkillLink();
+        vm.etch(address(0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e), address(mockENS).code);
+
+        // Copy storage from mockENS to the etched address
+        // Set owner for quoteNode
+        vm.store(
+            address(0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e),
+            keccak256(abi.encode(quoteNode, uint256(0))),
+            bytes32(uint256(uint160(owner)))
+        );
+        vm.store(
+            address(0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e),
+            keccak256(abi.encode(sushiNode, uint256(0))),
+            bytes32(uint256(uint160(owner)))
+        );
+
+        // Deploy mock skills
+        quoteSkill = new MockQuoteSkill();
+        sushiSkill = new MockSushiQuote();
+    }
+
+    // ── Registration tests ───────────────────────────────────────────────
+
+    function test_register_success() public {
+        bytes4[] memory sels = new bytes4[](1);
+        sels[0] = getQuoteSel;
+
+        vm.prank(owner);
+        registry.register(quoteNode, address(quoteSkill), sels);
+
+        (address impl, address skillOwner, uint96 registeredAt,) = registry.skills(quoteNode);
+        assertEq(impl, address(quoteSkill));
+        assertEq(skillOwner, owner);
+        assertGt(registeredAt, 0);
+        assertEq(registry.skillCount(), 1);
+    }
+
+    function test_register_notOwner_reverts() public {
+        bytes4[] memory sels = new bytes4[](1);
+        sels[0] = getQuoteSel;
+
+        vm.prank(attacker);
+        vm.expectRevert();
+        registry.register(quoteNode, address(quoteSkill), sels);
+    }
+
+    function test_register_noSelectors_reverts() public {
+        bytes4[] memory sels = new bytes4[](0);
+
+        vm.prank(owner);
+        vm.expectRevert(SkillLink.NoSelectors.selector);
+        registry.register(quoteNode, address(quoteSkill), sels);
+    }
+
+    function test_register_overwrite() public {
+        bytes4[] memory sels = new bytes4[](1);
+        sels[0] = getQuoteSel;
+
+        vm.prank(owner);
+        registry.register(quoteNode, address(quoteSkill), sels);
+
+        // Re-register with new impl
+        vm.prank(owner);
+        registry.register(quoteNode, address(sushiSkill), sels);
+
+        (address impl,,,) = registry.skills(quoteNode);
+        assertEq(impl, address(sushiSkill));
+        // skillCount should still be 1 (update, not new)
+        assertEq(registry.skillCount(), 1);
+    }
+
+    // ── Call tests ───────────────────────────────────────────────────────
+
+    function test_call_success() public {
+        bytes4[] memory sels = new bytes4[](1);
+        sels[0] = getQuoteSel;
+
+        vm.prank(owner);
+        registry.register(quoteNode, address(quoteSkill), sels);
+
+        bytes memory callData = abi.encodeWithSelector(getQuoteSel, "ethereum");
+        bytes memory result = registry.call(quoteNode, callData);
+        uint256 price = abi.decode(result, (uint256));
+        assertEq(price, 2300e6);
+    }
+
+    function test_call_unregistered_reverts() public {
+        bytes memory callData = abi.encodeWithSelector(getQuoteSel, "ethereum");
+        vm.expectRevert(abi.encodeWithSelector(SkillLink.SkillNotRegistered.selector, quoteNode));
+        registry.call(quoteNode, callData);
+    }
+
+    function test_call_forbiddenSelector_reverts() public {
+        bytes4[] memory sels = new bytes4[](1);
+        sels[0] = getQuoteSel; // only allow getQuote
+
+        vm.prank(owner);
+        registry.register(quoteNode, address(quoteSkill), sels);
+
+        bytes memory callData = abi.encodeWithSelector(forbiddenSel);
+        vm.expectRevert(abi.encodeWithSelector(SkillLink.SelectorNotAllowed.selector, quoteNode, forbiddenSel));
+        registry.call(quoteNode, callData);
+    }
+
+    function test_call_forwardsValue() public {
+        bytes4[] memory sels = new bytes4[](1);
+        sels[0] = getQuoteSel;
+
+        vm.prank(owner);
+        registry.register(quoteNode, address(quoteSkill), sels);
+
+        // Call with value (skill doesn't use it but shouldn't revert)
+        bytes memory callData = abi.encodeWithSelector(getQuoteSel, "ethereum");
+        bytes memory result = registry.call{value: 0}(quoteNode, callData);
+        uint256 price = abi.decode(result, (uint256));
+        assertEq(price, 2300e6);
+    }
+
+    // ── Composition test ─────────────────────────────────────────────────
+
+    function test_composition_bestQuote() public {
+        bytes4[] memory sels = new bytes4[](1);
+        sels[0] = getQuoteSel;
+
+        vm.startPrank(owner);
+        registry.register(quoteNode, address(quoteSkill), sels);
+        registry.register(sushiNode, address(sushiSkill), sels);
+        vm.stopPrank();
+
+        BestQuoteAggregator agg = new BestQuoteAggregator(registry, quoteNode, sushiNode);
+        uint256 best = agg.getBestQuote("ethereum");
+        // quoteSkill returns 2300e6, sushiSkill returns 2295e6
+        assertEq(best, 2300e6);
+    }
+
+    // ── View helpers ─────────────────────────────────────────────────────
+
+    function test_getSelectors() public {
+        bytes4[] memory sels = new bytes4[](2);
+        sels[0] = getQuoteSel;
+        sels[1] = forbiddenSel;
+
+        vm.prank(owner);
+        registry.register(quoteNode, address(quoteSkill), sels);
+
+        bytes4[] memory result = registry.getSelectors(quoteNode);
+        assertEq(result.length, 2);
+        assertEq(result[0], getQuoteSel);
+        assertEq(result[1], forbiddenSel);
+    }
+
+    function test_isSelectorAllowed() public {
+        bytes4[] memory sels = new bytes4[](1);
+        sels[0] = getQuoteSel;
+
+        vm.prank(owner);
+        registry.register(quoteNode, address(quoteSkill), sels);
+
+        assertTrue(registry.isSelectorAllowed(quoteNode, getQuoteSel));
+        assertFalse(registry.isSelectorAllowed(quoteNode, forbiddenSel));
+    }
+}

--- a/contracts/test/SkillLink.t.sol
+++ b/contracts/test/SkillLink.t.sol
@@ -239,4 +239,67 @@ contract SkillLinkTest is Test {
         assertTrue(registry.isSelectorAllowed(quoteNode, getQuoteSel));
         assertFalse(registry.isSelectorAllowed(quoteNode, forbiddenSel));
     }
+
+    // ── NameWrapper-wrapped name tests ───────────────────────────────────
+    //
+    // Wrapped names report `ENS_REGISTRY.owner(node)` as the NameWrapper
+    // contract address. The real owner lives on `NameWrapper.ownerOf(uint256(node))`.
+    // SkillLink falls through to NameWrapper in that case — these tests verify it.
+
+    function test_register_wrappedName_success() public {
+        // Etch a mock NameWrapper at the canonical Sepolia address and set
+        // it as the ENS owner of `quoteNode`.
+        address wrapperAddr = 0x0635513f179D50A207757E05759CbD106d7dFcE8;
+        vm.etch(wrapperAddr, address(new MockNameWrapper()).code);
+        MockNameWrapper(wrapperAddr).setOwner(uint256(quoteNode), owner);
+
+        // ENS Registry now reports NameWrapper as the owner of quoteNode.
+        vm.store(
+            address(0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e),
+            keccak256(abi.encode(quoteNode, uint256(0))),
+            bytes32(uint256(uint160(wrapperAddr)))
+        );
+
+        bytes4[] memory sels = new bytes4[](1);
+        sels[0] = getQuoteSel;
+
+        vm.prank(owner);
+        registry.register(quoteNode, address(quoteSkill), sels);
+
+        (address impl, address skillOwner,,) = registry.skills(quoteNode);
+        assertEq(impl, address(quoteSkill));
+        assertEq(skillOwner, owner);
+    }
+
+    function test_register_wrappedName_notWrappedOwner_reverts() public {
+        address wrapperAddr = 0x0635513f179D50A207757E05759CbD106d7dFcE8;
+        vm.etch(wrapperAddr, address(new MockNameWrapper()).code);
+        // Wrap-owner is `owner`, but the attacker is calling.
+        MockNameWrapper(wrapperAddr).setOwner(uint256(quoteNode), owner);
+        vm.store(
+            address(0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e),
+            keccak256(abi.encode(quoteNode, uint256(0))),
+            bytes32(uint256(uint160(wrapperAddr)))
+        );
+
+        bytes4[] memory sels = new bytes4[](1);
+        sels[0] = getQuoteSel;
+
+        vm.prank(attacker);
+        vm.expectRevert();
+        registry.register(quoteNode, address(quoteSkill), sels);
+    }
+}
+
+/// @dev Mock ENS NameWrapper for the wrapped-name test path
+contract MockNameWrapper {
+    mapping(uint256 => address) public _owner;
+
+    function setOwner(uint256 id, address o) external {
+        _owner[id] = o;
+    }
+
+    function ownerOf(uint256 id) external view returns (address) {
+        return _owner[id];
+    }
 }

--- a/docs/SKILLLINK.md
+++ b/docs/SKILLLINK.md
@@ -1,0 +1,133 @@
+# SkillLink — ENS-keyed on-chain skill registry
+
+`SkillLink` makes ENS names directly callable from Solidity. Smart contracts (and EOAs) can invoke a registered skill by its ENS namehash, with a per-name selector allowlist enforced on-chain.
+
+This is the on-chain mirror of the off-chain MCP composition path: the bridge already routes `type:"contract"` execution via viem to a specific impl. The registry lets a contract do the same lookup natively, by ENS name, in a single `call()`.
+
+## Deployment
+
+| Network | Address | Explorer |
+|---|---|---|
+| Sepolia (testnet) | `0xE2532C1dB5FceFA946Ee64D44c22027c070DE8Aa` | [Etherscan](https://sepolia.etherscan.io/address/0xE2532C1dB5FceFA946Ee64D44c22027c070DE8Aa) |
+
+The contract uses two ENS-side constants:
+
+| Role | Address (Sepolia) |
+|---|---|
+| ENS Registry | `0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e` |
+| ENS NameWrapper | `0x0635513f179D50A207757E05759CbD106d7dFcE8` |
+
+## ABI essentials
+
+```solidity
+// Register or update — only callable by the current ENS owner of `node`.
+function register(bytes32 node, address impl, bytes4[] calldata selectors) external;
+
+// Invoke a registered skill by ENS namehash. Forwards msg.value, returns result.
+function call(bytes32 node, bytes calldata data) external payable returns (bytes memory);
+
+// Discovery
+function skills(bytes32 node) external view returns (
+    address impl, address owner, uint96 registeredAt, uint256 selectorBitmap
+);
+function getSelectors(bytes32 node) external view returns (bytes4[] memory);
+function isSelectorAllowed(bytes32 node, bytes4 selector) external view returns (bool);
+function skillCount() external view returns (uint256);
+
+event SkillRegistered(bytes32 indexed node, address indexed impl, address indexed owner, bytes4[] selectors);
+event SkillCalled(bytes32 indexed node, address indexed sender, bytes4 indexed selector, bool success, uint256 gasUsed);
+```
+
+## Capability model
+
+The selector allowlist is the registry's only access-control mechanism. When you `register()`, you commit to exactly which 4-byte function selectors callers can invoke through the registry. `call()` reverts with `SelectorNotAllowed` if asked to forward anything outside the list.
+
+This means the impl contract can have many functions, but only the ones you whitelist at register time are reachable through `SkillLink.call()`. Direct calls to the impl bypass the allowlist — the contract is not a proxy, it's a router with policy.
+
+## Ownership model
+
+Ownership is the ENS name itself. There is no admin role on the registry, no upgradability, no pause switch. The only person who can re-`register()` a skill is whoever currently owns the ENS name in the ENS Registry (or the NameWrapper, for wrapped names).
+
+Rotation is therefore a feature: transferring the ENS name to a new owner gives them sole authority to update the skill's impl and selector list. The registry itself stores nothing about who *should* own the name.
+
+### NameWrapper compatibility
+
+Most modern `.eth` names are wrapped via the ENS NameWrapper. For wrapped names, `ENS_REGISTRY.owner(node)` returns the NameWrapper contract address rather than the actual user. SkillLink handles this:
+
+```solidity
+address ensOwner = ENS_REGISTRY.owner(node);
+if (ensOwner == address(NAME_WRAPPER)) {
+    ensOwner = NAME_WRAPPER.ownerOf(uint256(node));
+}
+require(msg.sender == ensOwner, "not the ENS owner");
+```
+
+If you're porting to mainnet, swap the NameWrapper constant — it's `0xD4416b13d2b3a9aBae7AcD5D6C2BbDBE25686401` on mainnet vs `0x0635513f179D50A207757E05759CbD106d7dFcE8` on Sepolia.
+
+## Composition demo
+
+The `contracts/src/examples/` directory ships three reference contracts that exercise the registry end-to-end:
+
+| Contract | ENS name | Role |
+|---|---|---|
+| `QuoteUniswap` | `quote.uniswap.skilltest.eth` | Mock price oracle, returns `2300e6` for `"ethereum"` |
+| `QuoteSushi` | `quote.sushi.skilltest.eth` | Same shape, returns `2295e6` for `"ethereum"` |
+| `BestQuoteAggregator` | `quote.aggregate.skilltest.eth` | Calls both via `registry.call()`, returns the higher quote |
+
+`BestQuoteAggregator` is itself a registered skill. A third party can call:
+
+```bash
+cast call $SKILLLINK_ADDRESS "call(bytes32,bytes)(bytes)" \
+  $(node="quote.aggregate.skilltest.eth" cast namehash $node) \
+  $(cast calldata "getBestQuote(string)" "ethereum") \
+  --rpc-url $SEPOLIA_RPC_URL
+```
+
+…and the registry dispatches to `BestQuoteAggregator`, which itself dispatches to `QuoteUniswap` and `QuoteSushi` through the registry, which records `SkillCalled` events for each hop. **One external call, three on-chain skill invocations, zero hardcoded addresses below the entry point.**
+
+## Deploying the demo
+
+```bash
+export SEPOLIA_PRIVATE_KEY=0x...                                   # owner of *.skilltest.eth subnames
+export SKILLLINK_ADDRESS=0xE2532C1dB5FceFA946Ee64D44c22027c070DE8Aa # already deployed
+export SEPOLIA_RPC_URL=https://ethereum-sepolia-rpc.publicnode.com
+export ETHERSCAN_API_KEY=...                                       # for source verification
+
+forge script contracts/script/DeployComposition.s.sol \
+  --rpc-url $SEPOLIA_RPC_URL \
+  --broadcast \
+  --verify
+```
+
+The script:
+1. Deploys `QuoteUniswap` and `QuoteSushi`
+2. Registers both in `SkillLink` via `register()`
+3. Deploys `BestQuoteAggregator(registry, uniswapNode, sushiNode)`
+4. Registers the aggregator as `quote.aggregate.skilltest.eth`
+5. Calls `agg.getBestQuote("ethereum")` once and logs the result
+
+If steps 2 or 4 revert with `NotENSOwner`, the wallet doesn't currently own the corresponding `*.skilltest.eth` subname on Sepolia — fix the ENS ownership first, then re-run.
+
+## Bridge integration (planned)
+
+Once a manifest's `execution.address` resolves to a name registered in `SkillLink`, the bridge can opt into routing through the registry by setting `useRegistry: true` on the execution config. This makes off-chain MCP callers benefit from the same selector allowlist + analytics events as on-chain composition, without changing the bundle author's code.
+
+Tracked as the `useRegistry` flag work in [issue #52](https://github.com/hien-p/Skillname/issues/52).
+
+## Analytics integration
+
+The `SkillCalled` event is shaped for the analytics indexer ([issue #15](https://github.com/hien-p/Skillname/issues/15)):
+
+- `node` (indexed): identifies the skill by ENS namehash
+- `sender` (indexed): the calling agent's address
+- `selector` (indexed): which function was invoked
+- `success`: outcome
+- `gasUsed`: cost signal
+
+A Cloudflare Worker tailing this event on Base Sepolia (or wherever paid execution lands) can populate per-skill call count, top callers, and latency distribution without any off-chain coordination.
+
+## Limitations
+
+- **Single-chain (Sepolia).** The contract reads ENS state at the canonical Ethereum Registry address, so it cannot live on a chain without ENS. Cross-chain ENS lookup (CCIP-Read / EIP-3668) is out of scope for now.
+- **Selector bitmap is a Bloom filter, not an index.** The `selectorBitmap` field gives a fast-path negative test using the low 8 bits of the selector. Positive cases still fall through to a linear scan over the full `selectors[]` array. Acceptable while skills declare ≤ a few selectors each; revisit if a skill ever needs > 32 selectors.
+- **No payment-per-call gating.** The registry is free to call. Paid skill invocation continues to route through `keeperhub-paid` / x402 off-chain. A future version could embed payment metering on-chain if the demand justifies the gas overhead.

--- a/docs/SKILLLINK.md
+++ b/docs/SKILLLINK.md
@@ -8,7 +8,7 @@ This is the on-chain mirror of the off-chain MCP composition path: the bridge al
 
 | Network | Address | Explorer |
 |---|---|---|
-| Sepolia (testnet) | `0xE2532C1dB5FceFA946Ee64D44c22027c070DE8Aa` | [Etherscan](https://sepolia.etherscan.io/address/0xE2532C1dB5FceFA946Ee64D44c22027c070DE8Aa) |
+| Sepolia (testnet) | `0x428865D8Dec9Bcc882c9e034DB4c81CBd93293A5` | [Etherscan](https://sepolia.etherscan.io/address/0x428865D8Dec9Bcc882c9e034DB4c81CBd93293A5) |
 
 The contract uses two ENS-side constants:
 
@@ -64,26 +64,29 @@ require(msg.sender == ensOwner, "not the ENS owner");
 
 If you're porting to mainnet, swap the NameWrapper constant — it's `0xD4416b13d2b3a9aBae7AcD5D6C2BbDBE25686401` on mainnet vs `0x0635513f179D50A207757E05759CbD106d7dFcE8` on Sepolia.
 
-## Composition demo
+## Composition demo — live on Sepolia
 
-The `contracts/src/examples/` directory ships three reference contracts that exercise the registry end-to-end:
+The `contracts/src/examples/` directory ships three reference contracts that exercise the registry end-to-end. **All three are deployed and registered as of 2026-05-02** (block 10772628):
 
-| Contract | ENS name | Role |
-|---|---|---|
-| `QuoteUniswap` | `quote.uniswap.skilltest.eth` | Mock price oracle, returns `2300e6` for `"ethereum"` |
-| `QuoteSushi` | `quote.sushi.skilltest.eth` | Same shape, returns `2295e6` for `"ethereum"` |
-| `BestQuoteAggregator` | `quote.aggregate.skilltest.eth` | Calls both via `registry.call()`, returns the higher quote |
+| Contract | ENS name | Address | Role |
+|---|---|---|---|
+| `QuoteUniswap` | `uni.skilltest.eth` | [`0x764a5623…`](https://sepolia.etherscan.io/address/0x764a562320112A5017107FC007a04100ec25Cd42) | Mock price oracle, returns `2300e6` for `"ethereum"` |
+| `QuoteSushi` | `sushi.skilltest.eth` | [`0xca716a62…`](https://sepolia.etherscan.io/address/0xca716a62ed267CB9538db57804e243dd4FBd5545) | Same shape, returns `2295e6` for `"ethereum"` |
+| `BestQuoteAggregator` | `agg.skilltest.eth` | [`0x9Eb87069…`](https://sepolia.etherscan.io/address/0x9Eb870696bcd321A88Dba40eAaC92Ac00fA472f2) | Calls both via `registry.call()`, returns the higher quote |
 
-`BestQuoteAggregator` is itself a registered skill. A third party can call:
+`BestQuoteAggregator` is itself a registered skill. **Anyone with a Sepolia RPC can run this — no key required:**
 
 ```bash
-cast call $SKILLLINK_ADDRESS "call(bytes32,bytes)(bytes)" \
-  $(node="quote.aggregate.skilltest.eth" cast namehash $node) \
+cast call 0x428865D8Dec9Bcc882c9e034DB4c81CBd93293A5 \
+  "call(bytes32,bytes)(bytes)" \
+  $(cast namehash agg.skilltest.eth) \
   $(cast calldata "getBestQuote(string)" "ethereum") \
-  --rpc-url $SEPOLIA_RPC_URL
+  --rpc-url https://ethereum-sepolia-rpc.publicnode.com
 ```
 
-…and the registry dispatches to `BestQuoteAggregator`, which itself dispatches to `QuoteUniswap` and `QuoteSushi` through the registry, which records `SkillCalled` events for each hop. **One external call, three on-chain skill invocations, zero hardcoded addresses below the entry point.**
+Returns `0x…89173700` = **`2300000000`** (= $2300.000000, 6 decimals).
+
+The registry dispatches to `BestQuoteAggregator`, which itself dispatches to `QuoteUniswap` and `QuoteSushi` through the registry, which records `SkillCalled` events for each hop. **One external call, three on-chain skill invocations, zero hardcoded addresses below the entry point.**
 
 ## Deploying the demo
 


### PR DESCRIPTION
## Summary

On-chain skill registry: smart contracts call other contracts by ENS name.

**Deployed:** `0xE2532C1dB5FceFA946Ee64D44c22027c070DE8Aa` on Sepolia
**Etherscan:** https://sepolia.etherscan.io/address/0xE2532C1dB5FceFA946Ee64D44c22027c070DE8Aa

## Contract — `SkillLink.sol`

- `register(node, impl, selectors)` — only ENS name owner can register (verified via ENS Registry)
- `call(node, data)` — selector allowlist check + forward to impl + emit analytics event
- `SkillRegistered` + `SkillCalled` events — feeds #15 analytics indexer

## Tests — 11/11 pass

| Test | What it proves |
|---|---|
| register_success | ENS owner can register |
| register_notOwner_reverts | Non-owner rejected |
| register_noSelectors_reverts | Empty selectors rejected |
| register_overwrite | Re-register updates impl |
| call_success | Skill returns correct data |
| call_unregistered_reverts | Unregistered skill rejected |
| call_forbiddenSelector_reverts | Unlisted selector rejected |
| call_forwardsValue | msg.value forwarded |
| composition_bestQuote | **Skill calls skill via registry** |
| getSelectors | View helper |
| isSelectorAllowed | View helper |

## Prize track angles

- **ENS Best AI Integration**: contracts discover + call skills by ENS name at runtime
- **ENS Most Creative**: selector allowlist as capability tokens, ENS ownership = publish authority

Closes #52 (Phase 1)