### PR TITLE
feat(bridge,cli): SkillLink registry routing — useRegistry flag + register-onchain verb

### DIFF
--- a/skillname-pack/packages/bridge/src/server.ts
+++ b/skillname-pack/packages/bridge/src/server.ts
@@ -616,7 +616,7 @@ function bigintSafeReplacer(_k: string, v: unknown) {
 const SKILLLINK_BY_CHAIN: Record<number, `0x${string}`> = {
   // Sepolia: see contracts/script/Deploy.s.sol output. Update after redeploy
   // with the NameWrapper-aware version.
-  11155111: "0xE2532C1dB5FceFA946Ee64D44c22027c070DE8Aa",
+  11155111: "0x428865D8Dec9Bcc882c9e034DB4c81CBd93293A5",
 };
 
 const SKILLLINK_CALL_ABI = [

--- a/skillname-pack/packages/bridge/src/server.ts
+++ b/skillname-pack/packages/bridge/src/server.ts
@@ -39,9 +39,12 @@ import {
 import {
   createPublicClient,
   createWalletClient,
+  decodeFunctionResult,
+  encodeFunctionData,
   getAbiItem,
   http,
   isAddress,
+  namehash,
   type Abi,
   type AbiFunction,
   type Chain,
@@ -608,6 +611,27 @@ function bigintSafeReplacer(_k: string, v: unknown) {
   return typeof v === "bigint" ? v.toString() : v;
 }
 
+// SkillLink registry — canonical deployments per chainId. Override per-tool
+// via exec.registry on the manifest if you need a different one.
+const SKILLLINK_BY_CHAIN: Record<number, `0x${string}`> = {
+  // Sepolia: see contracts/script/Deploy.s.sol output. Update after redeploy
+  // with the NameWrapper-aware version.
+  11155111: "0xE2532C1dB5FceFA946Ee64D44c22027c070DE8Aa",
+};
+
+const SKILLLINK_CALL_ABI = [
+  {
+    type: "function",
+    name: "call",
+    stateMutability: "payable",
+    inputs: [
+      { name: "node", type: "bytes32" },
+      { name: "data", type: "bytes" },
+    ],
+    outputs: [{ name: "result", type: "bytes" }],
+  },
+] as const;
+
 async function resolveContractAddress(
   client: ReturnType<typeof getPublicClient>,
   addrOrEns: string,
@@ -656,6 +680,117 @@ function mapArgsViaAbi(
   return order.map((k) => args[k]);
 }
 
+async function executeViaRegistry(
+  client: ReturnType<typeof getPublicClient>,
+  exec: Extract<Tool["execution"], { type: "contract" }>,
+  callArgs: unknown[],
+  mode: "read" | "write",
+) {
+  if (!exec.address.endsWith(".eth")) {
+    log.err(`useRegistry: true requires .eth address, got ${exec.address}`);
+    return {
+      content: [
+        {
+          type: "text",
+          text: `useRegistry: true requires exec.address to be an ENS name (.eth). Got "${exec.address}".`,
+        },
+      ],
+      isError: true,
+    };
+  }
+
+  const registryAddr =
+    (exec.registry as `0x${string}` | undefined) ??
+    SKILLLINK_BY_CHAIN[exec.chainId];
+  if (!registryAddr) {
+    log.err(`no SkillLink address known for chainId ${exec.chainId}`);
+    return {
+      content: [
+        {
+          type: "text",
+          text: `No canonical SkillLink address for chainId ${exec.chainId}. Set exec.registry explicitly on the manifest.`,
+        },
+      ],
+      isError: true,
+    };
+  }
+
+  const node = namehash(exec.address);
+  const innerCalldata = encodeFunctionData({
+    abi: exec.abi as Abi,
+    functionName: exec.method,
+    args: callArgs,
+  });
+
+  log.info(
+    `via SkillLink ${registryAddr} → node ${node.slice(0, 10)}… inner ${innerCalldata.slice(0, 10)}…`,
+  );
+
+  if (mode === "read") {
+    const t0 = Date.now();
+    const { result } = await client.simulateContract({
+      address: registryAddr,
+      abi: SKILLLINK_CALL_ABI,
+      functionName: "call",
+      args: [node, innerCalldata],
+    });
+    // SkillLink.call returns the raw bytes from the impl — decode against the
+    // bundle's ABI so the user sees a typed result, not 0x-encoded bytes.
+    const decoded = decodeFunctionResult({
+      abi: exec.abi as Abi,
+      functionName: exec.method,
+      data: result as `0x${string}`,
+    });
+    log.ok(`registry.read ${exec.method} done in ${Date.now() - t0}ms`);
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(decoded, bigintSafeReplacer, 2),
+        },
+      ],
+    };
+  }
+
+  // write — signed via AGENT_WALLET_PRIVATE_KEY, fires SkillCalled event
+  if (!AGENT_WALLET_PRIVATE_KEY) {
+    log.err(`AGENT_WALLET_PRIVATE_KEY not set — cannot sign registry.write`);
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Cannot execute registry.write: AGENT_WALLET_PRIVATE_KEY not set in bridge env.`,
+        },
+      ],
+      isError: true,
+    };
+  }
+  const account = privateKeyToAccount(
+    AGENT_WALLET_PRIVATE_KEY as `0x${string}`,
+  );
+  const chain = CHAIN_BY_ID[exec.chainId];
+  const wallet = createWalletClient({ account, chain, transport: http() });
+  const t0 = Date.now();
+  const txHash = await wallet.writeContract({
+    address: registryAddr,
+    abi: SKILLLINK_CALL_ABI,
+    functionName: "call",
+    args: [node, innerCalldata],
+    chain,
+  });
+  log.ok(
+    `registry.write ${exec.method} → ${txHash} in ${Date.now() - t0}ms (SkillCalled event fires)`,
+  );
+  return {
+    content: [
+      {
+        type: "text",
+        text: `Transaction sent via SkillLink registry: ${txHash}`,
+      },
+    ],
+  };
+}
+
 async function executeContract(
   tool: Tool,
   args: Record<string, unknown>,
@@ -672,7 +807,6 @@ async function executeContract(
 
   try {
     const client = getPublicClient(exec.chainId);
-    const address = await resolveContractAddress(client, exec.address);
 
     // Map the named-args object onto positional args using the ABI as the
     // canonical source of order: read the matching AbiFunction's `inputs[].name`,
@@ -680,6 +814,16 @@ async function executeContract(
     // for ABIs that lack the function entry (rare; e.g. proxy patterns where the
     // method dispatches through a fallback). Fails loud on missing args.
     const callArgs = mapArgsViaAbi(exec.abi as Abi, exec.method, args, tool);
+
+    // ── Registry-routed dispatch (opt-in via useRegistry: true) ────────────
+    // Goes through SkillLink.call(namehash(address), encodedCalldata) instead
+    // of the direct impl. Adds the on-chain selector allowlist + SkillCalled
+    // analytics event for paths that traverse a real tx (write mode).
+    if (exec.useRegistry) {
+      return await executeViaRegistry(client, exec, callArgs, mode);
+    }
+
+    const address = await resolveContractAddress(client, exec.address);
 
     if (mode === "read") {
       const t0 = Date.now();

--- a/skillname-pack/packages/cli/src/commands/register-onchain.ts
+++ b/skillname-pack/packages/cli/src/commands/register-onchain.ts
@@ -1,0 +1,129 @@
+/**
+ * skill register-onchain — register a deployed impl in the SkillLink registry.
+ *
+ * Wraps a single `cast send SkillLink.register(node, impl, selectors)` call
+ * with ENS namehash computation and selector parsing.
+ *
+ * Usage:
+ *   skill register-onchain <ensName> --impl 0x… --selectors 0xa9059cbb,0x70a08231
+ *
+ * Required env:
+ *   SEPOLIA_PRIVATE_KEY  — must be the current owner of the ENS name
+ *
+ * Optional env:
+ *   SEPOLIA_RPC_URL      — default: https://ethereum-sepolia-rpc.publicnode.com
+ *   SKILLLINK_ADDRESS    — default: hardcoded canonical Sepolia deployment
+ */
+
+import "dotenv/config";
+import {
+  createPublicClient,
+  createWalletClient,
+  http,
+  isAddress,
+  isHex,
+  namehash,
+  parseAbi,
+  type Hex,
+} from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+import { sepolia } from "viem/chains";
+
+const SKILLLINK_DEFAULT: `0x${string}` =
+  "0xE2532C1dB5FceFA946Ee64D44c22027c070DE8Aa";
+
+const SKILLLINK_ABI = parseAbi([
+  "function register(bytes32 node, address impl, bytes4[] selectors) external",
+  "function skills(bytes32 node) external view returns (address impl, address owner, uint96 registeredAt, uint256 selectorBitmap)",
+]);
+
+export interface RegisterOnchainOpts {
+  impl: string;
+  selectors: string[];
+  registry?: string;
+  rpcUrl?: string;
+}
+
+export async function registerOnchain(ensName: string, opts: RegisterOnchainOpts): Promise<void> {
+  if (!ensName.endsWith(".eth")) {
+    throw new Error(`ensName must end with .eth, got "${ensName}"`);
+  }
+  if (!isAddress(opts.impl)) {
+    throw new Error(`--impl must be a 0x-prefixed address, got "${opts.impl}"`);
+  }
+  if (opts.selectors.length === 0) {
+    throw new Error(`--selectors must be a comma-separated list of 4-byte hex strings`);
+  }
+  for (const sel of opts.selectors) {
+    if (!isHex(sel) || sel.length !== 10) {
+      throw new Error(
+        `selector "${sel}" must be a 4-byte hex string (0x + 8 hex chars), e.g. 0xa9059cbb`,
+      );
+    }
+  }
+
+  const privateKey = process.env.SEPOLIA_PRIVATE_KEY;
+  if (!privateKey) {
+    throw new Error("SEPOLIA_PRIVATE_KEY not set in environment");
+  }
+
+  const rpcUrl =
+    opts.rpcUrl ??
+    process.env.SEPOLIA_RPC_URL ??
+    "https://ethereum-sepolia-rpc.publicnode.com";
+
+  const registry =
+    (opts.registry as `0x${string}` | undefined) ??
+    (process.env.SKILLLINK_ADDRESS as `0x${string}` | undefined) ??
+    SKILLLINK_DEFAULT;
+
+  const account = privateKeyToAccount(privateKey as `0x${string}`);
+  const publicClient = createPublicClient({
+    chain: sepolia,
+    transport: http(rpcUrl),
+  });
+  const wallet = createWalletClient({
+    account,
+    chain: sepolia,
+    transport: http(rpcUrl),
+  });
+
+  const node = namehash(ensName);
+  const selectors = opts.selectors as Hex[];
+
+  console.log(`skill register-onchain ${ensName}`);
+  console.log(`  registry:  ${registry}`);
+  console.log(`  ens:       ${ensName}`);
+  console.log(`  node:      ${node}`);
+  console.log(`  impl:      ${opts.impl}`);
+  console.log(`  selectors: ${selectors.join(", ")}`);
+  console.log(`  signer:    ${account.address}`);
+  console.log();
+
+  const txHash = await wallet.writeContract({
+    address: registry,
+    abi: SKILLLINK_ABI,
+    functionName: "register",
+    args: [node, opts.impl as `0x${string}`, selectors],
+  });
+  console.log(`  → tx ${txHash}`);
+  console.log(`  waiting for confirmation…`);
+
+  const receipt = await publicClient.waitForTransactionReceipt({ hash: txHash });
+  if (receipt.status !== "success") {
+    throw new Error(`tx reverted: https://sepolia.etherscan.io/tx/${txHash}`);
+  }
+
+  // Verify by reading back
+  const skill = await publicClient.readContract({
+    address: registry,
+    abi: SKILLLINK_ABI,
+    functionName: "skills",
+    args: [node],
+  });
+
+  console.log(`  ✓ registered at block ${receipt.blockNumber}`);
+  console.log(`  ✓ skill.impl  = ${skill[0]}`);
+  console.log(`  ✓ skill.owner = ${skill[1]}`);
+  console.log(`  https://sepolia.etherscan.io/tx/${txHash}`);
+}

--- a/skillname-pack/packages/cli/src/index.ts
+++ b/skillname-pack/packages/cli/src/index.ts
@@ -5,30 +5,36 @@
  * CLI for the skillname ENS skill registry.
  *
  * Usage:
- *   skill resolve <ensName> [--chain mainnet|sepolia] [--json]
- *   skill verify  <ensName> [--chain mainnet|sepolia]
- *   skill init    <name>
- *   skill publish <dir> <ensName>
- *   skill lock    <ensName>
+ *   skill resolve          <ensName> [--chain mainnet|sepolia] [--json]
+ *   skill verify           <ensName> [--chain mainnet|sepolia]
+ *   skill init             <name>
+ *   skill register-onchain <ensName> --impl 0x… --selectors 0xa9059cbb,0x70a08231
+ *   skill publish          <dir> <ensName>
+ *   skill lock             <ensName>
  */
 
 import { resolve } from "./commands/resolve.js";
 import { verify } from "./commands/verify.js";
 import { init } from "./commands/init.js";
+import { registerOnchain } from "./commands/register-onchain.js";
 
 const HELP = `
 skill — ENS-native skill registry CLI
 
 Commands:
-  resolve <ensName>   Resolve an ENS name to its skill bundle
-  verify  <ensName>   Validate schema + ENSIP-25 trust for a skill
-  init    <name>      Scaffold a new skill bundle directory
-  publish <dir> <ens> Publish a bundle to IPFS + set ENS text records
-  lock    <ensName>   Generate a lockfile from skill imports
+  resolve          <ensName>   Resolve an ENS name to its skill bundle
+  verify           <ensName>   Validate schema + ENSIP-25 trust for a skill
+  init             <name>      Scaffold a new skill bundle directory
+  register-onchain <ensName>   Register a deployed impl in the SkillLink registry
+  publish          <dir> <ens> Publish a bundle to IPFS + set ENS text records
+  lock             <ensName>   Generate a lockfile from skill imports
 
 Options:
   --chain <chain>     Chain to resolve on (mainnet | sepolia, default: sepolia)
   --json              Output raw JSON instead of formatted text
+  --impl <addr>       Implementation contract address (register-onchain)
+  --selectors <list>  Comma-separated 4-byte hex selectors (register-onchain)
+  --registry <addr>   Override SkillLink registry address (register-onchain)
   --help, -h          Show this help
 
 Examples:
@@ -36,6 +42,8 @@ Examples:
   skill resolve quote.uniswap.eth --chain mainnet --json
   skill verify swap.uniswap.eth
   skill init my-skill
+  skill register-onchain quote.uniswap.skilltest.eth \\
+    --impl 0x1234… --selectors 0xa9059cbb
 `.trim();
 
 function parseArgs(argv: string[]) {
@@ -52,6 +60,12 @@ function parseArgs(argv: string[]) {
       flags.json = true;
     } else if (arg === "--chain" && i + 1 < args.length) {
       flags.chain = args[++i];
+    } else if (arg === "--impl" && i + 1 < args.length) {
+      flags.impl = args[++i];
+    } else if (arg === "--selectors" && i + 1 < args.length) {
+      flags.selectors = args[++i];
+    } else if (arg === "--registry" && i + 1 < args.length) {
+      flags.registry = args[++i];
     } else if (arg.startsWith("--")) {
       // Unknown flag — skip
       console.error(`Unknown flag: ${arg}`);
@@ -103,6 +117,23 @@ async function main() {
         process.exit(1);
       }
       await init(positional[0]);
+      break;
+
+    case "register-onchain":
+      if (!positional[0] || !flags.impl || !flags.selectors) {
+        console.error(
+          "Usage: skill register-onchain <ensName> --impl 0x… --selectors 0xa9059cbb[,0x…]",
+        );
+        process.exit(1);
+      }
+      await registerOnchain(positional[0], {
+        impl: String(flags.impl),
+        selectors: String(flags.selectors)
+          .split(",")
+          .map((s) => s.trim())
+          .filter(Boolean),
+        registry: flags.registry ? String(flags.registry) : undefined,
+      });
       break;
 
     case "publish":

--- a/skillname-pack/packages/schema/skill-v1.schema.json
+++ b/skillname-pack/packages/schema/skill-v1.schema.json
@@ -231,6 +231,16 @@
           "default": "read",
           "description": "read = eth_call (free, view/pure); write = transaction (signer or KeeperHub)"
         },
+        "useRegistry": {
+          "type": "boolean",
+          "default": false,
+          "description": "If true, the bridge dispatches through SkillLink.call(namehash(address), calldata) instead of calling the impl directly. Requires `address` to be an ENS name registered in the registry. Adds the on-chain selector allowlist + SkillCalled analytics event to off-chain MCP calls."
+        },
+        "registry": {
+          "type": "string",
+          "pattern": "^0x[a-fA-F0-9]{40}$",
+          "description": "Optional override for the SkillLink registry address. If omitted, the bridge uses its hardcoded canonical deployment per chainId."
+        },
         "payment": { "$ref": "#/definitions/Payment" }
       }
     },

--- a/skillname-pack/packages/sdk/src/index.ts
+++ b/skillname-pack/packages/sdk/src/index.ts
@@ -85,6 +85,18 @@ export type Execution =
       abi: readonly unknown[];
       method: string;
       mode?: "read" | "write";
+      /**
+       * If true, dispatch through SkillLink.call(namehash(address), calldata)
+       * instead of calling the impl directly. Requires `address` to be an ENS
+       * name registered in the registry. Adds the on-chain selector allowlist
+       * + SkillCalled analytics event to off-chain MCP calls.
+       */
+      useRegistry?: boolean;
+      /**
+       * Optional override for the SkillLink registry address. Falls back to
+       * the bridge's canonical deployment per chainId when omitted.
+       */
+      registry?: string;
       payment?: Payment;
     };
 


