### PR TITLE
feat: agent-research composite skill + web semver resolver + NFT counts

### DIFF
--- a/.github/workflows/pin-and-register.yml
+++ b/.github/workflows/pin-and-register.yml
@@ -65,18 +65,11 @@ jobs:
           ~/go/bin/0g-storage-client --version || ~/go/bin/0g-storage-client version || true
 
       - id: pin
-<<<<<<< Updated upstream
-        name: Pin to 0G
-        env:
-          SEPOLIA_PRIVATE_KEY: ${{ secrets.SEPOLIA_PRIVATE_KEY }}
-          OG_RPC_URL: ${{ vars.OG_RPC_URL || 'https://evmrpc-testnet.0g.ai' }}
-=======
         name: Pin to 0G via Go CLI
         env:
           SEPOLIA_PRIVATE_KEY: ${{ secrets.SEPOLIA_PRIVATE_KEY }}
           OG_RPC_URL: ${{ vars.OG_RPC_URL || 'https://evmrpc-testnet.0g.ai' }}
           OG_INDEXER_URL: ${{ vars.OG_INDEXER_URL || 'https://indexer-storage-testnet-turbo.0g.ai' }}
->>>>>>> Stashed changes
         run: |
           if [ -n "${{ inputs.slug }}" ]; then
             pnpm tsx scripts/pin-to-0g.ts "${{ inputs.slug }}"
@@ -91,13 +84,8 @@ jobs:
         run: |
           ROOTS="${{ steps.pin.outputs.roots }}"
           if [ -z "$ROOTS" ]; then
-<<<<<<< Updated upstream
-            echo "::warning::pin step did not produce any 0G roots; skipping register"
-            exit 0
-=======
             echo "::error::pin step produced no 0G roots — check operator balance + faucet"
             exit 1
->>>>>>> Stashed changes
           fi
           pnpm tsx scripts/register-skills.ts \
             --parent "${{ inputs.parent }}" \

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -2315,8 +2315,18 @@
   const HELLO_WORLD = {"$schema":"https://manifest.eth/schemas/skill-v1.json","name":"hello-world","ensName":"hello.world.eth","version":"1.0.0","description":"One function: greet a name. The smallest possible local-execution skill.","license":"MIT","tools":[{"name":"greet","description":"Returns 'Hello, {name}!' Runs locally inside the bridge process.","execution":{"type":"local","handler":"tools/greet.json"}}],"trust":{"ensip25":{"enabled":true},"erc8004":{"registry":"eip155:11155111:0x48f77FfE1f02FB94bDe9c8ffe84bB4956ace11e4","agentId":6}}};
   const INFER_0G = {"$schema":"https://manifest.eth/schemas/skill-v1.json","name":"infer-0g","ensName":"infer.skilltest.eth","version":"1.0.0","description":"AI inference via 0G Compute Network. Routes prompts to decentralized GPU providers.","license":"MIT","tools":[{"name":"infer","description":"Run AI inference on 0G Compute Network.","execution":{"type":"0g-compute","providerAddress":"0xa48f01287233509FD694a22Bf840225062E67836","model":"qwen/qwen-2.5-7b-instruct"}}]};
   const AGENT_RESEARCH = {"$schema":"https://manifest.eth/schemas/skill-v1.json","name":"agent-research","ensName":"agent.skilltest.eth","version":"1.0.0","description":"Composite skill: research a token + holder by fanning out to three atomic skills — quote (price), score (Passport reputation), infer (LLM verdict). Demonstrates the import-graph: one ENS name resolves to three transitive tools at the bridge.","license":"MIT","dependencies":["quote.skilltest.eth","score.skilltest.eth","infer.skilltest.eth"],"tools":[{"name":"research_token","description":"Fan out to three imported skills: get the token's USD price via quote.skilltest.eth, the holder's Gitcoin Passport score via score.skilltest.eth, then ask infer.skilltest.eth (0G Compute) for a one-sentence verdict.","execution":{"type":"local","handler":"tools/research_token.json"}}],"trust":{"ensip25":{"enabled":true}}};
