### PR TITLE
feat: scaffold analytics indexer (#15) + ENSIP-25 binding script (#56)

### DIFF
--- a/apps/analytics/README.md
+++ b/apps/analytics/README.md
@@ -1,0 +1,93 @@
+# skillname analytics indexer
+
+Cloudflare Worker that tails `SkillCalled` events from the SkillLink registry on Sepolia, aggregates per-skill stats into KV, and serves them via a small HTTP API. Scaffolds [issue #15](https://github.com/hien-p/Skillname/issues/15).
+
+## Architecture
+
+```
+cron (1m)              Sepolia RPC               KV
+   │                       │                      │
+   └─→ scan(fromBlock)──→  eth_getLogs ──→ ingest each log:
+                           topics=[SkillCalled]    update skill:<node>
+                                                    {calls, gas, top_callers}
+   │
+   └─→ persist `_cursor:last_scanned_block`
+
+HTTP                                              KV
+GET /skill/:node      ─────────────────────→  read skill:<node> → JSON
+GET /skills?limit=N   ─→ list skill:* → sort by calls_24h desc
+GET /health           ─→ {ok: true}
+```
+
+`SkillCalled` is the registry's per-call event:
+
+```solidity
+event SkillCalled(
+    bytes32 indexed node,
+    address indexed sender,
+    bytes4  indexed selector,
+    bool    success,
+    uint256 gasUsed
+);
+```
+
+## Setup
+
+```bash
+cd apps/analytics
+pnpm install
+
+# 1. Create the KV namespace
+wrangler kv:namespace create SKILL_STATS
+# Copy the printed `id =` value into wrangler.toml under [[kv_namespaces]].
+
+# 2. Deploy
+wrangler deploy
+```
+
+Once deployed, the cron handler runs every minute, scanning up to 1000 new blocks per run, capped at the chain head. The cursor is persisted in KV so restarts and Worker invocations don't double-count.
+
+## HTTP API
+
+- `GET /skill/:node` — JSON stats for one skill, where `:node` is the bytes32 ENS namehash (e.g. `0xa1b2c3…`)
+
+  ```json
+  {
+    "node": "0xa1b2c3…",
+    "calls_total": 42,
+    "calls_24h": 7,
+    "calls_7d": 31,
+    "gas_total": "1234567",
+    "top_callers": [
+      { "addr": "0xdead…", "count": 14 },
+      { "addr": "0xbeef…", "count": 9 }
+    ],
+    "last_block": 10769453,
+    "last_seen_at": 1746162831
+  }
+  ```
+
+  If the skill has never been called, returns zero-valued struct (not 404).
+
+- `GET /skills?limit=10` — top N skills by `calls_24h`
+
+- `GET /health` — `{ ok: true, version: "0.0.1" }`
+
+## Updating after the SkillLink redeploy
+
+When the NameWrapper-aware version of SkillLink ships from #52, update three values in `wrangler.toml`:
+
+```toml
+[vars]
+SKILLLINK_ADDRESS = "0xNEW…"
+START_BLOCK = "<block_of_new_deploy>"
+```
+
+Then `wrangler kv:key delete --binding=SKILL_STATS _cursor:last_scanned_block` to reset the indexer cursor, and `wrangler deploy`. The Worker re-scans from the new deploy block.
+
+## Limitations (intentional, hackathon scope)
+
+- **Sliding windows are crude** — `calls_24h` and `calls_7d` increment on every event but never decay. A future pass could implement proper window decay via a separate cron sweep.
+- **No native ENS reverse-resolution** for `top_callers` — addresses are stored as hex. Frontend can resolve them via the SDK if needed.
+- **Single-chain (Sepolia)** — same constraint as the SkillLink contract itself. Cross-chain events would need separate Workers per chain.
+- **No retention policy** — KV records grow unbounded. Fine for demo (small N), needs eviction for production.

--- a/apps/analytics/package.json
+++ b/apps/analytics/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@skillname/analytics",
+  "version": "0.0.1",
+  "description": "Cloudflare Worker that indexes SkillCalled events from the SkillLink registry into KV.",
+  "license": "MIT",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "tail": "wrangler tail"
+  },
+  "dependencies": {
+    "viem": "^2.21.55"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20240909.0",
+    "typescript": "^5.9.3",
+    "wrangler": "^3.78.0"
+  }
+}

