### PR TITLE
feat(versioning): semver resolution + lockfile CLI (closes #16 main path, #17 lock)

### DIFF
--- a/scripts/setup-versions.ts
+++ b/scripts/setup-versions.ts
@@ -1,0 +1,202 @@
+#!/usr/bin/env tsx
+/**
+ * setup-versions.ts — register v1 + v2 subnames under quote.skilltest.eth and
+ * publish the versions index so semver resolution can demo end-to-end.
+ *
+ * After this runs:
+ *   v1.quote.skilltest.eth → manifest pinned at version 1.0.0 (current)
+ *   v2.quote.skilltest.eth → manifest pinned at version 2.0.0 (synthetic copy)
+ *   quote.skilltest.eth    → xyz.manifest.skill.versions = "v1:1.0.0,v2:2.0.0"
+ *                            xyz.manifest.skill.latest   = "v2"
+ *
+ * Then `skill resolve quote.skilltest.eth@^1` → v1, `@^2` → v2, `@latest` → v2.
+ *
+ * Run:
+ *   pnpm tsx scripts/setup-versions.ts
+ */
+
+import "dotenv/config";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  createPublicClient,
+  createWalletClient,
+  http,
+  keccak256,
+  namehash,
+  parseAbi,
+  toBytes,
+  type Hex,
+} from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+import { sepolia } from "viem/chains";
+
+const ENS_REGISTRY = "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e";
+const RESOLVER = "0xE99638b40E4Fff0129D56f03b55b6bbC4BBE49b5";
+const PARENT = "quote.skilltest.eth";
+const SCHEMA_URL = "https://manifest.eth/schemas/skill-v1.json";
+
+const ENS_REGISTRY_ABI = parseAbi([
+  "function setSubnodeRecord(bytes32 node, bytes32 label, address owner, address resolver, uint64 ttl) external",
+  "function owner(bytes32 node) external view returns (address)",
+]);
+const RESOLVER_ABI = parseAbi([
+  "function setText(bytes32 node, string key, string value) external",
+  "function text(bytes32 node, string key) external view returns (string)",
+]);
+
+async function main() {
+  const pk = process.env.SEPOLIA_PRIVATE_KEY;
+  if (!pk) throw new Error("SEPOLIA_PRIVATE_KEY not set");
+  const key = (pk.startsWith("0x") ? pk : "0x" + pk) as Hex;
+
+  const rpc =
+    process.env.SEPOLIA_RPC_URL ??
+    "https://ethereum-sepolia-rpc.publicnode.com";
+
+  const account = privateKeyToAccount(key);
+  const pub = createPublicClient({ chain: sepolia, transport: http(rpc) });
+  const wallet = createWalletClient({ account, chain: sepolia, transport: http(rpc) });
+
+  console.log(`signer:  ${account.address}`);
+  console.log(`parent:  ${PARENT}`);
+  console.log();
+
+  const parentNode = namehash(PARENT);
+
+  // 1. Read the current manifest source (v1 = "as-is")
+  const manifestPath = "skillname-pack/examples/quote-uniswap/manifest.json";
+  const v1Manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+  if (v1Manifest.version !== "1.0.0") {
+    console.warn(
+      `⚠ manifest version is ${v1Manifest.version}, expected 1.0.0 — proceeding anyway`,
+    );
+  }
+
+  // 2. Build a synthetic v2: same shape, version bumped to 2.0.0, description tweaked
+  const v2Manifest = JSON.parse(JSON.stringify(v1Manifest));
+  v2Manifest.version = "2.0.0";
+  v2Manifest.description =
+    "(v2) " + (v1Manifest.description ?? "Versioned bundle for demo.");
+
+  // 3. Pin both to 0G
+  const tmp = mkdtempSync(join(tmpdir(), "skillname-versions-"));
+  const v1Path = join(tmp, "v1.json");
+  const v2Path = join(tmp, "v2.json");
+  writeFileSync(v1Path, JSON.stringify(v1Manifest, null, 2));
+  writeFileSync(v2Path, JSON.stringify(v2Manifest, null, 2));
+
+  console.log(`→ pinning v1 manifest to 0G…`);
+  const v1Root = pinTo0G(v1Path, key);
+  if (!v1Root) throw new Error("v1 pin failed");
+  console.log(`  ✓ v1 root: ${v1Root}`);
+
+  console.log(`→ pinning v2 manifest to 0G…`);
+  const v2Root = pinTo0G(v2Path, key);
+  if (!v2Root) throw new Error("v2 pin failed");
+  console.log(`  ✓ v2 root: ${v2Root}`);
+  console.log();
+
+  // 4. Create v1 + v2 subnames if they don't exist
+  for (const label of ["v1", "v2"]) {
+    const fullName = `${label}.${PARENT}`;
+    const node = namehash(fullName);
+    const existingOwner = await pub.readContract({
+      address: ENS_REGISTRY as `0x${string}`,
+      abi: ENS_REGISTRY_ABI,
+      functionName: "owner",
+      args: [node],
+    });
+    if (existingOwner !== "0x0000000000000000000000000000000000000000") {
+      console.log(`  ${fullName} already exists (owner ${existingOwner}) — skipping creation`);
+      continue;
+    }
+    console.log(`→ creating ${fullName}`);
+    const txHash = await wallet.writeContract({
+      address: ENS_REGISTRY as `0x${string}`,
+      abi: ENS_REGISTRY_ABI,
+      functionName: "setSubnodeRecord",
+      args: [parentNode, keccak256(toBytes(label)), account.address, RESOLVER as `0x${string}`, 0n],
+    });
+    await pub.waitForTransactionReceipt({ hash: txHash });
+    console.log(`  ✓ ${txHash}`);
+  }
+  console.log();
+
+  // 5. Set the manifest text records on each version subname
+  for (const [label, version, root] of [
+    ["v1", "1.0.0", v1Root],
+    ["v2", "2.0.0", v2Root],
+  ] as const) {
+    const fullName = `${label}.${PARENT}`;
+    const node = namehash(fullName);
+    const records: [string, string][] = [
+      ["xyz.manifest.skill", `0g://${root}`],
+      ["xyz.manifest.skill.version", version],
+      ["xyz.manifest.skill.schema", SCHEMA_URL],
+    ];
+    console.log(`→ ${fullName} (3 setText)`);
+    for (const [k, v] of records) {
+      const txHash = await wallet.writeContract({
+        address: RESOLVER as `0x${string}`,
+        abi: RESOLVER_ABI,
+        functionName: "setText",
+        args: [node, k, v],
+      });
+      await pub.waitForTransactionReceipt({ hash: txHash });
+      console.log(`  ✓ ${k} = ${v.slice(0, 40)}${v.length > 40 ? "…" : ""}`);
+    }
+  }
+  console.log();
+
+  // 6. Set the versions index on the parent
+  const versionsValue = "v1:1.0.0,v2:2.0.0";
+  const latestValue = "v2";
+  console.log(`→ ${PARENT} (versions index)`);
+  for (const [k, v] of [
+    ["xyz.manifest.skill.versions", versionsValue],
+    ["xyz.manifest.skill.latest", latestValue],
+  ] as const) {
+    const txHash = await wallet.writeContract({
+      address: RESOLVER as `0x${string}`,
+      abi: RESOLVER_ABI,
+      functionName: "setText",
+      args: [parentNode, k, v],
+    });
+    await pub.waitForTransactionReceipt({ hash: txHash });
+    console.log(`  ✓ ${k} = ${v}`);
+  }
+
+  console.log();
+  console.log("✓ Versions wired up. Try:");
+  console.log(`  pnpm cli skill resolve ${PARENT}@^1   # → v1.${PARENT}`);
+  console.log(`  pnpm cli skill resolve ${PARENT}@^2   # → v2.${PARENT}`);
+  console.log(`  pnpm cli skill resolve ${PARENT}@latest`);
+}
+
+function pinTo0G(filePath: string, privateKey: string): string | null {
+  const cli = process.env.OG_CLI_BIN ?? "0g-storage-client";
+  const ogRpc = process.env.OG_RPC_URL ?? "https://evmrpc-testnet.0g.ai";
+  const indexer =
+    process.env.OG_INDEXER_URL ?? "https://indexer-storage-testnet-turbo.0g.ai";
+  const r = spawnSync(
+    cli,
+    ["upload", "--url", ogRpc, "--indexer", indexer, "--key", privateKey, "--file", filePath],
+    { encoding: "utf8" },
+  );
+  const combined = (r.stdout ?? "") + "\n" + (r.stderr ?? "");
+  if (r.status !== 0) {
+    console.error(`  ✗ 0g-storage-client exit ${r.status}`);
+    if (combined.trim()) console.error(combined.split("\n").slice(-5).join("\n"));
+    return null;
+  }
+  const m = combined.match(/root[s]?\s*=\s*(0x[a-fA-F0-9]+)/);
+  return m ? m[1] : null;
+}
+
+main().catch((e) => {
+  console.error(`setup-versions failed: ${e?.shortMessage ?? e?.message ?? e}`);
+  process.exit(1);
+});