+  // Synthetic v2 — same shape as v1, version + description bumped. Mirrors
+  // what scripts/setup-versions.ts pinned to 0G.
+  const QUOTE_UNISWAP_V2 = {
+    ...QUOTE_UNISWAP,
+    ensName: "v2.quote.skilltest.eth",
+    version: "2.0.0",
+    description: "(v2) " + QUOTE_UNISWAP.description,
+  };
   const MANIFEST_CACHE = {
     'quote.skilltest.eth': QUOTE_UNISWAP, 'quote.uniswap.eth': QUOTE_UNISWAP,
+    'v1.quote.skilltest.eth': QUOTE_UNISWAP,
+    'v2.quote.skilltest.eth': QUOTE_UNISWAP_V2,
     'swap.skilltest.eth': SWAP_UNISWAP, 'swap.uniswap.eth': SWAP_UNISWAP,
     'score.skilltest.eth': SCORE_GITCOIN, 'score.gitcoin.eth': SCORE_GITCOIN,
     'weather.skilltest.eth': WEATHER_TOMORROW, 'weather.tomorrow.eth': WEATHER_TOMORROW,

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -1875,6 +1875,9 @@
           <div class="label">SKILLLINK · sepolia</div>
           <div class="metric-value" style="margin-top:6px;font-size:42px" id="onchainCount">—</div>
           <div class="label" style="margin-top:2px">SKILLS REGISTERED</div>
+          <div class="label" style="margin-top:8px;font-size:10px;color:var(--text-secondary)">
+            <span id="nftCount">—</span> SkillNFT · <span id="agentCount">—</span> agents
+          </div>
         </div>
         <div class="metric-foot" style="flex-direction:column;align-items:stretch;gap:8px">
           <button id="onchainRun" type="button" style="background:var(--text-display);color:var(--black);border:none;padding:10px 14px;font-family:inherit;font-size:11px;font-weight:600;letter-spacing:0.06em;text-transform:uppercase;cursor:pointer;border-radius:0">
@@ -2311,6 +2314,7 @@
   const WEATHER_TOMORROW = {"$schema":"https://manifest.eth/schemas/skill-v1.json","name":"weather-tomorrow","ensName":"weather.tomorrow.eth","version":"1.0.0","description":"One function: get the current and next-day weather forecast for a lat/lng. Free, no auth, via Open-Meteo.","license":"MIT","tools":[{"name":"forecast","description":"Returns hourly + daily forecast.","execution":{"type":"http","endpoint":"https://api.open-meteo.com/v1/forecast","method":"GET"}}],"trust":{"ensip25":{"enabled":true},"erc8004":{"registry":"eip155:11155111:0x48f77FfE1f02FB94bDe9c8ffe84bB4956ace11e4","agentId":10}}};
   const HELLO_WORLD = {"$schema":"https://manifest.eth/schemas/skill-v1.json","name":"hello-world","ensName":"hello.world.eth","version":"1.0.0","description":"One function: greet a name. The smallest possible local-execution skill.","license":"MIT","tools":[{"name":"greet","description":"Returns 'Hello, {name}!' Runs locally inside the bridge process.","execution":{"type":"local","handler":"tools/greet.json"}}],"trust":{"ensip25":{"enabled":true},"erc8004":{"registry":"eip155:11155111:0x48f77FfE1f02FB94bDe9c8ffe84bB4956ace11e4","agentId":6}}};
   const INFER_0G = {"$schema":"https://manifest.eth/schemas/skill-v1.json","name":"infer-0g","ensName":"infer.skilltest.eth","version":"1.0.0","description":"AI inference via 0G Compute Network. Routes prompts to decentralized GPU providers.","license":"MIT","tools":[{"name":"infer","description":"Run AI inference on 0G Compute Network.","execution":{"type":"0g-compute","providerAddress":"0xa48f01287233509FD694a22Bf840225062E67836","model":"qwen/qwen-2.5-7b-instruct"}}]};
+  const AGENT_RESEARCH = {"$schema":"https://manifest.eth/schemas/skill-v1.json","name":"agent-research","ensName":"agent.skilltest.eth","version":"1.0.0","description":"Composite skill: research a token + holder by fanning out to three atomic skills — quote (price), score (Passport reputation), infer (LLM verdict). Demonstrates the import-graph: one ENS name resolves to three transitive tools at the bridge.","license":"MIT","dependencies":["quote.skilltest.eth","score.skilltest.eth","infer.skilltest.eth"],"tools":[{"name":"research_token","description":"Fan out to three imported skills: get the token's USD price via quote.skilltest.eth, the holder's Gitcoin Passport score via score.skilltest.eth, then ask infer.skilltest.eth (0G Compute) for a one-sentence verdict.","execution":{"type":"local","handler":"tools/research_token.json"}}],"trust":{"ensip25":{"enabled":true}}};
   const MANIFEST_CACHE = {
     'quote.skilltest.eth': QUOTE_UNISWAP, 'quote.uniswap.eth': QUOTE_UNISWAP,
     'swap.skilltest.eth': SWAP_UNISWAP, 'swap.uniswap.eth': SWAP_UNISWAP,
@@ -2318,6 +2322,7 @@
     'weather.skilltest.eth': WEATHER_TOMORROW, 'weather.tomorrow.eth': WEATHER_TOMORROW,
     'hello.skilltest.eth': HELLO_WORLD, 'hello.world.eth': HELLO_WORLD,
     'infer.skilltest.eth': INFER_0G,
+    'agent.skilltest.eth': AGENT_RESEARCH,
   };
 
   async function fetchManifest(uri, ensName) {
@@ -2346,14 +2351,78 @@
     throw new Error(`unsupported scheme: ${uri.slice(0, 12)}…`);
   }
 
+  // ── Versioning support — quote.skilltest.eth@^1 / @latest etc. ────────────
+  // Mirrors @skillname/sdk's resolveVersionedName + semverSatisfies.
+  const VERSIONS_KEY = 'xyz.manifest.skill.versions';
+  function parseSemver(v) {
+    const m = String(v).match(/^v?(\d+)\.(\d+)\.(\d+)$/);
+    if (!m) throw new Error(`invalid semver: "${v}"`);
+    return { major: +m[1], minor: +m[2], patch: +m[3] };
+  }
+  function cmpSemver(a, b) {
+    return a.major - b.major || a.minor - b.minor || a.patch - b.patch;
+  }
+  function normalizeShorthand(v) {
+    const s = v.startsWith('v') ? v.slice(1) : v;
+    const p = s.split('.');
+    while (p.length < 3) p.push('0');
+    return p.join('.');
+  }
+  function semverSatisfies(v, range) {
+    range = range.trim();
+    if (range === '*' || range === 'latest' || range === '') return true;
+    const sv = parseSemver(v);
+    if (range.startsWith('^')) {
+      const r = parseSemver(normalizeShorthand(range.slice(1)));
+      return sv.major === r.major && cmpSemver(sv, r) >= 0;
+    }
+    if (range.startsWith('~')) {
+      const r = parseSemver(normalizeShorthand(range.slice(1)));
+      return sv.major === r.major && sv.minor === r.minor && cmpSemver(sv, r) >= 0;
+    }
+    return cmpSemver(sv, parseSemver(normalizeShorthand(range))) === 0;
+  }
+  function parseVersionsRecord(raw) {
+    if (!raw) return [];
+    return raw.split(',').map(p => p.trim()).filter(Boolean).map(pair => {
+      const i = pair.indexOf(':');
+      if (i === -1) throw new Error(`malformed versions entry: "${pair}"`);
+      return { label: pair.slice(0, i).trim(), version: pair.slice(i + 1).trim() };
+    });
+  }
+  async function resolveVersionedName(nameAtRange, chain) {
+    const i = nameAtRange.indexOf('@');
+    if (i === -1) return nameAtRange;
+    const parent = nameAtRange.slice(0, i);
+    const range = nameAtRange.slice(i + 1);
+    const client = clients[chain];
+    const versionsRaw = await client.getEnsText({ name: normalize(parent), key: VERSIONS_KEY });
+    if (!versionsRaw) {
+      throw new Error(`${parent} has no ${VERSIONS_KEY} text record — cannot match range "${range}"`);
+    }
+    const idx = parseVersionsRecord(versionsRaw);
+    const matches = idx.filter(e => semverSatisfies(e.version, range));
+    if (matches.length === 0) {
+      throw new Error(`no version in ${parent} satisfies "${range}". Available: ${idx.map(e => `${e.label}:${e.version}`).join(', ')}`);
+    }
+    matches.sort((a, b) => cmpSemver(parseSemver(b.version), parseSemver(a.version)));
+    return `${matches[0].label}.${parent}`;
+  }
+
   async function resolveSkill(name, chain) {
     const t0 = performance.now();
+    // Versioned input ("name@^1") — resolve to concrete subname first.
+    let resolvedFromRange;
+    if (name.includes('@')) {
+      resolvedFromRange = name;
+      name = await resolveVersionedName(name, chain);
+    }
     const client = clients[chain];
     const normalized = normalize(name);
     const uri = await client.getEnsText({ name: normalized, key: SKILL_KEY });
     if (!uri) throw new Error(`no ${SKILL_KEY} text record on ${name}`);
     const result = await fetchManifest(uri, normalized);
-    return { ...result, ms: Math.round(performance.now() - t0) };
+    return { ...result, ms: Math.round(performance.now() - t0), resolvedFromRange };
   }
 
   let liveResolveActive = false;
@@ -2440,7 +2509,7 @@
     `;
 
     $('#tabToolsCount').textContent = manifest.tools.length;
-    $('#tabDepsCount').textContent = (manifest.imports || []).length;
+    $('#tabDepsCount').textContent = (manifest.dependencies || []).length;
     $('#skillDetailToolsHeader').textContent = `Tools (${manifest.tools.length})`;
 
     const toolsHost = $('#skillDetailTools');
@@ -2472,17 +2541,19 @@
       toolsHost.appendChild(card);
     }
 
-    // Dependencies — manifest.imports is the planned schema field (Issue #3).
+    // Dependencies — manifest.dependencies (schema-canonical field).
+    // The bridge merges this with the xyz.manifest.skill.imports ENS text record
+    // when walking the graph (sdk parseImports).
     const depsHost = $('#skillDetailDeps');
-    const imports = manifest.imports || [];
-    if (imports.length === 0) {
+    const deps = manifest.dependencies || [];
+    if (deps.length === 0) {
       depsHost.innerHTML = `<div class="empty-state">
         <strong>No dependencies</strong>
-        This is a leaf skill — its <code>imports[]</code> array is empty, so the bridge can register it without walking a graph.
-        Once Issue #3 ships, multi-skill agents will list their imports here as ENS pointers (<code>quote.uniswap.eth</code>, <code>swap.uniswap.eth</code>…) and the bridge will resolve transitively.
+        This is a leaf skill — its <code>dependencies[]</code> array is empty, so the bridge can register it without walking a graph.
+        Composite skills list their imports here as ENS pointers (<code>quote.uniswap.eth</code>, <code>swap.uniswap.eth</code>…) and the bridge resolves them transitively.
       </div>`;
     } else {
-      depsHost.innerHTML = imports.map(d =>
+      depsHost.innerHTML = deps.map(d =>
         `<div class="tool-card"><header><span class="exec-tag">IMPORT</span><h3>${d}</h3></header></div>`
       ).join('');
     }
@@ -2649,22 +2720,31 @@
   // composition demo (agg.skilltest.eth → BestQuoteAggregator → uni + sushi)
   // when the user clicks RUN DEMO.
   const SKILLLINK_ADDR = '0x428865D8Dec9Bcc882c9e034DB4c81CBd93293A5';
+  const IDENTITY_REGISTRY_ADDR = '0x48f77FfE1f02FB94bDe9c8ffe84bB4956ace11e4';
+  const SKILL_NFT_ADDR = '0xa16e83529d9bed52e74673a08f4c8255b1102827';
   const SKILLLINK_ABI = parseAbi([
     'function skillCount() external view returns (uint256)',
     'function call(bytes32 node, bytes data) external payable returns (bytes)',
   ]);
+  const COUNT_ABI = parseAbi([
+    'function totalSupply() external view returns (uint256)',
+    'function lastId() external view returns (uint256)',
+  ]);
   const sepoliaPublic = createPublicClient({ chain: sepolia, transport: http() });
 
   async function refreshOnchainCount() {
-    try {
-      const n = await sepoliaPublic.readContract({
-        address: SKILLLINK_ADDR,
-        abi: SKILLLINK_ABI,
-        functionName: 'skillCount',
-      });
-      $('#onchainCount').textContent = String(n);
-    } catch (e) {
-      $('#onchainCount').textContent = '?';
+    const reads = [
+      [SKILLLINK_ADDR,        'skillCount',  '#onchainCount'],
+      [SKILL_NFT_ADDR,        'totalSupply', '#nftCount'],
+      [IDENTITY_REGISTRY_ADDR,'lastId',      '#agentCount'],
+    ];
+    for (const [addr, fn, sel] of reads) {
+      try {
+        const n = await sepoliaPublic.readContract({ address: addr, abi: COUNT_ABI, functionName: fn });
+        $(sel).textContent = String(n);
+      } catch (_) {
+        $(sel).textContent = '?';
+      }
     }
   }
   refreshOnchainCount();

--- a/apps/web/logs/index.html
+++ b/apps/web/logs/index.html
@@ -575,7 +575,8 @@
 
       <aside class="card day-rail" id="dayRail">
         <div class="label">DAYS</div>
-        <a class="day-btn active" href="#day-8"><span class="num">d8</span><span class="date">may 01</span></a>
+        <a class="day-btn active" href="#day-9"><span class="num">d9</span><span class="date">may 02</span></a>
+        <a class="day-btn" href="#day-8"><span class="num">d8</span><span class="date">may 01</span></a>
         <a class="day-btn" href="#day-7"><span class="num">d7</span><span class="date">apr 30</span></a>
         <a class="day-btn" href="#day-6"><span class="num">d6</span><span class="date">apr 29</span></a>
         <a class="day-btn" href="#day-5"><span class="num">d5</span><span class="date">apr 28</span></a>
@@ -583,12 +584,71 @@
 
       <main>
 
+        <!-- ── DAY 9 ── -->
+        <section class="day-section" id="day-9">
+          <div class="day-header">
+            <div class="day-num">D9</div>
+            <div class="day-name">composite skill demo · agent.skilltest.eth published · dependency graph wired · publish-flow fixes</div>
+            <div class="label">2026·05·02 · FRI · TODAY</div>
+          </div>
+
+          <article class="card entry">
+            <div class="hover-flag">FEATURE</div>
+            <div class="entry-time">16:50 · STAGING</div>
+            <div class="entry-title">First composite skill on-chain — <code>agent.skilltest.eth</code> imports three atomic leaves</div>
+            <ul>
+              <li>New bundle <code>skillname-pack/examples/agent-research</code>: <code>name: agent-research</code>, <code>ensName: agent.skilltest.eth</code>, <code>dependencies: [quote.skilltest.eth, score.skilltest.eth, infer.skilltest.eth]</code> — validates green against <code>skill-v1.schema.json</code></li>
+              <li>One <code>local</code> tool <code>research_token(token_id, holder_address)</code> with a real fan-out handler at <code>tools/research_token.json</code>: parallel <code>quote.get_quote</code> + <code>score.trust_score</code>, then sequential <code>infer.infer</code> for a one-sentence verdict — anticipates the 2-arg <code>(input, ctx)</code> signature for when bridge local-exec lands</li>
+              <li>Pinned to 0G Galileo: root <code>0x71a02456cd57fec6603520cf14230fabfc3e7caa82a0419399f70fc6dfb80d59</code></li>
+              <li>ENS subname registered on Sepolia under parent <code>skilltest.eth</code> with four text records: <code>xyz.manifest.skill = 0g://0x71a0…</code>, <code>.version = 1.0.0</code>, <code>.schema</code>, and the new <code>.imports = quote.skilltest.eth,score.skilltest.eth,infer.skilltest.eth</code></li>
+              <li>The Dependencies tab on <code>/#/skill/agent.skilltest.eth</code> now renders three IMPORT cards — first non-leaf in the registry</li>
+            </ul>
+            <div class="proof-label label">image (proof of work):</div>
+            <div class="proof-grid">
+              <div class="proof">deps tab · 3 IMPORT cards</div>
+              <div class="proof">on-chain text records</div>
+            </div>
+          </article>
+
+          <article class="card entry">
+            <div class="hover-flag">FIX</div>
+            <div class="entry-time">17:00 · STAGING</div>
+            <div class="entry-title">Web read the wrong manifest field for dependencies</div>
+            <ul>
+              <li>Skill detail view at <code>apps/web/index.html</code> read <code>manifest.imports</code> (a roadmap-#3 placeholder), but the schema-canonical field — agreed with <code>packages/sdk/src/index.ts</code> and the bridge dep-walker — is <code>manifest.dependencies</code></li>
+              <li>Effect: every published bundle's deps tab showed the empty-state regardless of imports. The bug was masked because all five existing leaves were dependency-free</li>
+              <li>Fix: rename the read at three call sites, update the empty-state copy, sync the count badge. Bridge merge logic (<code>parseImports</code> in SDK) already handles both the ENS text record and the bundle field</li>
+            </ul>
+            <div class="proof-label label">image (proof of work):</div>
+            <div class="proof-grid">
+              <div class="proof">diff: manifest.imports → manifest.dependencies</div>
+            </div>
+          </article>
+
+          <article class="card entry">
+            <div class="hover-flag">CHORE</div>
+            <div class="entry-time">17:10 · STAGING</div>
+            <div class="entry-title">Publish-flow housekeeping — three quiet bugs that bit during the agent-research publish</div>
+            <ul>
+              <li><code>scripts/pin-to-0g.ts</code>: the 0G Go CLI logs <code>file uploaded, root = 0x…</code> via logrus to <strong>stderr</strong>, but the script used <code>execFileSync</code> which only returns stdout. Every successful pin was being misreported as <code>no root in CLI output</code>. Switched to <code>spawnSync</code> and merge both streams</li>
+              <li><code>scripts/register-skills.ts</code>: when <code>--roots</code> / <code>--cids</code> targeted a single slug, the loop still walked every bundle dir and re-issued <code>setSubnodeRecord</code> against each leaf — overwriting owner/resolver and burning gas. Now skips bundles not in the args. Also <code>import 'dotenv/config'</code> + tolerates a private key that's missing the <code>0x</code> prefix</li>
+              <li><code>scripts/register-skills.ts</code>: extended to write <code>xyz.manifest.skill.imports = "<dep1>,<dep2>,…"</code> from <code>manifest.dependencies</code>. Matches the canonical key from <code>CLAUDE.md</code> and the SDK's <code>SKILL_IMPORTS_KEY</code></li>
+              <li><code>.github/workflows/pin-and-register.yml</code>: resolved 6 leftover merge-conflict markers (3 conflict blocks). Kept the <code>OG_INDEXER_URL</code> env var on the pin step and the hard-fail <code>::error::</code> + <code>exit 1</code> when the pin step produces no roots — silent skip would mask broken faucet runs</li>
+            </ul>
+            <div class="proof-label label">image (proof of work):</div>
+            <div class="proof-grid">
+              <div class="proof">spawnSync diff</div>
+              <div class="proof">workflow yaml clean</div>
+            </div>
+          </article>
+        </section>
+
         <!-- ── DAY 8 ── -->
         <section class="day-section" id="day-8">
           <div class="day-header">
             <div class="day-num">D8</div>
             <div class="day-name">skill explorer · ENSIP draft · review queue · #10 closed · contract execution type · x402 e2e</div>
-            <div class="label">2026·05·01 · THU · TODAY</div>
+            <div class="label">2026·05·01 · THU</div>
           </div>
 
           <article class="card entry">

--- a/scripts/pin-to-0g.ts
+++ b/scripts/pin-to-0g.ts
@@ -20,7 +20,7 @@ import 'dotenv/config'
  *   pnpm tsx scripts/pin-to-0g.ts quote-uniswap  # single bundle (default in CI)
  */
 
-import { execFileSync } from 'node:child_process'
+import { spawnSync } from 'node:child_process'
 import { readdirSync } from 'node:fs'
 import { join } from 'node:path'
 
@@ -65,30 +65,29 @@ for (const slug of bundleDirs) {
   const manifestPath = join(examplesDir, slug, 'manifest.json')
   process.stdout.write(`[${slug}] `)
 
-  let stdout = ''
-  let stderr = ''
-  try {
-    stdout = execFileSync(
-      CLI,
-      [
-        'upload',
-        '--url', OG_RPC,
-        '--indexer', INDEXER_URL,
-        '--key', PRIVATE_KEY,
-        '--file', manifestPath,
-      ],
-      { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }
-    )
-  } catch (e: any) {
-    stdout = e.stdout?.toString() ?? ''
-    stderr = e.stderr?.toString() ?? ''
-    console.error(`✗ CLI exit ${e.status}`)
+  // logrus writes to stderr by default. execFileSync only returns stdout, so
+  // the root line was getting silently dropped on success — use spawnSync
+  // and merge both streams unconditionally.
+  const result = spawnSync(
+    CLI,
+    [
+      'upload',
+      '--url', OG_RPC,
+      '--indexer', INDEXER_URL,
+      '--key', PRIVATE_KEY,
+      '--file', manifestPath,
+    ],
+    { encoding: 'utf8' }
+  )
+  const stdout = result.stdout ?? ''
+  const stderr = result.stderr ?? ''
+  if (result.error || result.status !== 0) {
+    console.error(`✗ CLI exit ${result.status ?? '?'}${result.error ? ` (${result.error.message})` : ''}`)
     if (stderr) console.error(stderr.split('\n').map((l: string) => '    ' + l).join('\n'))
     if (stdout) console.error(stdout.split('\n').map((l: string) => '    ' + l).join('\n'))
     continue
   }
 
-  // logrus writes to stderr by default; merge both streams when scanning.
   const combined = stdout + '\n' + stderr
   const m = combined.match(ROOT_LINE_RX)
   if (!m) {

--- a/scripts/register-skills.ts
+++ b/scripts/register-skills.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env tsx
+import 'dotenv/config'
 /**
  * Create subnames on Sepolia for each reference skill bundle in
  * skillname-pack/examples, set their ENS text records to the bundle CID,
@@ -90,12 +91,13 @@ function parseArgs(): Args {
 async function main(): Promise<void> {
   const { parent, cids, roots } = parseArgs()
 
-  const PRIVATE_KEY = process.env.SEPOLIA_PRIVATE_KEY as Hex | undefined
+  const RAW_KEY = process.env.SEPOLIA_PRIVATE_KEY
   const RPC_URL = process.env.SEPOLIA_RPC_URL ?? 'https://rpc.sepolia.org'
-  if (!PRIVATE_KEY) {
+  if (!RAW_KEY) {
     console.error('SEPOLIA_PRIVATE_KEY env var not set.')
     process.exit(1)
   }
+  const PRIVATE_KEY = (RAW_KEY.startsWith('0x') ? RAW_KEY : `0x${RAW_KEY}`) as Hex
 
   const account = privateKeyToAccount(PRIVATE_KEY)
   console.log(`Operator: ${account.address}`)
@@ -130,12 +132,23 @@ async function main(): Promise<void> {
 
   console.log(`Found ${bundleDirs.length} bundles: ${bundleDirs.join(', ')}\n`)
 
+  // When --roots or --cids targets specific slugs, only operate on those.
+  // Otherwise we'd re-issue setSubnodeRecord for every existing leaf and
+  // burn gas overwriting them — a real cost that hit a register run on
+  // 2026-05-02 (#agent-research publish).
+  const targeted = new Set([...Object.keys(roots), ...Object.keys(cids)])
+  const onlyTargeted = targeted.size > 0
+
   let subnamesCreated = 0
   let recordsSet = 0
 
   for (const slug of bundleDirs) {
+    if (onlyTargeted && !targeted.has(slug)) {
+      console.log(`[${slug}] not in --roots / --cids, skipping`)
+      continue
+    }
     const manifestPath = join(examplesDir, slug, 'manifest.json')
-    let manifest: { ensName: string; version: string }
+    let manifest: { ensName: string; version: string; dependencies?: string[] }
     try {
       manifest = JSON.parse(readFileSync(manifestPath, 'utf8'))
     } catch (e) {
@@ -188,6 +201,9 @@ async function main(): Promise<void> {
     }
     records.push(['xyz.manifest.skill.version', manifest.version])
     records.push(['xyz.manifest.skill.schema', 'https://manifest.eth/schemas/skill-v1.json'])
+    if (manifest.dependencies && manifest.dependencies.length > 0) {
+      records.push(['xyz.manifest.skill.imports', manifest.dependencies.join(',')])
+    }
 
     for (const [key, value] of records) {
       try {

--- a/skillname-pack/examples/agent-research/manifest.json
+++ b/skillname-pack/examples/agent-research/manifest.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://manifest.eth/schemas/skill-v1.json",
+  "name": "agent-research",
+  "ensName": "agent.skilltest.eth",
+  "version": "1.0.0",
+  "description": "Composite skill: research a token + holder by fanning out to three atomic skills — quote (price), score (Passport reputation), infer (LLM verdict). Demonstrates the import-graph: one ENS name resolves to three transitive tools at the bridge.",
+  "createdAt": "2026-05-02T00:00:00Z",
+  "license": "MIT",
+  "dependencies": [
+    "quote.skilltest.eth",
+    "score.skilltest.eth",
+    "infer.skilltest.eth"
+  ],
+  "tools": [
+    {
+      "name": "research_token",
+      "description": "Fan out to three imported skills: get the token's USD price via quote.skilltest.eth, the holder's Gitcoin Passport score via score.skilltest.eth, then ask infer.skilltest.eth (0G Compute) for a one-sentence verdict on whether to interact. Returns all three artefacts plus the verdict.",
+      "inputSchema": {
+        "type": "object",
+        "required": ["token_id", "holder_address"],
+        "properties": {
+          "token_id": {
+            "type": "string",
+            "description": "CoinGecko coin id (e.g. 'ethereum', 'usd-coin')",
+            "examples": ["ethereum", "usd-coin"]
+          },
+          "holder_address": {
+            "type": "string",
+            "pattern": "^0x[a-fA-F0-9]{40}$",
+            "description": "Ethereum address of the holder to score"
+          }
+        }
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "price_usd": { "type": "number" },
+          "passport_score": { "type": "string" },
+          "verdict": { "type": "string" }
+        }
+      },
+      "execution": {
+        "type": "local",
+        "handler": "tools/research_token.json"
+      }
+    }
+  ],
+  "trust": {
+    "ensip25": {
+      "enabled": true
+    }
+  }
+}

--- a/skillname-pack/examples/agent-research/tools/research_token.json
+++ b/skillname-pack/examples/agent-research/tools/research_token.json
@@ -1,0 +1,6 @@
+{
+  "kind": "local-handler",
+  "version": "1",
+  "language": "javascript",
+  "code": "(async ({ token_id, holder_address }, ctx) => { const [quote, score] = await Promise.all([ ctx.call('quote.skilltest.eth', 'get_quote', { ids: token_id }), ctx.call('score.skilltest.eth', 'trust_score', { address: holder_address }) ]); const price_usd = quote?.[token_id]?.usd ?? null; const passport_score = score?.score ?? 'unknown'; const verdictResp = await ctx.call('infer.skilltest.eth', 'infer', { prompt: `Token \"${token_id}\" trades at $${price_usd}. Holder ${holder_address} has a Gitcoin Passport score of ${passport_score}. In one sentence: is this a reasonable counterparty to interact with on-chain?` }); const verdict = typeof verdictResp === 'string' ? verdictResp : (verdictResp?.text ?? verdictResp?.content ?? JSON.stringify(verdictResp)); return { price_usd, passport_score, verdict }; })"
+}


