### PR TITLE
feat(nft): SkillNFT — ERC-7857 sketch, deployed at 0xa16e83…

### DIFF
--- a/contracts/script/DeploySkillNFT.s.sol
+++ b/contracts/script/DeploySkillNFT.s.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Script.sol";
+import "../src/SkillNFT.sol";
+
+/// @notice Deploys SkillNFT to Sepolia. No constructor args.
+///
+/// Usage:
+///   SEPOLIA_PRIVATE_KEY=0x... \
+///   forge script contracts/script/DeploySkillNFT.s.sol \
+///     --rpc-url https://ethereum-sepolia-rpc.publicnode.com --broadcast
+contract DeploySkillNFT is Script {
+    function run() external {
+        uint256 deployerKey = vm.envUint("SEPOLIA_PRIVATE_KEY");
+        vm.startBroadcast(deployerKey);
+        SkillNFT nft = new SkillNFT();
+        console.log("SkillNFT deployed at:", address(nft));
+        console.log("name:", nft.name());
+        console.log("symbol:", nft.symbol());
+        vm.stopBroadcast();
+    }
+}

--- a/contracts/src/SkillNFT.sol
+++ b/contracts/src/SkillNFT.sol
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+/// @title SkillNFT — ERC-721 wrapper for ENS-named skills (ERC-7857 sketch)
+/// @notice Each token represents ownership of a registered skill, identified
+///         by its ENS namehash + IdentityRegistry agentId. Transferring the
+///         NFT transfers economic rights (e.g. future x402 settlement splits)
+///         without affecting the underlying ENS ownership — the two
+///         identities are bound on-chain via this contract's storage.
+///
+///         This is a minimal scaffold for the 0G iNFT track + ENS Most
+///         Creative track. Splitter integration (% of x402 → token holder)
+///         and ERC-6551 token-bound accounts are intentionally deferred to
+///         keep the surface auditable for the hackathon submission.
+///
+/// @dev    Implemented from scratch (no OpenZeppelin dep) to keep the
+///         contracts/ tree dependency-free. Covers ERC-721 + ERC-721Metadata
+///         + ERC-165 — the minimum for marketplaces (OpenSea testnet) to
+///         recognise the collection.
+
+interface IIdentityRegistry {
+    function ownerOf(uint256 agentId) external view returns (address);
+}
+
+contract SkillNFT {
+    // ── Constants ────────────────────────────────────────────────────────
+
+    string public constant name   = "Skillname Agent";
+    string public constant symbol = "SKILL";
+
+    /// @notice IdentityRegistry on Sepolia (per docs/ENSIP25_BINDING.md)
+    IIdentityRegistry public constant IDENTITY_REGISTRY =
+        IIdentityRegistry(0x48f77FfE1f02FB94bDe9c8ffe84bB4956ace11e4);
+
+    // ── Types ────────────────────────────────────────────────────────────
+
+    struct Agent {
+        bytes32 ensNode;       // namehash of the ENS name this token wraps
+        uint256 agentId;       // IdentityRegistry agentId at mint time
+        string  metadataUri;   // pointer to JSON metadata (typically 0g:// or ipfs://)
+        address minter;        // address that called mint()
+        uint64  mintedAt;      // block.timestamp
+    }
+
+    // ── State ────────────────────────────────────────────────────────────
+
+    uint256 public totalSupply;
+    mapping(uint256 => Agent) public agents;        // tokenId → Agent
+    mapping(uint256 => address) private _owners;    // tokenId → owner
+    mapping(address => uint256) private _balances;  // owner → balance
+    mapping(uint256 => address) private _approved;  // tokenId → approved
+    mapping(address => mapping(address => bool)) private _operators;
+
+    // ── Events ───────────────────────────────────────────────────────────
+
+    /// @notice ERC-721
+    event Transfer(address indexed from, address indexed to, uint256 indexed tokenId);
+    event Approval(address indexed owner, address indexed approved, uint256 indexed tokenId);
+    event ApprovalForAll(address indexed owner, address indexed operator, bool approved);
+
+    /// @notice Skillname-specific — when a new agent is minted.
+    event AgentMinted(
+        uint256 indexed tokenId,
+        bytes32 indexed ensNode,
+        uint256 indexed agentId,
+        address minter,
+        string  metadataUri
+    );
+
+    /// @notice Lets metadata indexers (OpenSea, etc.) refresh per-token data.
+    event MetadataUpdate(uint256 indexed tokenId);
+
+    // ── Errors ───────────────────────────────────────────────────────────
+
+    error AgentIdNotOwnedByMinter(uint256 agentId, address minter, address registryOwner);
+    error TokenDoesNotExist(uint256 tokenId);
+    error NotAuthorized(address caller);
+    error TransferToZero();
+    error NotCurrentOwner(address from, address actualOwner);
+    error InvalidRecipient();
+
+    // ── Mint ─────────────────────────────────────────────────────────────
+
+    /// @notice Mint a new skill NFT. Caller must be the IdentityRegistry
+    ///         owner of `agentId` so the binding is meaningful.
+    /// @param  ensNode      namehash of the ENS name this token represents
+    /// @param  agentId      IdentityRegistry agentId previously minted to caller
+    /// @param  metadataUri  JSON metadata URI (0g:// or ipfs://); should resolve
+    ///                      to an OpenSea-compatible JSON document.
+    function mintAgent(
+        bytes32 ensNode,
+        uint256 agentId,
+        string calldata metadataUri
+    ) external returns (uint256 tokenId) {
+        // Verify msg.sender owns this agentId on the registry
+        address registryOwner = IDENTITY_REGISTRY.ownerOf(agentId);
+        if (registryOwner != msg.sender) {
+            revert AgentIdNotOwnedByMinter(agentId, msg.sender, registryOwner);
+        }
+
+        unchecked {
+            tokenId = ++totalSupply;
+        }
+        agents[tokenId] = Agent({
+            ensNode: ensNode,
+            agentId: agentId,
+            metadataUri: metadataUri,
+            minter: msg.sender,
+            mintedAt: uint64(block.timestamp)
+        });
+        _owners[tokenId] = msg.sender;
+        unchecked { _balances[msg.sender]++; }
+
+        emit Transfer(address(0), msg.sender, tokenId);
+        emit AgentMinted(tokenId, ensNode, agentId, msg.sender, metadataUri);
+    }
+
+    /// @notice Update the metadata URI for a token. Only the current owner.
+    function setMetadataUri(uint256 tokenId, string calldata uri) external {
+        address owner = _owners[tokenId];
+        if (owner == address(0)) revert TokenDoesNotExist(tokenId);
+        if (msg.sender != owner) revert NotAuthorized(msg.sender);
+        agents[tokenId].metadataUri = uri;
+        emit MetadataUpdate(tokenId);
+    }
+
+    // ── ERC-721 core ─────────────────────────────────────────────────────
+
+    function ownerOf(uint256 tokenId) public view returns (address) {
+        address o = _owners[tokenId];
+        if (o == address(0)) revert TokenDoesNotExist(tokenId);
+        return o;
+    }
+
+    function balanceOf(address owner) external view returns (uint256) {
+        return _balances[owner];
+    }
+
+    function tokenURI(uint256 tokenId) external view returns (string memory) {
+        if (_owners[tokenId] == address(0)) revert TokenDoesNotExist(tokenId);
+        return agents[tokenId].metadataUri;
+    }
+
+    function approve(address to, uint256 tokenId) external {
+        address owner = ownerOf(tokenId);
+        if (msg.sender != owner && !_operators[owner][msg.sender]) {
+            revert NotAuthorized(msg.sender);
+        }
+        _approved[tokenId] = to;
+        emit Approval(owner, to, tokenId);
+    }
+
+    function getApproved(uint256 tokenId) external view returns (address) {
+        if (_owners[tokenId] == address(0)) revert TokenDoesNotExist(tokenId);
+        return _approved[tokenId];
+    }
+
+    function setApprovalForAll(address operator, bool approved) external {
+        _operators[msg.sender][operator] = approved;
+        emit ApprovalForAll(msg.sender, operator, approved);
+    }
+
+    function isApprovedForAll(address owner, address operator) external view returns (bool) {
+        return _operators[owner][operator];
+    }
+
+    function transferFrom(address from, address to, uint256 tokenId) public {
+        _transfer(from, to, tokenId);
+    }
+
+    function safeTransferFrom(address from, address to, uint256 tokenId) external {
+        _transfer(from, to, tokenId);
+        // Recipient onERC721Received check intentionally omitted — keeping the
+        // contract minimal. EOAs and standard wallets handle this fine; integrators
+        // that need full ERC-721 receiver semantics should call transferFrom.
+    }
+
+    function safeTransferFrom(
+        address from,
+        address to,
+        uint256 tokenId,
+        bytes calldata /*data*/
+    ) external {
+        _transfer(from, to, tokenId);
+    }
+
+    function _transfer(address from, address to, uint256 tokenId) internal {
+        if (to == address(0)) revert TransferToZero();
+        address owner = _owners[tokenId];
+        if (owner == address(0)) revert TokenDoesNotExist(tokenId);
+        if (owner != from) revert NotCurrentOwner(from, owner);
+
+        bool authorized =
+            msg.sender == owner ||
+            _operators[owner][msg.sender] ||
+            _approved[tokenId] == msg.sender;
+        if (!authorized) revert NotAuthorized(msg.sender);
+
+        delete _approved[tokenId];
+        unchecked {
+            _balances[from]--;
+            _balances[to]++;
+        }
+        _owners[tokenId] = to;
+        emit Transfer(from, to, tokenId);
+    }
+
+    // ── ERC-165 ──────────────────────────────────────────────────────────
+
+    function supportsInterface(bytes4 id) external pure returns (bool) {
+        return
+            id == 0x01ffc9a7 || // ERC-165
+            id == 0x80ac58cd || // ERC-721
+            id == 0x5b5e139f;   // ERC-721 Metadata
+    }
+}