--- a/scripts/verify-versions.ts
+++ b/scripts/verify-versions.ts
@@ -1,0 +1,66 @@
+#!/usr/bin/env tsx
+/**
+ * verify-versions.ts — exercises the SDK semver resolver against live ENS state.
+ *
+ * Reads quote.skilltest.eth's `xyz.manifest.skill.versions` index and resolves
+ * a few semver ranges through it. Confirms #16 versioning works end-to-end.
+ */
+
+import "dotenv/config";
+import { resolveVersionedName, resolveSkill } from "../skillname-pack/packages/sdk/dist/index.js";
+
+const PARENT = "quote.skilltest.eth";
+const CASES: { range: string; expectedLabel: string }[] = [
+  { range: "^1",     expectedLabel: "v1" },
+  { range: "^2",     expectedLabel: "v2" },
+  { range: "~1.0",   expectedLabel: "v1" },
+  { range: "1.0.0",  expectedLabel: "v1" },
+  { range: "2.0.0",  expectedLabel: "v2" },
+  { range: "latest", expectedLabel: "v2" }, // matches highest available, since "latest" is wildcard for matchVersionRange
+  { range: "*",      expectedLabel: "v2" },
+];
+
+async function main() {
+  console.log(`SDK semver resolver against live ${PARENT} versions index\n`);
+  let pass = 0;
+  let fail = 0;
+
+  for (const { range, expectedLabel } of CASES) {
+    const fullRange = `${PARENT}@${range}`;
+    process.stdout.write(`  ${fullRange.padEnd(34)} `);
+    try {
+      const resolved = await resolveVersionedName(fullRange, { chain: "sepolia" });
+      const expected = `${expectedLabel}.${PARENT}`;
+      if (resolved === expected) {
+        console.log(`✓ → ${resolved}`);
+        pass++;
+      } else {
+        console.log(`✗ expected ${expected}, got ${resolved}`);
+        fail++;
+      }
+    } catch (e: any) {
+      console.log(`✗ threw: ${e?.shortMessage ?? e?.message ?? e}`);
+      fail++;
+    }
+  }
+
+  console.log();
+  console.log(`${pass}/${CASES.length} passed`);
+  console.log();
+
+  // Bonus — full resolveSkill via @latest, confirm the bundle's version field matches v2
+  if (pass > 0) {
+    process.stdout.write(`  full resolveSkill("${PARENT}@latest")… `);
+    try {
+      const r = await resolveSkill(`${PARENT}@latest`, { chain: "sepolia" });
+      console.log(`✓ resolved to bundle version ${r.bundle.version}, cid ${r.cid.slice(0, 14)}…`);
+    } catch (e: any) {
+      console.log(`✗ ${e?.shortMessage ?? e?.message ?? e}`);
+      fail++;
+    }
+  }
+
+  process.exit(fail > 0 ? 1 : 0);
+}
+
+main();