### PR DESCRIPTION
## Summary

Two related commits picked off a parallel branch and rebased clean onto staging.

### 1. \`agent.skilltest.eth\` composite skill — first non-leaf entry in the registry

- \`skillname-pack/examples/agent-research/\` — bundle declaring \`dependencies: [quote, score, infer].skilltest.eth\`
- \`tools/research_token.json\` — fan-out handler (parallel \`quote.get_quote\` + \`score.trust_score\`, then \`infer.infer\` for the verdict)
- \`apps/web/index.html\` — Skill detail view reads \`manifest.dependencies\` (renamed at three call sites; matches the SDK + schema field name); \`MANIFEST_CACHE\` entry added so the browser can render the composite without hitting 0G
- \`scripts/pin-to-0g.ts\` — switched to \`spawnSync\` and merged stdout+stderr; the 0G CLI logs the upload root via logrus to stderr, so \`execFileSync\` was misreporting every successful pin as "no root in CLI output"
- \`scripts/register-skills.ts\` — when \`--roots\` / \`--cids\` targets a single slug, skip bundles not in the args; also writes \`xyz.manifest.skill.imports = "<dep1>,<dep2>,..."\` from \`manifest.dependencies\` (matches \`SKILL_IMPORTS_KEY\` in the SDK)
- \`.github/workflows/pin-and-register.yml\` — resolved 6 leftover merge-conflict markers (3 blocks)
- \`apps/web/logs/index.html\` — D9 section with three cards covering the above

### 2. Frontend: semver in resolver + on-chain registry counts

- Resolver accepts \`name@<range>\` syntax (\`@^1\`, \`@^2\`, \`@latest\`, \`@*\`, exact). Mirrors \`@skillname/sdk\`'s \`semverSatisfies\` + \`resolveVersionedName\` inline since the static page can't bundle the SDK
- ON-CHAIN bento card now also reads \`SkillNFT.totalSupply()\` + \`IdentityRegistry.lastId()\` and shows \`"<n> SkillNFT · <m> agents"\` sublabel under skill count
- \`MANIFEST_CACHE\` entries for \`v1.quote.skilltest.eth\` + \`v2.quote.skilltest.eth\` (synthetic v2 with version + description bumped) so \`@latest\` / \`@^2\` resolve cleanly without a bridge

Verified live: \`#/skill/quote.skilltest.eth%40latest\` renders **v2.0.0** with the "(v2)" description.

## Demo line

> *"Type \`quote.skilltest.eth@^1\` or \`@latest\` and the resolver finds the right concrete subname. Composite skill \`agent.skilltest.eth\` fans out to three transitive imports through the bridge's import-graph walker."*