--- a/contracts/test/SkillNFT.t.sol
+++ b/contracts/test/SkillNFT.t.sol
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import "../src/SkillNFT.sol";
+
+/// @dev Mock the IdentityRegistry at the canonical Sepolia address so tests
+///      run hermetically.
+contract MockIdentityRegistry {
+    mapping(uint256 => address) public _owner;
+    function setOwner(uint256 id, address o) external { _owner[id] = o; }
+    function ownerOf(uint256 id) external view returns (address) { return _owner[id]; }
+}
+
+contract SkillNFTTest is Test {
+    SkillNFT nft;
+    MockIdentityRegistry mockRegistry;
+
+    address agentOwner = address(0xBEEF);
+    address attacker   = address(0xDEAD);
+    address transferTarget = address(0xC0DE);
+
+    bytes32 quoteNode = keccak256("quote.skilltest.eth"); // simplified, fine for unit tests
+    uint256 agentId = 7;
+    string  uriV1 = "0g://0x5d27a5c2b10d86f258195078562cae80ae83c39f9d27d82bd3a5f047e1e997a2";
+    string  uriV2 = "0g://0xa70c88dc726a53ec6a06c2637f104f1b39358965ed6065d791fd49483c4b4687";
+
+    function setUp() public {
+        nft = new SkillNFT();
+
+        // Etch a mock IdentityRegistry at the canonical Sepolia address +
+        // populate storage so SkillNFT's constant address resolves to it.
+        address regAddr = 0x48f77FfE1f02FB94bDe9c8ffe84bB4956ace11e4;
+        vm.etch(regAddr, address(new MockIdentityRegistry()).code);
+        // Set owner of agentId 7 → agentOwner
+        vm.store(
+            regAddr,
+            keccak256(abi.encode(agentId, uint256(0))),
+            bytes32(uint256(uint160(agentOwner)))
+        );
+    }
+
+    // ── mint ─────────────────────────────────────────────────────────────
+
+    function test_mint_success() public {
+        vm.prank(agentOwner);
+        uint256 id = nft.mintAgent(quoteNode, agentId, uriV1);
+
+        assertEq(id, 1);
+        assertEq(nft.totalSupply(), 1);
+        assertEq(nft.ownerOf(id), agentOwner);
+        assertEq(nft.balanceOf(agentOwner), 1);
+        assertEq(nft.tokenURI(id), uriV1);
+
+        (bytes32 ensNode, uint256 storedAgentId, string memory uri, address minter, uint64 mintedAt) =
+            nft.agents(id);
+        assertEq(ensNode, quoteNode);
+        assertEq(storedAgentId, agentId);
+        assertEq(uri, uriV1);
+        assertEq(minter, agentOwner);
+        assertGt(mintedAt, 0);
+    }
+
+    function test_mint_notAgentOwner_reverts() public {
+        vm.prank(attacker);
+        vm.expectRevert();
+        nft.mintAgent(quoteNode, agentId, uriV1);
+    }
+
+    function test_mint_assignsIncrementingTokenIds() public {
+        vm.prank(agentOwner);
+        uint256 a = nft.mintAgent(quoteNode, agentId, uriV1);
+        vm.prank(agentOwner);
+        uint256 b = nft.mintAgent(quoteNode, agentId, uriV2);
+        assertEq(a, 1);
+        assertEq(b, 2);
+        assertEq(nft.totalSupply(), 2);
+    }
+
+    // ── metadata ─────────────────────────────────────────────────────────
+
+    function test_setMetadataUri_owner() public {
+        vm.prank(agentOwner);
+        uint256 id = nft.mintAgent(quoteNode, agentId, uriV1);
+
+        vm.prank(agentOwner);
+        nft.setMetadataUri(id, uriV2);
+        assertEq(nft.tokenURI(id), uriV2);
+    }
+
+    function test_setMetadataUri_notOwner_reverts() public {
+        vm.prank(agentOwner);
+        uint256 id = nft.mintAgent(quoteNode, agentId, uriV1);
+
+        vm.prank(attacker);
+        vm.expectRevert();
+        nft.setMetadataUri(id, uriV2);
+    }
+
+    // ── transfer ─────────────────────────────────────────────────────────
+
+    function test_transfer() public {
+        vm.prank(agentOwner);
+        uint256 id = nft.mintAgent(quoteNode, agentId, uriV1);
+
+        vm.prank(agentOwner);
+        nft.transferFrom(agentOwner, transferTarget, id);
+
+        assertEq(nft.ownerOf(id), transferTarget);
+        assertEq(nft.balanceOf(agentOwner), 0);
+        assertEq(nft.balanceOf(transferTarget), 1);
+    }
+
+    function test_transfer_notOwner_reverts() public {
+        vm.prank(agentOwner);
+        uint256 id = nft.mintAgent(quoteNode, agentId, uriV1);
+
+        vm.prank(attacker);
+        vm.expectRevert();
+        nft.transferFrom(agentOwner, transferTarget, id);
+    }
+
+    function test_approveAndTransferFrom() public {
+        vm.prank(agentOwner);
+        uint256 id = nft.mintAgent(quoteNode, agentId, uriV1);
+
+        vm.prank(agentOwner);
+        nft.approve(attacker, id);
+        assertEq(nft.getApproved(id), attacker);
+
+        // Even attacker can transferFrom because they have approval
+        vm.prank(attacker);
+        nft.transferFrom(agentOwner, transferTarget, id);
+        assertEq(nft.ownerOf(id), transferTarget);
+        // Approval should clear after transfer
+        assertEq(nft.getApproved(id), address(0));
+    }
+
+    // ── ERC-165 ──────────────────────────────────────────────────────────
+
+    function test_supportsInterface() public {
+        assertTrue(nft.supportsInterface(0x01ffc9a7), "ERC-165");
+        assertTrue(nft.supportsInterface(0x80ac58cd), "ERC-721");
+        assertTrue(nft.supportsInterface(0x5b5e139f), "ERC-721 Metadata");
+        assertFalse(nft.supportsInterface(0xffffffff));
+    }
+
+    // ── ERC-721 metadata getters ─────────────────────────────────────────
+
+    function test_metadataNameSymbol() public {
+        assertEq(nft.name(), "Skillname Agent");
+        assertEq(nft.symbol(), "SKILL");
+    }
+
+    function test_tokenURI_nonexistent_reverts() public {
+        vm.expectRevert();
+        nft.tokenURI(999);
+    }
+}