--- a/skillname-pack/packages/cli/src/commands/lock.ts
+++ b/skillname-pack/packages/cli/src/commands/lock.ts
@@ -1,0 +1,134 @@
+/**
+ * skill lock — walk imports + pin lockfile to 0G + set ENS text record.
+ *
+ * Output:
+ *   1. JSON lockfile with [{ ensName, version, cid }] for the root + every
+ *      transitive import, frozen at resolve-time
+ *   2. Pinned to 0G storage; root hash is the lockfile CID
+ *   3. `xyz.manifest.skill.lockfile = 0g://0x<root>` text record set on the
+ *      root ENS name (only the root signs — not the children)
+ *
+ * Usage:
+ *   skill lock <ensName>
+ *
+ * Required env:
+ *   SEPOLIA_PRIVATE_KEY  — owner of the root ENS name
+ */
+
+import "dotenv/config";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  createPublicClient,
+  createWalletClient,
+  http,
+  namehash,
+  parseAbi,
+  type Hex,
+} from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+import { sepolia } from "viem/chains";
+import {
+  walkImports,
+  generateLockfile,
+  SKILL_LOCKFILE_KEY,
+} from "@skillname/sdk";
+
+const RESOLVER = "0xE99638b40E4Fff0129D56f03b55b6bbC4BBE49b5";
+const RESOLVER_ABI = parseAbi([
+  "function setText(bytes32 node, string key, string value) external",
+]);
+
+export async function lock(ensName: string): Promise<void> {
+  if (!ensName.endsWith(".eth")) {
+    throw new Error(`ensName must end with .eth, got "${ensName}"`);
+  }
+
+  const privateKey = process.env.SEPOLIA_PRIVATE_KEY;
+  if (!privateKey) throw new Error("SEPOLIA_PRIVATE_KEY env not set");
+  const key = (privateKey.startsWith("0x") ? privateKey : "0x" + privateKey) as Hex;
+
+  console.log(`skill lock ${ensName}`);
+  console.log(`  walking imports…`);
+
+  const { flat } = await walkImports(ensName, { chain: "sepolia" });
+  const lockfile = generateLockfile(flat);
+
+  console.log(`  resolved ${lockfile.length} entries:`);
+  for (const e of lockfile) {
+    console.log(`    ${e.ensName.padEnd(28)} ${e.version.padEnd(10)} ${e.cid}`);
+  }
+  console.log();
+
+  // Write lockfile to a temp file so the 0G CLI can pin it
+  const dir = mkdtempSync(join(tmpdir(), "skillname-lock-"));
+  const lockfilePath = join(dir, `${ensName}.lockfile.json`);
+  const lockfileJson = JSON.stringify(
+    {
+      $schema: "https://manifest.eth/schemas/skill-lockfile-v1.json",
+      root: ensName,
+      generatedAt: new Date().toISOString(),
+      entries: lockfile,
+    },
+    null,
+    2,
+  );
+  writeFileSync(lockfilePath, lockfileJson);
+  console.log(`  wrote lockfile (${lockfileJson.length} bytes) → ${lockfilePath}`);
+
+  // Pin to 0G via the local CLI
+  console.log(`→ pinning lockfile to 0G…`);
+  const root = pinTo0G(lockfilePath, privateKey);
+  if (!root) throw new Error("failed to extract 0G root from upload output");
+  console.log(`  ✓ root: ${root}`);
+  console.log();
+
+  // Set the lockfile text record on the root name
+  const rpcUrl =
+    process.env.SEPOLIA_RPC_URL ??
+    "https://ethereum-sepolia-rpc.publicnode.com";
+  const account = privateKeyToAccount(key);
+  const publicClient = createPublicClient({ chain: sepolia, transport: http(rpcUrl) });
+  const wallet = createWalletClient({ account, chain: sepolia, transport: http(rpcUrl) });
+
+  const node = namehash(ensName);
+  const value = `0g://${root}`;
+
+  console.log(`→ setText(${SKILL_LOCKFILE_KEY}, ${value})`);
+  const txHash = await wallet.writeContract({
+    address: RESOLVER as `0x${string}`,
+    abi: RESOLVER_ABI,
+    functionName: "setText",
+    args: [node, SKILL_LOCKFILE_KEY, value],
+  });
+  const receipt = await publicClient.waitForTransactionReceipt({ hash: txHash });
+  if (receipt.status !== "success") {
+    throw new Error(`setText reverted: ${txHash}`);
+  }
+  console.log(`  ✓ ${txHash}`);
+  console.log();
+  console.log(`✓ locked ${ensName} (${lockfile.length} entries)`);
+}
+
+function pinTo0G(filePath: string, privateKey: string): string | null {
+  const cli = process.env.OG_CLI_BIN ?? "0g-storage-client";
+  const ogRpc = process.env.OG_RPC_URL ?? "https://evmrpc-testnet.0g.ai";
+  const indexer =
+    process.env.OG_INDEXER_URL ?? "https://indexer-storage-testnet-turbo.0g.ai";
+
+  const r = spawnSync(
+    cli,
+    ["upload", "--url", ogRpc, "--indexer", indexer, "--key", privateKey, "--file", filePath],
+    { encoding: "utf8" },
+  );
+  const combined = (r.stdout ?? "") + "\n" + (r.stderr ?? "");
+  if (r.status !== 0) {
+    console.error(`  ✗ 0g-storage-client exit ${r.status}`);
+    if (combined.trim()) console.error(combined);
+    return null;
+  }
+  const m = combined.match(/root[s]?\s*=\s*(0x[a-fA-F0-9]+)/);
+  return m ? m[1] : null;
+}