--- a/apps/analytics/src/index.ts
+++ b/apps/analytics/src/index.ts
@@ -1,0 +1,217 @@
+/**
+ * skillname analytics indexer
+ *
+ * Cron-driven Cloudflare Worker that tails `SkillCalled` events from the
+ * SkillLink registry on Sepolia, aggregates per-skill stats into KV, and
+ * serves them via a small HTTP API.
+ *
+ * Aggregations per `node` (ENS namehash):
+ *   - calls_total              : lifetime invocations
+ *   - calls_24h / calls_7d     : sliding window counters
+ *   - gas_total                : sum of `gasUsed` from the event
+ *   - top_callers              : top 5 sender addresses by call count
+ *   - last_block               : highest block we've scanned for this skill
+ *
+ * HTTP routes:
+ *   GET  /skill/:node          → JSON stats for one skill (node is 0x… namehash)
+ *   GET  /skills               → top N skills by calls_24h
+ *   GET  /health               → liveness
+ */
+
+import { decodeEventLog, getAbiItem, keccak256, toBytes, type Hex } from "viem";
+
+interface Env {
+  SKILL_STATS: KVNamespace;
+  SKILLLINK_ADDRESS: string;
+  SEPOLIA_RPC_URL: string;
+  START_BLOCK: string;
+}
+
+interface SkillStats {
+  node: string;
+  calls_total: number;
+  calls_24h: number;
+  calls_7d: number;
+  gas_total: string; // BigInt-as-string
+  top_callers: { addr: string; count: number }[];
+  last_block: number;
+  last_seen_at?: number; // unix seconds
+}
+
+const SKILL_CALLED_EVENT = {
+  type: "event",
+  name: "SkillCalled",
+  inputs: [
+    { name: "node", type: "bytes32", indexed: true },
+    { name: "sender", type: "address", indexed: true },
+    { name: "selector", type: "bytes4", indexed: true },
+    { name: "success", type: "bool", indexed: false },
+    { name: "gasUsed", type: "uint256", indexed: false },
+  ],
+} as const;
+
+// Pre-computed keccak topic for filtering.
+const SKILL_CALLED_TOPIC = keccak256(
+  toBytes("SkillCalled(bytes32,address,bytes4,bool,uint256)"),
+);
+
+// Cursor key — the last block we've scanned globally (per-skill last_block is
+// stored on each skill record).
+const CURSOR_KEY = "_cursor:last_scanned_block";
+
+// ── HTTP handler ──────────────────────────────────────────────────────────
+
+export default {
+  async fetch(req: Request, env: Env): Promise<Response> {
+    const url = new URL(req.url);
+    const cors = {
+      "access-control-allow-origin": "*",
+      "content-type": "application/json",
+    };
+
+    if (url.pathname === "/health") {
+      return Response.json({ ok: true, version: "0.0.1" }, { headers: cors });
+    }
+
+    if (url.pathname.startsWith("/skill/")) {
+      const node = url.pathname.slice("/skill/".length);
+      if (!/^0x[0-9a-f]{64}$/i.test(node)) {
+        return Response.json(
+          { error: `node must be a bytes32 namehash (0x + 64 hex)` },
+          { status: 400, headers: cors },
+        );
+      }
+      const raw = await env.SKILL_STATS.get(`skill:${node.toLowerCase()}`);
+      if (!raw) {
+        return Response.json(
+          { node, calls_total: 0, calls_24h: 0, calls_7d: 0, gas_total: "0", top_callers: [], last_block: 0 },
+          { headers: cors },
+        );
+      }
+      return new Response(raw, { headers: cors });
+    }
+
+    if (url.pathname === "/skills") {
+      const limit = Number(url.searchParams.get("limit") ?? 10);
+      const list = await env.SKILL_STATS.list({ prefix: "skill:" });
+      const stats: SkillStats[] = [];
+      for (const k of list.keys) {
+        const raw = await env.SKILL_STATS.get(k.name);
+        if (raw) stats.push(JSON.parse(raw));
+      }
+      stats.sort((a, b) => b.calls_24h - a.calls_24h);
+      return Response.json(stats.slice(0, limit), { headers: cors });
+    }
+
+    return Response.json({ error: "not found" }, { status: 404, headers: cors });
+  },
+
+  // ── Scheduled handler ───────────────────────────────────────────────────
+
+  async scheduled(_event: ScheduledEvent, env: Env, ctx: ExecutionContext) {
+    ctx.waitUntil(scan(env));
+  },
+};
+
+// ── Indexer core ──────────────────────────────────────────────────────────
+
+async function scan(env: Env): Promise<void> {
+  const cursor = await env.SKILL_STATS.get(CURSOR_KEY);
+  const fromBlock = cursor ? Number(cursor) + 1 : Number(env.START_BLOCK);
+
+  // Get the chain head — cap our window at 1000 blocks per run so we don't
+  // exhaust subrequest limits or hit RPC log caps.
+  const head = await rpc(env.SEPOLIA_RPC_URL, "eth_blockNumber", []);
+  const headNum = Number(head);
+  const toBlock = Math.min(headNum, fromBlock + 1000);
+
+  if (toBlock < fromBlock) return; // nothing new
+
+  const logs: Log[] = await rpc(env.SEPOLIA_RPC_URL, "eth_getLogs", [
+    {
+      address: env.SKILLLINK_ADDRESS,
+      topics: [SKILL_CALLED_TOPIC],
+      fromBlock: `0x${fromBlock.toString(16)}`,
+      toBlock: `0x${toBlock.toString(16)}`,
+    },
+  ]);
+
+  for (const log of logs) {
+    await ingest(log, env);
+  }
+
+  await env.SKILL_STATS.put(CURSOR_KEY, String(toBlock));
+}
+
+interface Log {
+  topics: string[];
+  data: string;
+  blockNumber: string;
+  transactionHash: string;
+  address: string;
+}
+
+async function ingest(log: Log, env: Env): Promise<void> {
+  const { args } = decodeEventLog({
+    abi: [SKILL_CALLED_EVENT],
+    data: log.data as Hex,
+    topics: log.topics as [Hex, ...Hex[]],
+  });
+  const node = (args.node as string).toLowerCase();
+  const sender = (args.sender as string).toLowerCase();
+  const gasUsed = args.gasUsed as bigint;
+  const blockNum = Number(log.blockNumber);
+  const nowSec = Math.floor(Date.now() / 1000);
+
+  const key = `skill:${node}`;
+  const existing = await env.SKILL_STATS.get(key);
+  const stats: SkillStats = existing
+    ? JSON.parse(existing)
+    : {
+        node,
+        calls_total: 0,
+        calls_24h: 0,
+        calls_7d: 0,
+        gas_total: "0",
+        top_callers: [],
+        last_block: 0,
+      };
+
+  // Idempotency — never count the same block twice for the same skill.
+  if (blockNum <= stats.last_block) return;
+
+  stats.calls_total += 1;
+  stats.calls_24h += 1; // decay is approximate — a future Worker pass can
+  stats.calls_7d += 1; //   sweep windows; demo-acceptable for now
+  stats.gas_total = (BigInt(stats.gas_total) + gasUsed).toString();
+  stats.last_block = blockNum;
+  stats.last_seen_at = nowSec;
+
+  // Update top callers (cap at 5)
+  const existingIdx = stats.top_callers.findIndex((c) => c.addr === sender);
+  if (existingIdx >= 0) {
+    stats.top_callers[existingIdx].count += 1;
+  } else {
+    stats.top_callers.push({ addr: sender, count: 1 });
+  }
+  stats.top_callers.sort((a, b) => b.count - a.count);
+  stats.top_callers = stats.top_callers.slice(0, 5);
+
+  await env.SKILL_STATS.put(key, JSON.stringify(stats));
+}
+
+// ── JSON-RPC helper ───────────────────────────────────────────────────────
+
+async function rpc<T = unknown>(url: string, method: string, params: unknown[]): Promise<T> {
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+  });
+  const body = (await res.json()) as { result?: T; error?: { message: string } };
+  if (body.error) throw new Error(`${method} failed: ${body.error.message}`);
+  return body.result as T;
+}
+
+// Ensure dev imports aren't tree-shaken
+void getAbiItem;

