### PR TITLE
feat: deploy stub IdentityRegistry on Sepolia for ENSIP-25 binding (#56)

### DIFF
--- a/contracts/script/DeployIdentityRegistry.s.sol
+++ b/contracts/script/DeployIdentityRegistry.s.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Script.sol";
+import "../src/IdentityRegistry.sol";
+
+/// @notice Deploys IdentityRegistry to whatever chain `--rpc-url` points at.
+///
+/// Usage:
+///   SEPOLIA_PRIVATE_KEY=0x... \
+///   forge script contracts/script/DeployIdentityRegistry.s.sol \
+///     --rpc-url https://ethereum-sepolia-rpc.publicnode.com --broadcast
+contract DeployIdentityRegistry is Script {
+    function run() external {
+        uint256 deployerKey = vm.envUint("SEPOLIA_PRIVATE_KEY");
+        vm.startBroadcast(deployerKey);
+        IdentityRegistry registry = new IdentityRegistry();
+        console.log("IdentityRegistry deployed at:", address(registry));
+        vm.stopBroadcast();
+    }
+}

--- a/contracts/src/IdentityRegistry.sol
+++ b/contracts/src/IdentityRegistry.sol
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+/// @title IdentityRegistry — minimal ERC-8004-compatible Identity Registry
+/// @notice Mints sequential agentIds, each tied to a free-form name string and
+///         the wallet that registered it. The address of this contract is what
+///         goes into the ENSIP-25 `agent-registration[<erc7930>][<agentId>]`
+///         text-record key.
+/// @dev    ENSIP-25 verification is one-directional — the spec only requires
+///         the ENS text record to exist with a non-empty value. The registry
+///         side is intentionally minimal: just enough to give judges a
+///         browsable contract at a public Sepolia address. We don't enforce
+///         a reverse-binding from agentId → ENS name; ownership of the
+///         mapping lives in ENS, not here.
+contract IdentityRegistry {
+    struct Agent {
+        string  name;       // free-form, typically the ENS name being identified
+        address owner;      // wallet that registered this agentId
+        uint64  mintedAt;   // block.timestamp at registration
+    }
+
+    /// @notice agentId → Agent. id 0 is reserved as "unset".
+    mapping(uint256 => Agent) public agents;
+
+    /// @notice Last minted agentId. Starts at 0; the first mint returns 1.
+    uint256 public lastId;
+
+    event AgentRegistered(
+        uint256 indexed agentId,
+        address indexed owner,
+        string  name
+    );
+    event AgentTransferred(
+        uint256 indexed agentId,
+        address indexed from,
+        address indexed to
+    );
+
+    error NotAgentOwner(uint256 agentId, address sender, address owner);
+    error AgentNotFound(uint256 agentId);
+
+    /// @notice Mint a new agentId tied to a name. Anyone can call.
+    function register(string calldata name) external returns (uint256 agentId) {
+        agentId = ++lastId;
+        agents[agentId] = Agent({
+            name: name,
+            owner: msg.sender,
+            mintedAt: uint64(block.timestamp)
+        });
+        emit AgentRegistered(agentId, msg.sender, name);
+    }
+
+    /// @notice Transfer an agent's ownership. Only the current owner can call.
+    function transfer(uint256 agentId, address to) external {
+        Agent storage a = agents[agentId];
+        if (a.owner == address(0)) revert AgentNotFound(agentId);
+        if (msg.sender != a.owner) revert NotAgentOwner(agentId, msg.sender, a.owner);
+        emit AgentTransferred(agentId, a.owner, to);
+        a.owner = to;
+    }
+
+    /// @notice Convenience — return the name registered for an agentId.
+    function nameOf(uint256 agentId) external view returns (string memory) {
+        return agents[agentId].name;
+    }
+
+    /// @notice Convenience — return the owner of an agentId.
+    function ownerOf(uint256 agentId) external view returns (address) {
+        return agents[agentId].owner;
+    }
+}

--- a/docs/ENSIP25_BINDING.md
+++ b/docs/ENSIP25_BINDING.md
@@ -61,17 +61,29 @@ Worked example for Sepolia (chainId 11155111 = `0xaa36a7`):
 
 For each of the 5 reference subnames (`hello`, `quote`, `swap`, `score`, `weather` under `*.skilltest.eth`):
 
-### 1. Pick a registry address
+### 1. Use the deployed `IdentityRegistry` on Sepolia
 
-Per the spec, the registry can be any EVM address — typically an ERC-8004 IdentityRegistry, but spec-wise nothing enforces that. Three options ranked from cheapest:
+The registry is **live** at:
 
-| Option | Effort | Trade-off |
+| Network | Address | Explorer |
 |---|---|---|
-| **Use the ENSIP-25 reference example address** (`0x8004A169FB4a3325136EB29fA0ceB6D2e539a432` on mainnet) | None | Demos the binding format; doesn't actually point at a Sepolia registry. Defensible because spec says verification is just "text record present" — no NFT reverse-check |
-| **Deploy a stub registry on Sepolia** | ~30min | Anyone hitting the registry sees a real contract. Even a no-op contract works for spec compliance. |
-| **Find/deploy a real ERC-8004 IdentityRegistry on Sepolia** | ~1h | Maximum fidelity; harder to defend at submission if judges question what the registry does |
+| Sepolia | `0x48f77FfE1f02FB94bDe9c8ffe84bB4956ace11e4` | [Etherscan](https://sepolia.etherscan.io/address/0x48f77FfE1f02FB94bDe9c8ffe84bB4956ace11e4) |
 
-**Recommendation**: option 2 — write a 50-line `IdentityRegistry.sol` that exposes `register(name, owner)` and a `nameOf(uint256)` getter. Lives at a Sepolia address, comments cite ENSIP-25. That gives us a real contract people can poke at without the full ERC-8004 surface area.
+Source at `contracts/src/IdentityRegistry.sol` — minimal: `register(string name) → uint256 agentId`, ownership transfer, name + owner getters. Spec compliance for ENSIP-25 verification is satisfied just by having the contract address used in the ERC-7930 encoded text-record key — the spec doesn't require any specific registry behavior beyond that.
+
+The CAIP-10 string to use in `manifest.json`:
+
+```
+eip155:11155111:0x48f77FfE1f02FB94bDe9c8ffe84bB4956ace11e4
+```
+
+Worked example — for `agentId 1`, the ENSIP-25 text-record key is:
+
+```
+agent-registration[0x0001000003aa36a71448f77ffe1f02fb94bde9c8ffe84bb4956ace11e4][1]
+```
+
+Computed via `@skillname/sdk`'s `encodeErc7930()` + the standard ENSIP-25 template. The 3-byte chain reference `aa36a7` is Sepolia (chainId 11155111) in canonical big-endian.
 
 ### 2. Update each bundle's `manifest.json`
 


### PR DESCRIPTION
## Summary

Unblocks the ENSIP-25 binding work tracked in [#56](https://github.com/hien-p/Skillname/issues/56) by picking a concrete registry contract on Sepolia. **Already deployed and verified on-chain.**

| Network | Address | Explorer |
|---|---|---|
| Sepolia | `0x48f77FfE1f02FB94bDe9c8ffe84bB4956ace11e4` | [Etherscan](https://sepolia.etherscan.io/address/0x48f77FfE1f02FB94bDe9c8ffe84bB4956ace11e4) |

Bytecode size: ~2 KB. Deploy gas: 624,429. `lastId() = 0` (no agents minted yet).

## Why a stub vs chasing a canonical ERC-8004 deployment

Per ENSIP-25 the verification path is one-directional — the spec only requires the ENS text record to exist with a non-empty value. The registry side is intentionally minimal: just enough to give judges a real, browsable contract at a public Sepolia address. **A no-op contract would technically satisfy the spec.** The implementation here adds a tiny bit of useful state (sequential agentIds, names, owners) so registrations are inspectable on Etherscan and produce events the analytics indexer can later consume.

This avoids the half-day rabbit hole of finding/deploying a "real" ERC-8004 IdentityRegistry while we don't yet have a confirmed canonical address on Sepolia.

## Contract surface

```solidity
function register(string calldata name) external returns (uint256 agentId);
function transfer(uint256 agentId, address to) external;
function nameOf(uint256 agentId) external view returns (string memory);
function ownerOf(uint256 agentId) external view returns (address);

event AgentRegistered(uint256 indexed agentId, address indexed owner, string name);
event AgentTransferred(uint256 indexed agentId, address indexed from, address indexed to);
```

No imports, no admin role, no upgradability. ~70 lines total.

## Worked ENSIP-25 binding example

For an agent registered as `agentId 1`, the resulting text-record key is:

```
agent-registration[0x0001000003aa36a71448f77ffe1f02fb94bde9c8ffe84bb4956ace11e4][1]
```

Computed via `@skillname/sdk`'s `encodeErc7930()`. The 3-byte chain reference `aa36a7` is Sepolia (chainId 11155111) in canonical big-endian.

## What's next (not in this PR)

To make any of the 5 reference skills show "✓ verified" in the SDK / web app:

1. `cast send <registry> "register(string)" "quote.skilltest.eth"` — mint an agentId per skill (~50k gas each)
2. Run `pnpm tsx scripts/bind-ensip25.ts` for each — sets the ENS text record on the resolver
3. Update each `manifest.json`'s `trust.erc8004` block to point at this registry + the new agentId
4. Re-pin the manifests via the existing `pin-to-0g.ts` / `pin-to-storacha.ts` scripts (requires storage credentials currently empty in `.env`)
5. Update `xyz.manifest.skill` text record to the new CID per skill

Steps 1+2 I can do right now with the same key. Steps 3+4 need the manifest-source change and storage credentials (`W3_PRINCIPAL_KEY` / `OG_COMPUTE_PRIVATE_KEY` are empty in `.env`). Happy to drive 1+2 immediately if you want — or land this PR first and do the bindings as a follow-up.

## Test plan

- [x] `forge build` — `IdentityRegistry` compiles clean
- [x] `forge test` — existing 13 SkillLink tests still pass
- [x] On-chain: `cast code` returns ~2 KB, `cast call lastId()` returns 0
- [ ] Manual: `cast send 0x48f77F… "register(string)" "test"` from any wallet → expect agentId 1, `AgentRegistered` event