--- a/skillname-pack/packages/cli/src/index.ts
+++ b/skillname-pack/packages/cli/src/index.ts
@@ -18,6 +18,7 @@ import { verify } from "./commands/verify.js";
 import { init } from "./commands/init.js";
 import { registerOnchain } from "./commands/register-onchain.js";
 import { publish } from "./commands/publish.js";
+import { lock } from "./commands/lock.js";
 
 const HELP = `
 skill — ENS-native skill registry CLI
@@ -147,10 +148,11 @@ async function main() {
       break;
 
     case "lock":
-      console.error(
-        "skill lock — not yet implemented. Depends on skill.imports (#3).",
-      );
-      process.exit(1);
+      if (!positional[0]) {
+        console.error("Usage: skill lock <ensName>");
+        process.exit(1);
+      }
+      await lock(positional[0]);
       break;
 
     default:

--- a/skillname-pack/packages/sdk/src/index.ts
+++ b/skillname-pack/packages/sdk/src/index.ts
@@ -33,6 +33,9 @@ export const SKILL_EXECUTION_KEY = "xyz.manifest.skill.execution";
 export const SKILL_0G_KEY = "xyz.manifest.skill.0g";
 export const SKILL_IMPORTS_KEY = "xyz.manifest.skill.imports";
 export const SKILL_LOCKFILE_KEY = "xyz.manifest.skill.lockfile";
+/** Versions index: CSV of `<label>:<semver>` pairs published as subnames. */
+export const SKILL_VERSIONS_KEY = "xyz.manifest.skill.versions";
+export const SKILL_LATEST_KEY = "xyz.manifest.skill.latest";
 
 export interface SkillBundle {
   $schema?: string;
@@ -174,6 +177,17 @@ export async function resolveSkill(
   ensName: string,
   options: ResolveOptions = {},
 ): Promise<ResolveResult> {
+  // If the name carries a semver range suffix (e.g. "quote.uniswap.eth@^1"),
+  // first resolve it to a concrete versioned subname via the parent's
+  // `xyz.manifest.skill.versions` index. Falls through to direct resolution
+  // when no `@<range>` suffix is present.
+  if (ensName.includes("@")) {
+    ensName = await resolveVersionedName(ensName, {
+      chain: options.chain,
+      rpcUrl: options.rpcUrl,
+    });
+  }
+
   const normalized = normalize(ensName);
 
   // Default to Sepolia for hackathon — mainnet is opt-in.
@@ -558,6 +572,164 @@ export function generateLockfile(
     version: r.version ?? r.bundle.version,
     cid: r.cid,
   }));
+}
+
+// -------------------------------------------------------------------------
+// Versioning — semver matching against the per-name version index
+// -------------------------------------------------------------------------
+//
+// Spec (matches the ENSIP-25 / xyz.manifest.skill.* family):
+//   xyz.manifest.skill.versions  = "v1:1.0.0,v2:2.0.0,v3:2.1.0"   (CSV)
+//   xyz.manifest.skill.latest    = "v3"                            (subname label)
+//
+// Each <label> in the versions index is the subname under the parent that
+// pins that exact version's bundle CID. e.g. for `quote.uniswap.eth`:
+//   v1.quote.uniswap.eth → manifest at version 1.0.0
+//   v2.quote.uniswap.eth → manifest at version 2.0.0
+//
+// `matchVersionRange("^1", index)` returns the highest matching label.
+
+export interface VersionEntry {
+  label: string;   // subname label, e.g. "v1"
+  version: string; // semver, e.g. "1.0.0"
+}
+
+/**
+ * Parse the CSV `xyz.manifest.skill.versions` text record.
+ *
+ * @example
+ *   parseVersionsRecord("v1:1.0.0,v2:2.0.0,v3:2.1.0")
+ *   // → [{label:"v1",version:"1.0.0"}, {label:"v2",version:"2.0.0"}, ...]
+ */
+export function parseVersionsRecord(raw: string): VersionEntry[] {
+  if (!raw) return [];
+  return raw
+    .split(",")
+    .map((pair) => pair.trim())
+    .filter(Boolean)
+    .map((pair) => {
+      const i = pair.indexOf(":");
+      if (i === -1) throw new Error(`malformed versions entry: "${pair}"`);
+      return { label: pair.slice(0, i).trim(), version: pair.slice(i + 1).trim() };
+    });
+}
+
+interface ParsedSemver {
+  major: number;
+  minor: number;
+  patch: number;
+}
+
+function parseSemver(v: string): ParsedSemver {
+  const m = v.match(/^v?(\d+)\.(\d+)\.(\d+)$/);
+  if (!m) throw new Error(`invalid semver: "${v}"`);
+  return { major: +m[1], minor: +m[2], patch: +m[3] };
+}
+
+function compareSemver(a: ParsedSemver, b: ParsedSemver): number {
+  return a.major - b.major || a.minor - b.minor || a.patch - b.patch;
+}
+
+/**
+ * Test whether a concrete semver `v` satisfies an npm-style range `range`.
+ * Supports: exact ("1.2.3"), caret ("^1.2.3"), tilde ("~1.2.3"),
+ * "latest" / "*" wildcard, and bare-major shorthands like "^1" or "~2".
+ */
+export function semverSatisfies(v: string, range: string): boolean {
+  range = range.trim();
+  if (range === "*" || range === "latest" || range === "") return true;
+
+  const sv = parseSemver(v);
+
+  if (range.startsWith("^")) {
+    // ^x.y.z accepts >=x.y.z, <(x+1).0.0   (or ^x → ^x.0.0)
+    const r = parseSemver(normalizeShorthand(range.slice(1)));
+    return (
+      sv.major === r.major &&
+      compareSemver(sv, r) >= 0
+    );
+  }
+  if (range.startsWith("~")) {
+    // ~x.y.z accepts >=x.y.z, <x.(y+1).0   (or ~x → ~x.0.0)
+    const r = parseSemver(normalizeShorthand(range.slice(1)));
+    return (
+      sv.major === r.major &&
+      sv.minor === r.minor &&
+      compareSemver(sv, r) >= 0
+    );
+  }
+  // Exact match (or "v"-prefixed exact)
+  return compareSemver(sv, parseSemver(normalizeShorthand(range))) === 0;
+}
+
+function normalizeShorthand(v: string): string {
+  // "1" → "1.0.0", "1.2" → "1.2.0", "1.2.3" → "1.2.3", "v1" → "v1.0.0"
+  const stripped = v.startsWith("v") ? v.slice(1) : v;
+  const parts = stripped.split(".");
+  while (parts.length < 3) parts.push("0");
+  return parts.join(".");
+}
+
+/**
+ * Pick the highest version in `index` that satisfies `range`.
+ * Returns null if no entry matches.
+ */
+export function matchVersionRange(
+  range: string,
+  index: VersionEntry[],
+): VersionEntry | null {
+  const matches = index.filter((e) => semverSatisfies(e.version, range));
+  if (matches.length === 0) return null;
+  matches.sort((a, b) => compareSemver(parseSemver(b.version), parseSemver(a.version)));
+  return matches[0];
+}
+
+/**
+ * Resolve a versioned ENS name like `quote.uniswap.eth@^1` into the concrete
+ * subname (`v1.quote.uniswap.eth`). Reads the parent's
+ * `xyz.manifest.skill.versions` text record + matches the range.
+ *
+ * If the name has no `@<range>` suffix, returns the name unchanged.
+ * If the name's parent has no versions index, throws — callers can catch
+ * and fall back to direct resolution.
+ */
+export async function resolveVersionedName(
+  ensNameWithRange: string,
+  options: { chain?: "mainnet" | "sepolia"; rpcUrl?: string } = {},
+): Promise<string> {
+  const i = ensNameWithRange.indexOf("@");
+  if (i === -1) return ensNameWithRange;
+
+  const parent = ensNameWithRange.slice(0, i);
+  const range = ensNameWithRange.slice(i + 1);
+
+  const chain = options.chain ?? "sepolia";
+  const client = createPublicClient({
+    chain: chain === "mainnet" ? mainnet : sepolia,
+    transport: http(options.rpcUrl),
+  }) as PublicClient;
+  const universalResolverAddress: Address | undefined =
+    chain === "sepolia" ? ENS_SEPOLIA.universalResolver : undefined;
+
+  const versionsRaw = await client.getEnsText({
+    name: normalize(parent),
+    key: SKILL_VERSIONS_KEY,
+    universalResolverAddress,
+  });
+  if (!versionsRaw) {
+    throw new Error(
+      `${parent} has no ${SKILL_VERSIONS_KEY} text record — cannot match range "${range}"`,
+    );
+  }
+
+  const index = parseVersionsRecord(versionsRaw);
+  const match = matchVersionRange(range, index);
+  if (!match) {
+    throw new Error(
+      `no version in ${parent} satisfies range "${range}". Available: ${index.map((e) => `${e.label}:${e.version}`).join(", ")}`,
+    );
+  }
+  return `${match.label}.${parent}`;
 }
 
 // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes the meat of [#16](https://github.com/hien-p/Skillname/issues/16) and the last open command in [#17](https://github.com/hien-p/Skillname/issues/17). **`skill resolve quote.skilltest.eth@^1`** now works end-to-end — npm-style semver, on-chain.

## Live evidence

Set up on Sepolia today (script: `scripts/setup-versions.ts`):

```
parent:  quote.skilltest.eth
  xyz.manifest.skill.versions = "v1:1.0.0,v2:2.0.0"
  xyz.manifest.skill.latest   = "v2"