--- a/apps/analytics/tsconfig.json
+++ b/apps/analytics/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "types": ["@cloudflare/workers-types"],
+    "moduleResolution": "Bundler",
+    "module": "ESNext",
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}

--- a/apps/analytics/wrangler.toml
+++ b/apps/analytics/wrangler.toml
@@ -1,0 +1,23 @@
+name = "skillname-analytics"
+main = "src/index.ts"
+compatibility_date = "2026-01-01"
+compatibility_flags = ["nodejs_compat"]
+
+# KV namespace for skill aggregations.
+# Create with: wrangler kv:namespace create SKILL_STATS
+# then paste the id below.
+[[kv_namespaces]]
+binding = "SKILL_STATS"
+id = "REPLACE_WITH_KV_NAMESPACE_ID"
+
+# Scheduled trigger — every minute scan for new SkillCalled events.
+[triggers]
+crons = ["* * * * *"]
+
+[vars]
+# SkillLink registry on Sepolia. Update post-NameWrapper-aware redeploy.
+SKILLLINK_ADDRESS = "0xE2532C1dB5FceFA946Ee64D44c22027c070DE8Aa"
+SEPOLIA_RPC_URL = "https://ethereum-sepolia-rpc.publicnode.com"
+# Block to start scanning from. Set to the deploy block of SkillLink so we
+# don't sweep all of Sepolia history on first run.
+START_BLOCK = "10769398"

--- a/apps/analytics/wrangler.toml
+++ b/apps/analytics/wrangler.toml
@@ -16,8 +16,8 @@ crons = ["* * * * *"]
 
 [vars]
 # SkillLink registry on Sepolia. Update post-NameWrapper-aware redeploy.
-SKILLLINK_ADDRESS = "0xE2532C1dB5FceFA946Ee64D44c22027c070DE8Aa"
+SKILLLINK_ADDRESS = "0x428865D8Dec9Bcc882c9e034DB4c81CBd93293A5"
 SEPOLIA_RPC_URL = "https://ethereum-sepolia-rpc.publicnode.com"
 # Block to start scanning from. Set to the deploy block of SkillLink so we
 # don't sweep all of Sepolia history on first run.
-START_BLOCK = "10769398"
+START_BLOCK = "10772615"

--- a/docs/ENSIP25_BINDING.md
+++ b/docs/ENSIP25_BINDING.md
@@ -1,55 +1,85 @@
 # ENSIP-25 binding workflow
 
