### PR TITLE
feat(web): on-chain SkillLink demo card on the homepage

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -1869,6 +1869,23 @@
         </div>
       </article>
 
+      <article class="card metric" data-card="onchain" id="onchainCard">
+        <div class="hover-flag">ON-CHAIN · LIVE</div>
+        <div>
+          <div class="label">SKILLLINK · sepolia</div>
+          <div class="metric-value" style="margin-top:6px;font-size:42px" id="onchainCount">—</div>
+          <div class="label" style="margin-top:2px">SKILLS REGISTERED</div>
+        </div>
+        <div class="metric-foot" style="flex-direction:column;align-items:stretch;gap:8px">
+          <button id="onchainRun" type="button" style="background:var(--text-display);color:var(--black);border:none;padding:10px 14px;font-family:inherit;font-size:11px;font-weight:600;letter-spacing:0.06em;text-transform:uppercase;cursor:pointer;border-radius:0">
+            RUN DEMO →
+          </button>
+          <div id="onchainResult" class="label" style="font-size:11px;line-height:1.4;color:var(--text-secondary);min-height:16px">
+            agg.skilltest.eth → getBestQuote("ethereum")
+          </div>
+        </div>
+      </article>
+
       <article class="card metric" data-card="schemaversion">
         <div class="hover-flag">SCHEMA · v1</div>
         <div>
@@ -2626,6 +2643,71 @@
   });
   // On cold load, restore detail view if URL carries the route.
   if (location.hash.startsWith('#/skill/')) syncDetailFromHash();
+
+  // ── SkillLink on-chain demo ─────────────────────────────────────────────
+  // Live deployment on Sepolia. Reads skillCount() on load, runs the
+  // composition demo (agg.skilltest.eth → BestQuoteAggregator → uni + sushi)
+  // when the user clicks RUN DEMO.
+  const SKILLLINK_ADDR = '0x428865D8Dec9Bcc882c9e034DB4c81CBd93293A5';
+  const SKILLLINK_ABI = parseAbi([
+    'function skillCount() external view returns (uint256)',
+    'function call(bytes32 node, bytes data) external payable returns (bytes)',
+  ]);
+  const sepoliaPublic = createPublicClient({ chain: sepolia, transport: http() });
+
+  async function refreshOnchainCount() {
+    try {
+      const n = await sepoliaPublic.readContract({
+        address: SKILLLINK_ADDR,
+        abi: SKILLLINK_ABI,
+        functionName: 'skillCount',
+      });
+      $('#onchainCount').textContent = String(n);
+    } catch (e) {
+      $('#onchainCount').textContent = '?';
+    }
+  }
+  refreshOnchainCount();
+
+  $('#onchainRun').addEventListener('click', async () => {
+    const btn = $('#onchainRun');
+    const out = $('#onchainResult');
+    btn.disabled = true;
+    btn.textContent = 'RUNNING…';
+    out.textContent = '→ cast call → SkillLink → BestQuoteAggregator → uni + sushi';
+    out.style.color = 'var(--text-secondary)';
+    const t0 = performance.now();
+    try {
+      const node = namehash('agg.skilltest.eth');
+      // encodeFunctionData(getBestQuote(string), ['ethereum'])
+      // selector + dynamic string encoding
+      const innerCalldata = '0x0777905b' +
+        '0000000000000000000000000000000000000000000000000000000000000020' + // offset
+        '0000000000000000000000000000000000000000000000000000000000000008' + // length
+        '657468657265756d000000000000000000000000000000000000000000000000';   // "ethereum"
+      const raw = await sepoliaPublic.readContract({
+        address: SKILLLINK_ADDR,
+        abi: SKILLLINK_ABI,
+        functionName: 'call',
+        args: [node, innerCalldata],
+      });
+      // raw is bytes; decode last 32 bytes as uint256
+      const hex = raw.startsWith('0x') ? raw.slice(2) : raw;
+      const valHex = hex.slice(-64);
+      const val = BigInt('0x' + valHex);
+      const usd = Number(val) / 1_000_000;
+      const dt = (performance.now() - t0).toFixed(0);
+      out.innerHTML =
+        `<span style="color:var(--success)">$${usd.toFixed(2)}</span> · 3 hops · ${dt}ms · ` +
+        `<a href="https://sepolia.etherscan.io/address/${SKILLLINK_ADDR}" target="_blank" style="color:var(--text-display);text-decoration:underline">verify ↗</a>`;
+    } catch (e) {
+      out.textContent = `error: ${e.shortMessage ?? e.message ?? String(e)}`;
+      out.style.color = 'var(--accent-red)';
+    } finally {
+      btn.textContent = 'RUN DEMO →';
+      btn.disabled = false;
+    }
+  });
 
   $('#resolveBtn').addEventListener('click', runResolve);
   $('#ensInput').addEventListener('keydown', (e) => {


### PR DESCRIPTION
## Summary

Closes the demo loop visually: a bento card on the homepage that reads live state from the deployed `SkillLink` registry on Sepolia and runs the composition demo end-to-end in the browser, no terminal required.

## What it does

- **Reads `skillCount()` on page load** — currently shows `3` (uni, sushi, agg)
- **RUN DEMO button** — calls `SkillLink.call(namehash(agg.skilltest.eth), encodeFunctionData(getBestQuote, ['ethereum']))` via viem's `readContract` (eth_call, no signing)
- **Renders the result inline** — `$2300.00 · 3 hops · <ms>ms · verify ↗`
- **Verify link** — opens the SkillLink contract on Sepolia Etherscan so anyone can audit the call themselves

The whole path is external-call → SkillLink → BestQuoteAggregator → SkillLink → uni + sushi → result. **Three on-chain skill invocations, one click.**

## Why a bento card vs a full page

This is the simplest surface that doesn't require touching the existing skill explorer/detail flow (which assumes off-chain manifests). The new ENS subnames (`uni`, `sushi`, `agg.skilltest.eth`) only have on-chain registrations, no IPFS-backed manifests — so they wouldn't render correctly in the existing resolver. A dedicated card is honest about what's being shown.

## Trade-offs

- Hard-codes the `SKILLLINK_ADDR` constant. After any future redeploy, this needs updating in lockstep with `bridge/src/server.ts` (`SKILLLINK_BY_CHAIN`) and `apps/analytics/wrangler.toml` (`SKILLLINK_ADDRESS`).
- Inline calldata encoding (no `encodeFunctionData` import — viem's already-imported set covers everything except that one helper). Acceptable for a single function call; if we ever support arbitrary skill calls from the browser, switch to `encodeFunctionData`.
- Replaces the SCHEMA card slot — wait, no, **it's a new sibling**, the SCHEMA card is preserved. The grid will reflow to accommodate.

## Test plan

- [ ] Open the homepage in a browser, see "3" rendered for SKILLS REGISTERED
- [ ] Click RUN DEMO, see "$2300.00 · 3 hops · <ms>ms · verify ↗" appear within ~2s
- [ ] Click verify link → lands on SkillLink contract page on Sepolia Etherscan
- [ ] Hard-refresh, confirm the count refreshes

## Live demo (anyone can run, no key needed)

The same call from a terminal:

```bash
cast call 0x428865D8Dec9Bcc882c9e034DB4c81CBd93293A5 \
  "call(bytes32,bytes)(bytes)" \
  $(cast namehash agg.skilltest.eth) \
  $(cast calldata "getBestQuote(string)" "ethereum") \
  --rpc-url https://ethereum-sepolia-rpc.publicnode.com
```

Returns `0x...89173700` = `2300000000` = $2300.000000.