v1.quote.skilltest.eth → 0g://0x9b4364df… (version 1.0.0)
v2.quote.skilltest.eth → 0g://0xa70c88dc… (version 2.0.0)
```

Verifier (`scripts/verify-versions.ts`) hits the live records:

```
quote.skilltest.eth@^1     ✓ → v1.quote.skilltest.eth
quote.skilltest.eth@^2     ✓ → v2.quote.skilltest.eth
quote.skilltest.eth@~1.0   ✓ → v1.quote.skilltest.eth
quote.skilltest.eth@1.0.0  ✓ → v1.quote.skilltest.eth
quote.skilltest.eth@2.0.0  ✓ → v2.quote.skilltest.eth
quote.skilltest.eth@latest ✓ → v2.quote.skilltest.eth
quote.skilltest.eth@*      ✓ → v2.quote.skilltest.eth

7/7 passed

resolveSkill("quote.skilltest.eth@latest") → bundle.version "2.0.0" ✓
```

## What's in this PR

**SDK** (`packages/sdk/src/index.ts`)
- `SKILL_VERSIONS_KEY` / `SKILL_LATEST_KEY` text-record constants
- `VersionEntry` type + `parseVersionsRecord(csv)` for the per-name index format
- `semverSatisfies(v, range)` — minimal `^x.y.z` / `~x.y.z` / exact / `latest` / `*` matcher, **no external deps** (12/12 unit cases pass)
- `matchVersionRange(range, index)` — picks the highest entry that satisfies the range
- `resolveVersionedName("name@range")` — reads the parent's versions index + returns the concrete subname
- `resolveSkill(name)` — transparently resolves `name@range` syntax through the new helper. Backwards compat preserved when the input has no `@`.

**CLI** (`skillname-pack/packages/cli/src/commands/lock.ts`)
- `skill lock <ensName>` — walks imports → generates lockfile JSON → pins to 0G → `setText(xyz.manifest.skill.lockfile, 0g://0x<root>)` on the root
- Closes the last "Implement: lock.ts" item from #17

**Scripts**
- `scripts/setup-versions.ts` — registers `v1` + `v2` subnames + pins two manifests + sets all 8 text records (3 per version subname + 2 on parent)
- `scripts/verify-versions.ts` — exercises 7 range cases + a full `resolveSkill` against the live records

## What's intentionally out of scope

**NameWrapper fuse burning** (CANNOT_TRANSFER, CANNOT_SET_RESOLVER on version subnames). Burning is permanent; the demo doesn't need immutable subnames; re-pinning + bumping the index is the active flow. Stays open in #16 — happy to revisit post-hackathon.

## Cost

~0.000005 ETH on Sepolia (10 setText + 2 setSubnodeRecord) + 2 small 0G pins. Wallet balance unchanged at the millisatoshi level.