-This is the step-by-step for turning a reference skill bundle from "trust: unverified" into "✓ verified" per [ENSIP-25](https://docs.ens.domains/ensip/25). Tracks [issue #56](https://github.com/hien-p/Skillname/issues/56).
+Step-by-step for turning a reference skill bundle from "trust: unverified" into "✓ verified" per [ENSIP-25](https://docs.ens.domains/ensip/25). Tracks [issue #56](https://github.com/hien-p/Skillname/issues/56).
 
-## What ENSIP-25 actually requires
+---
 
-Three things have to be true at the same time:
+## What ENSIP-25 actually says
 
-1. The bundle's `manifest.json` declares
-   ```json
-   "trust": {
-     "ensip25": { "enabled": true },
-     "erc8004": {
-       "registry": "eip155:<chainId>:<contractAddr>",
-       "agentId": <id>
-     }
-   }
-   ```
-2. The ENS name has the text record `agent-registration[<erc7930>][<agentId>] = "1"` (or any non-empty, non-`"0"` value)
-3. The agentId on the ERC-8004 registry resolves back to that ENS name (NFT side of the binding)
+After re-reading [the spec](https://docs.ens.domains/ensip/25), the binding model is **simpler than originally documented in this file**. Two canonical facts that change how we should think about this:
 
-The SDK only runs `verifyEnsip25()` when (1) is present. Conditions (2) and (3) are checked at resolution time.
+### 1. The text record key
 
-## The unresolved upstream question — which ERC-8004 registry on Sepolia?
+```
+agent-registration[<registry>][<agentId>]
+```
 
-There is no canonical ERC-8004 IdentityRegistry deployed on Sepolia at a well-known address as of this writing. Three options, ranked from cheapest to most flexible:
+- `<registry>` is the registry's address encoded as an [**ERC-7930 interoperable address**](https://eips.ethereum.org/EIPS/eip-7930) (hex string with `0x` prefix)
+- `<agentId>` is **a string**, not necessarily an integer — the spec only forbids `[` and `]` in the value
 
-| Option | Cost | Notes |
-|---|---|---|
-| **Reuse a published reference** | None — just point at it | Search `etherscan.io/address` for "ERC-8004" or "IdentityRegistry" deployments by the spec authors. If one exists, use that — judges already trust it. |
-| **Deploy our own from the spec reference** | ~1h | Clone the [ERC-8004 reference repo](https://github.com/erc-8004/contracts), `forge create` against `SEPOLIA_PRIVATE_KEY`, mint an agentId per skill. Adds another contract surface to defend at submission. |
-| **Use a placeholder registry + document the gap** | Trivial | Lowest fidelity — judges checking the Etherscan link will see an unrelated contract. Don't ship this in a final submission. |
+The reference implementation in `@skillname/sdk` (`encodeErc7930()` and `verifyEnsip25()`) is now spec-compliant after the fix in this PR (see "Bug fix" below).
 
-**Recommendation**: ask an ENS mentor at the next office hours if there's an existing Sepolia deployment they bless. If yes → option 1. If no → option 2, and budget half a day for it.
+### 2. Verification is one-directional
 
-## Once you know the registry — the bind flow per skill
+The spec states:
+> "If the resolved value is non-empty, the ENS name is considered verified for that specific agent registry entry."
+
+**There is no requirement that the registry side reverse-binds back to the ENS name.** Verification depends on three things only:
+1. The bundle declares `trust.erc8004 = { registry, agentId }`
+2. The text record `agent-registration[<erc7930>][<agentId>]` exists with a non-empty value
+3. (Optional, recommended) The value is `"1"`
+
+**Earlier versions of this doc claimed step 3 required NFT-side reverse binding. That was wrong** — re-read the spec, it's not there. ENS transfers can stale the verification, but enforcement is by convention, not on-chain.
+
+This simplifies #56 dramatically: we don't need an ERC-8004 NFT mint for the spec to call this "bound". We need a registry address (which can be a pointer or even a no-op contract) and the ENS text record set.
+
+---
+
+## Bug fix in this PR — `encodeErc7930` chain_type
+
+The previous SDK implementation used `chain_type = 0x0001` for EVM chains. **The correct value per ERC-7930 is `0x0000`** (CASA namespace id for EIP-155). Cross-checked against the ENSIP-25 spec example for mainnet ERC-8004:
+
+| Source | Hex |
+|---|---|
+| Spec example (mainnet, registry `0x8004A169…`, agentId 167) | `0x000100000101148004a169fb4a3325136eb29fa0ceb6d2e539a432` |
+| Old SDK output | `0x000100010101148004a169fb4a3325136eb29fa0ceb6d2e539a432` |
+| Fixed SDK output | `0x000100000101148004a169fb4a3325136eb29fa0ceb6d2e539a432` ✓ |
+
+Worked example for Sepolia (chainId 11155111 = `0xaa36a7`):
+
+```
+0x 0001 0000 03 aa36a7 14 <20-byte address>
+   ────  ────  ──  ──────  ──  ─────────────
+   v=1   EVM   3   chRef   20  addr
+```
+
+> **Open spec question** — the EIP-7930 reference page shows Sepolia padded to 4 bytes (`04 00aa36a7`) while the canonical minimum-bytes encoding produces 3 bytes (`03 aa36a7`). My implementation chose canonical-minimum since the ENSIP-25 mainnet example clearly uses the same pattern (1 byte for chainId 1, not 4-byte `00000001`). If a future verifier disagrees, the fix is one line in `encodeErc7930()` — pad up to 4 bytes for chainId > 0xFF.
+
+---
+
+## What we need to do
 
 For each of the 5 reference subnames (`hello`, `quote`, `swap`, `score`, `weather` under `*.skilltest.eth`):
 
-### 1. Mint the Identity NFT
+### 1. Pick a registry address
 
-Call the ERC-8004 registry's `mint` (or equivalent) function with the wallet that owns the ENS name. Record the returned `agentId`.
+Per the spec, the registry can be any EVM address — typically an ERC-8004 IdentityRegistry, but spec-wise nothing enforces that. Three options ranked from cheapest:
 
-### 2. Update the bundle manifest
+| Option | Effort | Trade-off |
+|---|---|---|
+| **Use the ENSIP-25 reference example address** (`0x8004A169FB4a3325136EB29fA0ceB6D2e539a432` on mainnet) | None | Demos the binding format; doesn't actually point at a Sepolia registry. Defensible because spec says verification is just "text record present" — no NFT reverse-check |
+| **Deploy a stub registry on Sepolia** | ~30min | Anyone hitting the registry sees a real contract. Even a no-op contract works for spec compliance. |
+| **Find/deploy a real ERC-8004 IdentityRegistry on Sepolia** | ~1h | Maximum fidelity; harder to defend at submission if judges question what the registry does |
 
-Edit `skillname-pack/examples/<bundle>/manifest.json`:
+**Recommendation**: option 2 — write a 50-line `IdentityRegistry.sol` that exposes `register(name, owner)` and a `nameOf(uint256)` getter. Lives at a Sepolia address, comments cite ENSIP-25. That gives us a real contract people can poke at without the full ERC-8004 surface area.
+
+### 2. Update each bundle's `manifest.json`
 
 ```json
 "trust": {
   "ensip25": { "enabled": true },
   "erc8004": {
-    "registry": "eip155:11155111:0xYourErc8004RegistryOnSepolia",
+    "registry": "eip155:11155111:0xYourSepoliaRegistry",
     "agentId": 42
   }
 }
@@ -61,19 +91,19 @@ Edit `skillname-pack/examples/<bundle>/manifest.json`:
 pnpm tsx scripts/bind-ensip25.ts \
   quote.skilltest.eth \
   42 \
-  eip155:11155111:0xYourErc8004RegistryOnSepolia
+  eip155:11155111:0xYourSepoliaRegistry
 ```
 
 The script:
 - Computes `namehash(ensName)`
-- Encodes the registry as ERC-7930 via `@skillname/sdk`'s `encodeErc7930()`
+- Encodes the registry as ERC-7930 via `@skillname/sdk`'s `encodeErc7930()` (now spec-compliant)
 - Builds the key `agent-registration[<erc7930>][<agentId>]`
-- Calls `PublicResolver.setText(node, key, "1")` on Sepolia
-- Reads the value back to confirm
+- Calls `PublicResolver.setText(node, key, "1")` on Sepolia (resolver `0xE99638b40E4Fff0129D56f03b55b6bbC4BBE49b5` per the SDK's `ENS_SEPOLIA` map)
+- Reads back to confirm
 
-### 4. Re-pin the bundle and update the CID
+### 4. Re-pin the bundle
 
-Manifest changed → CID changed → ENS text record `xyz.manifest.skill` needs to point at the new CID. Use the existing `pin-to-0g.ts` + `pin-to-storacha.ts` scripts.
+Manifest changed → CID changed → ENS text record `xyz.manifest.skill` needs the new CID. Use the existing `pin-to-0g.ts` + `pin-to-storacha.ts` scripts.
 
 ### 5. Verify
 
@@ -83,26 +113,31 @@ pnpm cli skill resolve quote.skilltest.eth
 
 Look for `ensip25.bound: true` and the matching `agentId` in the output.
 
-## Doing all 5 in one pass
+---
 
-After the registry decision is made and one bundle is verified end-to-end, batch the rest:
+## Doing all 5 in one pass
 
 ```bash
 for ens in hello.skilltest.eth quote.skilltest.eth swap.skilltest.eth score.skilltest.eth weather.skilltest.eth; do
   agentId=$(yq -r ".\"$ens\".agentId" agents.yaml)  # however you track the per-skill agentId
-  pnpm tsx scripts/bind-ensip25.ts "$ens" "$agentId" eip155:11155111:0xYourErc8004Registry
+  pnpm tsx scripts/bind-ensip25.ts "$ens" "$agentId" eip155:11155111:0xYourSepoliaRegistry
 done
 ```
 
 Update each manifest's `trust.erc8004` accordingly, re-pin them as a batch, push the new CIDs to ENS via the existing `xyz.manifest.skill` setter.
 
+---
+
 ## Why this matters for the prize tracks
 
-- **Best ENS Integration for AI Agents**: every demo skill walks in with a verifiable identity that's not just "ENS resolves to a CID". Judges want ENS doing real work — bidirectional NFT↔ENS binding is the textbook example.
-- **Most Creative Use of ENS**: the verification key uses an ENS *text record key derived from a packed CAIP-10 / ERC-7930 address* — that's exactly the "what else can ENS do" pattern (verifiable credentials in text records) the criteria call out.
+- **Best ENS Integration for AI Agents**: every demo skill walks in with a verifiable identity stored as a structured text record — not just "ENS resolves to a CID". The verification key is computed on the fly from the `(registry, agentId)` pair, so it's truly dynamic identity.
+- **Most Creative Use of ENS**: ERC-7930-encoded interoperable address packed into an ENS text record key. This is exactly the "what else can ENS do?" the criteria call out. Worth a paragraph in the README pointing the judges at `encodeErc7930()` in `packages/sdk/src/index.ts:380`.
 
-## Limitations of the current scaffold
+---
 
-- Only handles the ENS side of the binding. The NFT mint + reverse pointer is left as a manual step until we pick a registry.
-- Updates one skill at a time. The batch pattern above is a shell loop, not a CLI verb (yet).
-- No idempotency check — re-running will issue a redundant `setText` if the value's already correct. Cheap on Sepolia but worth fixing if we ever do this in CI.
+## Open items
+
+- **The ChainReference encoding question above** — pick a side after spec authors clarify, fix in 1 line if needed
+- **Pick the registry contract** — option 2 (stub on Sepolia) is the recommended path
+- **Batch automation** — current `bind-ensip25.ts` does one skill at a time. The shell loop above is the workaround
+- **No idempotency check** — re-running issues a redundant `setText` even if the value's already correct. Cheap on Sepolia, worth fixing if we ever do this in CI

--- a/docs/ENSIP25_BINDING.md
+++ b/docs/ENSIP25_BINDING.md
@@ -1,0 +1,108 @@
+# ENSIP-25 binding workflow
+
+This is the step-by-step for turning a reference skill bundle from "trust: unverified" into "✓ verified" per [ENSIP-25](https://docs.ens.domains/ensip/25). Tracks [issue #56](https://github.com/hien-p/Skillname/issues/56).
+
+## What ENSIP-25 actually requires
+
+Three things have to be true at the same time:
+
+1. The bundle's `manifest.json` declares
+   ```json
+   "trust": {
+     "ensip25": { "enabled": true },
+     "erc8004": {
+       "registry": "eip155:<chainId>:<contractAddr>",
+       "agentId": <id>
+     }
+   }
+   ```
+2. The ENS name has the text record `agent-registration[<erc7930>][<agentId>] = "1"` (or any non-empty, non-`"0"` value)
+3. The agentId on the ERC-8004 registry resolves back to that ENS name (NFT side of the binding)
+
+The SDK only runs `verifyEnsip25()` when (1) is present. Conditions (2) and (3) are checked at resolution time.
+
+## The unresolved upstream question — which ERC-8004 registry on Sepolia?
+
+There is no canonical ERC-8004 IdentityRegistry deployed on Sepolia at a well-known address as of this writing. Three options, ranked from cheapest to most flexible:
+
+| Option | Cost | Notes |
+|---|---|---|
+| **Reuse a published reference** | None — just point at it | Search `etherscan.io/address` for "ERC-8004" or "IdentityRegistry" deployments by the spec authors. If one exists, use that — judges already trust it. |
+| **Deploy our own from the spec reference** | ~1h | Clone the [ERC-8004 reference repo](https://github.com/erc-8004/contracts), `forge create` against `SEPOLIA_PRIVATE_KEY`, mint an agentId per skill. Adds another contract surface to defend at submission. |
+| **Use a placeholder registry + document the gap** | Trivial | Lowest fidelity — judges checking the Etherscan link will see an unrelated contract. Don't ship this in a final submission. |
+
+**Recommendation**: ask an ENS mentor at the next office hours if there's an existing Sepolia deployment they bless. If yes → option 1. If no → option 2, and budget half a day for it.
+
+## Once you know the registry — the bind flow per skill
+
+For each of the 5 reference subnames (`hello`, `quote`, `swap`, `score`, `weather` under `*.skilltest.eth`):
+
+### 1. Mint the Identity NFT
+
+Call the ERC-8004 registry's `mint` (or equivalent) function with the wallet that owns the ENS name. Record the returned `agentId`.
+
+### 2. Update the bundle manifest
+
+Edit `skillname-pack/examples/<bundle>/manifest.json`:
+
+```json
+"trust": {
+  "ensip25": { "enabled": true },
+  "erc8004": {
+    "registry": "eip155:11155111:0xYourErc8004RegistryOnSepolia",
+    "agentId": 42
+  }
+}
+```
+
+### 3. Set the ENS text record
+
+```bash
+pnpm tsx scripts/bind-ensip25.ts \
+  quote.skilltest.eth \
+  42 \
+  eip155:11155111:0xYourErc8004RegistryOnSepolia
+```
+
+The script:
+- Computes `namehash(ensName)`
+- Encodes the registry as ERC-7930 via `@skillname/sdk`'s `encodeErc7930()`
+- Builds the key `agent-registration[<erc7930>][<agentId>]`
+- Calls `PublicResolver.setText(node, key, "1")` on Sepolia
+- Reads the value back to confirm
+
+### 4. Re-pin the bundle and update the CID
+
+Manifest changed → CID changed → ENS text record `xyz.manifest.skill` needs to point at the new CID. Use the existing `pin-to-0g.ts` + `pin-to-storacha.ts` scripts.
+
+### 5. Verify
+
+```bash
+pnpm cli skill resolve quote.skilltest.eth
+```
+
+Look for `ensip25.bound: true` and the matching `agentId` in the output.
+
+## Doing all 5 in one pass
+
+After the registry decision is made and one bundle is verified end-to-end, batch the rest:
+
+```bash
+for ens in hello.skilltest.eth quote.skilltest.eth swap.skilltest.eth score.skilltest.eth weather.skilltest.eth; do
+  agentId=$(yq -r ".\"$ens\".agentId" agents.yaml)  # however you track the per-skill agentId
+  pnpm tsx scripts/bind-ensip25.ts "$ens" "$agentId" eip155:11155111:0xYourErc8004Registry
+done
+```
+
+Update each manifest's `trust.erc8004` accordingly, re-pin them as a batch, push the new CIDs to ENS via the existing `xyz.manifest.skill` setter.
+
+## Why this matters for the prize tracks
+
+- **Best ENS Integration for AI Agents**: every demo skill walks in with a verifiable identity that's not just "ENS resolves to a CID". Judges want ENS doing real work — bidirectional NFT↔ENS binding is the textbook example.
+- **Most Creative Use of ENS**: the verification key uses an ENS *text record key derived from a packed CAIP-10 / ERC-7930 address* — that's exactly the "what else can ENS do" pattern (verifiable credentials in text records) the criteria call out.
+
+## Limitations of the current scaffold
+
+- Only handles the ENS side of the binding. The NFT mint + reverse pointer is left as a manual step until we pick a registry.
+- Updates one skill at a time. The batch pattern above is a shell loop, not a CLI verb (yet).
+- No idempotency check — re-running will issue a redundant `setText` if the value's already correct. Cheap on Sepolia but worth fixing if we ever do this in CI.

--- a/scripts/bind-ensip25.ts
+++ b/scripts/bind-ensip25.ts
@@ -1,0 +1,147 @@
+#!/usr/bin/env tsx
+/**
+ * bind-ensip25.ts — set the ENSIP-25 text record on an ENS name to bind it
+ * to an ERC-8004 Identity NFT.
+ *
+ * The text record key is `agent-registration[<erc7930>][<agentId>]` per
+ * ENSIP-25. Setting it to "1" asserts that the ENS name's owner has
+ * acknowledged the binding to the NFT side. The NFT contract should already
+ * point back to this ENS name on the registry side — without that, the
+ * binding is one-directional and `verifyEnsip25()` returns `bound: false`.
+ *
+ * This script handles only the ENS side of the loop. The NFT mint + reverse
+ * binding is left to the ERC-8004 registry's own flow (varies by deployment).
+ *
+ * Usage:
+ *   pnpm tsx scripts/bind-ensip25.ts <ensName> <agentId> <caip10Registry> [value]
+ *
+ * Example:
+ *   pnpm tsx scripts/bind-ensip25.ts \
+ *     quote.skilltest.eth 42 eip155:11155111:0xYourErc8004Registry 1
+ *
+ * Required env:
+ *   SEPOLIA_PRIVATE_KEY  — must own the ENS name
+ *
+ * Optional env:
+ *   SEPOLIA_RPC_URL      — default: https://ethereum-sepolia-rpc.publicnode.com
+ *   ENS_PUBLIC_RESOLVER  — default: 0xE99638b40E4Fff0129D56f03b55b6bbC4BBE49b5 (Sepolia)
+ */
+
+import "dotenv/config";
+import {
+  createPublicClient,
+  createWalletClient,
+  http,
+  isAddress,
+  namehash,
+  parseAbi,
+} from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+import { sepolia } from "viem/chains";
+import { encodeErc7930 } from "@skillname/sdk";
+
+const RESOLVER_DEFAULT = "0xE99638b40E4Fff0129D56f03b55b6bbC4BBE49b5";
+
+const RESOLVER_ABI = parseAbi([
+  "function setText(bytes32 node, string key, string value) external",
+  "function text(bytes32 node, string key) external view returns (string)",
+]);
+
+async function main() {
+  const [ensName, agentIdRaw, caip10, valueRaw] = process.argv.slice(2);
+  if (!ensName || !agentIdRaw || !caip10) {
+    console.error(
+      "Usage: pnpm tsx scripts/bind-ensip25.ts <ensName> <agentId> <caip10Registry> [value]",
+    );
+    console.error(
+      "Example: pnpm tsx scripts/bind-ensip25.ts quote.skilltest.eth 42 eip155:11155111:0xYourErc8004Registry",
+    );
+    process.exit(1);
+  }
+  if (!ensName.endsWith(".eth")) {
+    throw new Error(`ensName must end with .eth: ${ensName}`);
+  }
+  const agentId = Number(agentIdRaw);
+  if (!Number.isInteger(agentId) || agentId < 0) {
+    throw new Error(`agentId must be a non-negative integer: ${agentIdRaw}`);
+  }
+  // encodeErc7930 throws on invalid format — let it surface a clear error.
+  const erc7930 = encodeErc7930(caip10);
+  const value = valueRaw ?? "1";
+  const key = `agent-registration[${erc7930}][${agentId}]`;
+  const node = namehash(ensName);
+
+  const privateKey = process.env.SEPOLIA_PRIVATE_KEY;
+  if (!privateKey) throw new Error("SEPOLIA_PRIVATE_KEY not set");
+
+  const rpcUrl =
+    process.env.SEPOLIA_RPC_URL ??
+    "https://ethereum-sepolia-rpc.publicnode.com";
+
+  const resolver = (process.env.ENS_PUBLIC_RESOLVER ??
+    RESOLVER_DEFAULT) as `0x${string}`;
+  if (!isAddress(resolver)) throw new Error(`Invalid resolver: ${resolver}`);
+
+  const account = privateKeyToAccount(privateKey as `0x${string}`);
+  const publicClient = createPublicClient({
+    chain: sepolia,
+    transport: http(rpcUrl),
+  });
+  const wallet = createWalletClient({
+    account,
+    chain: sepolia,
+    transport: http(rpcUrl),
+  });
+
+  console.log(`bind-ensip25 ${ensName}`);
+  console.log(`  ens:      ${ensName}`);
+  console.log(`  node:     ${node}`);
+  console.log(`  agentId:  ${agentId}`);
+  console.log(`  registry: ${caip10}`);
+  console.log(`  erc7930:  ${erc7930}`);
+  console.log(`  key:      ${key}`);
+  console.log(`  value:    ${value}`);
+  console.log(`  resolver: ${resolver}`);
+  console.log(`  signer:   ${account.address}`);
+  console.log();
+
+  const txHash = await wallet.writeContract({
+    address: resolver,
+    abi: RESOLVER_ABI,
+    functionName: "setText",
+    args: [node, key, value],
+  });
+  console.log(`  → tx ${txHash}`);
+  console.log(`  waiting for confirmation…`);
+
+  const receipt = await publicClient.waitForTransactionReceipt({
+    hash: txHash,
+  });
+  if (receipt.status !== "success") {
+    throw new Error(`tx reverted: https://sepolia.etherscan.io/tx/${txHash}`);
+  }
+
+  // Verify by reading the text record back
+  const readBack = await publicClient.readContract({
+    address: resolver,
+    abi: RESOLVER_ABI,
+    functionName: "text",
+    args: [node, key],
+  });
+
+  console.log(`  ✓ text record set at block ${receipt.blockNumber}`);
+  console.log(`  ✓ readBack: "${readBack}"`);
+  console.log(`  https://sepolia.etherscan.io/tx/${txHash}`);
+  console.log();
+  console.log(
+    `Next: confirm the NFT side at ${caip10} reverse-binds to ${ensName}.`,
+  );
+  console.log(
+    `      Once both sides agree, \`skill verify ${ensName}\` should report ensip25.bound: true.`,
+  );
+}
+
+main().catch((e) => {
+  console.error(`Error: ${e?.message ?? e}`);
+  process.exit(1);
+});

--- a/skillname-pack/packages/sdk/src/index.ts
+++ b/skillname-pack/packages/sdk/src/index.ts
@@ -367,28 +367,45 @@ export async function verifyEnsip25(
 }
 
 /**
- * Encode CAIP-10-style address (eip155:1:0x...) as ERC-7930 interoperable address.
+ * Encode CAIP-10-style address (eip155:<chainId>:0x...) as ERC-7930
+ * interoperable address.
  *
- * Format: 0x [version 2 bytes] [chain_type 2 bytes] [chain_id_len 1 byte]
- *           [chain_id N bytes] [addr_len 1 byte] [addr 20 bytes]
+ * Per EIP-7930:
+ *   version            : 2 bytes  — 0x0001 for v1
+ *   chain_type         : 2 bytes  — 0x0000 for EVM chains (CASA namespace id)
+ *   chain_ref_length   : 1 byte
+ *   chain_reference    : N bytes  — chainId as canonical big-endian (no leading-zero pad)
+ *   address_length     : 1 byte
+ *   address            : 20 bytes for EVM
  *
- * Example for Ethereum mainnet (chainId=1) ERC-8004 IdentityRegistry:
- *   0x0001 0001 01 14 8004a169fb4a3325136eb29fa0ceb6d2e539a432
- *      ^^^^ ^^^^ ^^ ^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
- *      ver  type len 20 address
+ * Worked example — ENSIP-25 spec reference (Ethereum mainnet, ERC-8004 at
+ * 0x8004A169…, agentId 167):
+ *   0x0001 0000 01 01 14 8004a169fb4a3325136eb29fa0ceb6d2e539a432
+ *      ^^^^ ^^^^ ^^ ^^ ^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ *      ver  evm  cref-len/ref addr-len address
+ *   = 0x000100000101148004a169fb4a3325136eb29fa0ceb6d2e539a432
+ *
+ * Sepolia (chainId 11155111 = 0xaa36a7, 3 canonical bytes):
+ *   0x0001 0000 03 aa36a7 14 <addr>
  */
 export function encodeErc7930(caip10: string): string {
   const match = caip10.match(/^eip155:(\d+):(0x[a-fA-F0-9]{40})$/);
   if (!match) throw new Error(`Invalid CAIP-10: ${caip10}`);
   const [, chainIdStr, addr] = match;
   const chainId = parseInt(chainIdStr, 10);
+  if (chainId < 1) throw new Error(`Invalid chainId: ${chainId}`);
 
-  const chainIdHex = chainId.toString(16).padStart(2, "0");
-  const chainIdLen = (chainIdHex.length / 2).toString(16).padStart(2, "0");
+  // Canonical big-endian minimum bytes — pad to even hex digits, no extra
+  // leading zero on the byte boundary.
+  let chainIdHex = chainId.toString(16);
+  if (chainIdHex.length % 2 === 1) chainIdHex = "0" + chainIdHex;
+  const chainIdBytes = chainIdHex.length / 2;
+  const chainIdLenHex = chainIdBytes.toString(16).padStart(2, "0");
+
   const addrClean = addr.toLowerCase().replace("0x", "");
 
-  // version=0001, chain_type=0001 (eip155), chain_id_len, chain_id, addr_len=14, addr
-  return `0x0001${"0001"}${chainIdLen}${chainIdHex}14${addrClean}`;
+  // 0x0001 (version) | 0x0000 (chain_type=EVM) | <len> | <chainId> | 0x14 | <addr>
+  return `0x0001${"0000"}${chainIdLenHex}${chainIdHex}14${addrClean}`;
 }
 
 // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Two independent scaffolds laying the foundation for the depth-of-creativity prize plays. Each is intentionally minimal — entry points are working, the surface area is documented, and the remaining decisions are flagged.

## `apps/analytics/` — Cloudflare Worker (issue #15)

Cron-driven indexer that tails `SkillCalled` events from the SkillLink registry on Sepolia.

- **1-minute cron** — scans up to 1000 new blocks per run, persists cursor in KV, caps at chain head
- **Per-skill aggregation in KV** — `calls_total`, `calls_24h`, `calls_7d`, `gas_total`, top 5 callers, last block, last seen
- **HTTP API**:
  - `GET /skill/:node` — JSON stats for one ENS namehash
  - `GET /skills?limit=N` — top N skills by `calls_24h`
  - `GET /health`
- Pre-configured `wrangler.toml` with the current `SKILLLINK_ADDRESS` (`0xE2532C1d…`) and `START_BLOCK` (the deploy block) — bump both after the NameWrapper-aware redeploy from #52 lands

Out of scope for hackathon: proper window decay (calls_24h doesn't actually fall off after 24h yet), reverse-resolution of caller addresses, retention policy.

## `scripts/bind-ensip25.ts` + `docs/ENSIP25_BINDING.md` (issue #56)

The ENS-side automation for ENSIP-25 binding. Walks the manifest → text-record → verify path.

- Computes `namehash(ensName)` and the `agent-registration[<erc7930>][<agentId>]` key
- Reuses `@skillname/sdk`'s `encodeErc7930()` (the canonical impl per `CLAUDE.md`)
- Calls `PublicResolver.setText` on Sepolia, reads back to confirm
- **Does NOT** mint the NFT or set the reverse pointer — that's registry-side flow, intentionally out of scope

The companion doc lays out three options for the unresolved upstream question — *which ERC-8004 registry on Sepolia*. My recommendation: ask an ENS mentor first; if no canonical deployment exists yet, deploy the reference contract from the spec repo (~1h).

## Test plan

- [x] `apps/analytics/src/index.ts` — handler shape compiles against `@cloudflare/workers-types` (verified statically; no `wrangler dev` until KV namespace is created)
- [x] `scripts/bind-ensip25.ts` — script entry-point + arg validation works without keys
- [ ] Manual: deploy analytics Worker → wait for one cron tick → confirm `/health` is up and the cursor advances even with zero events
- [ ] Manual (after #56 unblocks): pick the ERC-8004 registry, mint one agentId, run `bind-ensip25.ts` against `quote.skilltest.eth`, confirm `skill resolve` returns `ensip25.bound: true`

## Dependencies / sequencing

- **Analytics indexer** is independent — can deploy any time. Will report zero events until skills are registered post-#52 redeploy, but the cron + cursor + API surface work standalone.
- **ENSIP-25 binding** is blocked on the registry-on-Sepolia decision. The script itself is ready; what's missing is which `eip155:11155111:0x…` address to pass it.