### PR TITLE
fix(bridge): accept recipient_address alias in execute_transfer

### DIFF
--- a/skillname-pack/packages/bridge/src/keeperhub.ts
+++ b/skillname-pack/packages/bridge/src/keeperhub.ts
@@ -109,7 +109,11 @@ export async function executeViaKeeperHub(
     // Simple token transfer — different args shape
     const transferArgs: Record<string, string> = {
       network: String(chainId),
-      to: (args.to as string) ?? "",
+      to:
+        (args.to as string) ??
+        (args.recipient_address as string) ??
+        (args.recipient as string) ??
+        "",
       amount: (args.amount as string) ?? "",
       token: (args.token as string) ?? "USDC",
     };
@@ -189,7 +193,11 @@ async function executeViaPaidServer(
 
   const khTool = exec.tool ?? "execute_contract_call";
   if (khTool === "execute_transfer") {
-    body.to = (args.to as string) ?? "";
+    body.to =
+      (args.to as string) ??
+      (args.recipient_address as string) ??
+      (args.recipient as string) ??
+      "";
     body.amount = (args.amount as string) ?? "";
     body.token = (args.token as string) ?? "USDC";
   } else {


### PR DESCRIPTION
Claude Desktop renames `to` to `recipient_address` in some calls. Bridge now accepts `to`, `recipient_address`, or `recipient` as the destination field — both free and paid paths.

Tested in Claude Desktop: x402 payment flow reaches KeeperHub successfully.