### PR DESCRIPTION
## Summary

Closes the contract half of [#18](https://github.com/hien-p/Skillname/issues/18) — ERC-7857 iNFT royalty wrapper. **Live on Sepolia** at:

| Network | Address | Explorer |
|---|---|---|
| Sepolia | \`0xa16e83529d9bed52e74673a08f4c8255b1102827\` | [Etherscan](https://sepolia.etherscan.io/address/0xa16e83529d9bed52e74673a08f4c8255b1102827) |

\`totalSupply() = 1\` — one demo token minted today binding \`quote.skilltest.eth\` (agentId 7, namehash \`0xde7e9dfb…\`) to the operator wallet.

## What's in the contract (\`contracts/src/SkillNFT.sol\`)

ERC-721 + Metadata + ERC-165, ~200 lines, no external dependencies (no OZ pull). Each token binds:

- ENS namehash of the skill it represents
- IdentityRegistry \`agentId\` (the agent identity from #60)
- Metadata URI (typically a \`0g://\` or \`ipfs://\` pointer)

\`mintAgent(ensNode, agentId, uri)\`:
- Verifies \`msg.sender\` owns the \`agentId\` on the deployed IdentityRegistry — so an NFT can't be minted out from under the registry-side agent owner
- Emits both ERC-721 \`Transfer\` and a custom \`AgentMinted\` event

\`setMetadataUri(tokenId, uri)\`:
- Owner-only
- Emits \`MetadataUpdate\` so OpenSea / Reservoir refresh

OpenSea testnet auto-discovers since \`supportsInterface\` declares \`0x80ac58cd\` (ERC-721) + \`0x5b5e139f\` (Metadata).

## Tests

11/11 Foundry cases pass:

\`\`\`
test_mint_success
test_mint_notAgentOwner_reverts
test_mint_assignsIncrementingTokenIds
test_setMetadataUri_owner
test_setMetadataUri_notOwner_reverts
test_transfer
test_transfer_notOwner_reverts
test_approveAndTransferFrom
test_supportsInterface
test_metadataNameSymbol
test_tokenURI_nonexistent_reverts
\`\`\`

## What's intentionally deferred (still open in #18)

- **Splitter contract on Base Sepolia** — % of x402 settlement → token holder. Blocked on the KeeperHub MCP issue (B-002 in FEEDBACK.md) that prevents real x402 settlements from landing. Once unblocked upstream, splitter is a separate ~2h.
- **ERC-6551 token-bound account** integration.
- **Sealed inference layer** for the 0G iNFT track (the "intelligence" half of the spec).

## Demo evidence

\`\`\`
$ cast call 0xa16e83… "totalSupply()(uint256)" --rpc-url ...
1

$ cast call 0xa16e83… "ownerOf(uint256)(address)" 1 --rpc-url ...
0x3Fb7c18EBBBa1A9b54692C2655F9Df0317f68e95

$ cast call 0xa16e83… "tokenURI(uint256)(string)" 1 --rpc-url ...
"0g://0x5d27a5c2b10d86f258195078562cae80ae83c39f9d27d82bd3a5f047e1e997a2"

$ cast call 0xa16e83… "supportsInterface(bytes4)(bool)" 0x80ac58cd --rpc-url ...
true
\`\`\`

Cost: 0.000001 ETH for deploy + 0.0000001 ETH for the demo mint. Trivial.