### PR DESCRIPTION
## Summary

Closes the off-chain integration half of [#52](https://github.com/hien-p/Skillname/issues/52) Phase 1. Off-chain MCP callers can now opt into on-chain dispatch via the `SkillLink` registry, and bundle authors get a one-shot CLI to register their impls without writing `cast` invocations by hand.

## Changes

**Schema** — `ContractExecution` gains two optional fields:

| Field | Type | Effect |
|---|---|---|
| `useRegistry` | `boolean` | Route through `SkillLink.call(namehash(address), calldata)` instead of calling the impl directly. Requires `address` to be a `*.eth` ENS name. |
| `registry` | `address` | Override the bridge's canonical SkillLink address per chainId. |

**SDK** — matching type extension on the `Execution` union (keeps the "all three layers must agree" rule from `CLAUDE.md`).

**Bridge** — new `executeViaRegistry()`:
- Computes `namehash(exec.address)` and encodes the inner calldata via `encodeFunctionData`
- Dispatches through `SkillLink.call(node, calldata)` instead of the impl directly
- Read mode uses `simulateContract` + `decodeFunctionResult` against the bundle's original ABI so the caller still gets a typed result, not raw 0x-bytes
- Write mode signs via `AGENT_WALLET_PRIVATE_KEY` — fires the `SkillCalled` analytics event on-chain
- `SKILLLINK_BY_CHAIN` map seeded with the existing Sepolia deploy (`0xE2532C1d…`); update after the NameWrapper-aware redeploy lands
- Rejects non-`.eth` addresses and chainIds with no canonical SkillLink (unless `exec.registry` is provided)

**CLI** — new `skill register-onchain` verb:
```bash
skill register-onchain quote.uniswap.skilltest.eth \\
  --impl 0x1234… --selectors 0xa9059cbb,0x70a08231
```
- Computes `namehash(ensName)`, validates `impl` and 4-byte selectors
- Signs `SkillLink.register(node, impl, selectors)` via `SEPOLIA_PRIVATE_KEY`
- Reads back `skills(node)` to confirm `impl` + `owner` after the tx
- Wired into `src/index.ts` + help

## Test plan

- [x] `tsc` clean across `@skillname/sdk`, `@skillname/bridge`, `@skillname/cli`
- [x] CLI `--help` renders correctly
- [x] CLI `register-onchain` without args prints usage hint
- [ ] Manual: after the SkillLink redeploy in #52, run `skill register-onchain` against one of the reference impls and confirm the `SkillRegistered` event fires
- [ ] Manual: author a `type:"contract"` manifest with `useRegistry: true` pointing at `quote.aggregate.skilltest.eth`, import via `skill_import`, call via `skill_call`, observe a `SkillCalled` event in the resulting tx receipt

## Dependencies

- The on-chain composition demo from #52 (currently in PR #53) needs to land first for the manual test plan to mean anything — the registry has to actually contain registered skills before the bridge can dispatch through it
- Once #56 (ENSIP-25 binding) ships, this same registry-routed path will surface verified-identity results in the bridge's structured output