### PR TITLE
fix: bind infer + agent skills (ENSIP-25) + CI smoke (closes #69)

### DIFF
--- a/.github/workflows/register-skills.yml
+++ b/.github/workflows/register-skills.yml
@@ -47,3 +47,11 @@ jobs:
             ARGS="$ARGS --cids ${{ inputs.cids }}"
           fi
           pnpm tsx scripts/register-skills.ts $ARGS
+
+      # Issue #69: smoke test ENSIP-25 binding after every register run, so a
+      # broken text record (or a re-pin that drops the binding) fails the
+      # workflow instead of silently degrading the demo signal.
+      - name: Verify ENSIP-25 binding
+        env:
+          SEPOLIA_RPC_URL: ${{ secrets.SEPOLIA_RPC_URL }}
+        run: pnpm tsx scripts/verify-ensip25.ts

--- a/scripts/bind-ensip25.ts
+++ b/scripts/bind-ensip25.ts
@@ -38,7 +38,10 @@ import {
 } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
 import { sepolia } from "viem/chains";
-import { encodeErc7930 } from "@skillname/sdk";
+// Workspace package isn't published; import from the built dist by relative
+// path (same convention as scripts/verify-ensip25.ts). Keeps the script
+// runnable from the repo root via pnpm tsx.
+import { encodeErc7930 } from "../skillname-pack/packages/sdk/dist/index.js";
 
 const RESOLVER_DEFAULT = "0xE99638b40E4Fff0129D56f03b55b6bbC4BBE49b5";
 
@@ -71,8 +74,11 @@ async function main() {
   const key = `agent-registration[${erc7930}][${agentId}]`;
   const node = namehash(ensName);
 
-  const privateKey = process.env.SEPOLIA_PRIVATE_KEY;
-  if (!privateKey) throw new Error("SEPOLIA_PRIVATE_KEY not set");
+  const rawKey = process.env.SEPOLIA_PRIVATE_KEY;
+  if (!rawKey) throw new Error("SEPOLIA_PRIVATE_KEY not set");
+  // Tolerate keys stored without the 0x prefix (the .env in this repo
+  // historically did so — see register-skills.ts for the same fix).
+  const privateKey = (rawKey.toLowerCase().startsWith("0x") ? rawKey : `0x${rawKey}`) as `0x${string}`;
 
   const rpcUrl =
     process.env.SEPOLIA_RPC_URL ??
@@ -82,7 +88,7 @@ async function main() {
     RESOLVER_DEFAULT) as `0x${string}`;
   if (!isAddress(resolver)) throw new Error(`Invalid resolver: ${resolver}`);
 
-  const account = privateKeyToAccount(privateKey as `0x${string}`);
+  const account = privateKeyToAccount(privateKey);
   const publicClient = createPublicClient({
     chain: sepolia,
     transport: http(rpcUrl),

--- a/scripts/mint-agents.ts
+++ b/scripts/mint-agents.ts
@@ -23,13 +23,16 @@ import { privateKeyToAccount } from "viem/accounts";
 import { sepolia } from "viem/chains";
 
 const REGISTRY = "0x48f77FfE1f02FB94bDe9c8ffe84bB4956ace11e4" as const;
-const NAMES = [
+const DEFAULT_NAMES = [
   "hello.skilltest.eth",
   "quote.skilltest.eth",
   "swap.skilltest.eth",
   "score.skilltest.eth",
   "weather.skilltest.eth",
 ];
+// Accept ENS names from argv so the script can be re-run for late-added
+// bundles (e.g. infer.skilltest.eth, agent.skilltest.eth — see issue #69).
+const NAMES = process.argv.slice(2).length > 0 ? process.argv.slice(2) : DEFAULT_NAMES;
 
 const ABI = parseAbi([
   "function register(string name) external returns (uint256 agentId)",

--- a/scripts/verify-ensip25.ts
+++ b/scripts/verify-ensip25.ts
@@ -26,10 +26,14 @@ const NAMES = [
   "swap.skilltest.eth",
   "score.skilltest.eth",
   "weather.skilltest.eth",
+  // Added 2026-05-03 (issue #69): infer + agent skills published after #56
+  // closed; bound via mint-agents.ts agentIds 11/12.
+  "infer.skilltest.eth",
+  "agent.skilltest.eth",
 ];
 
 async function main() {
-  console.log("verifying ENSIP-25 binding on 5 reference subnames\n");
+  console.log(`verifying ENSIP-25 binding on ${NAMES.length} reference subnames\n`);
   let pass = 0;
   let fail = 0;
   for (const name of NAMES) {

--- a/skillname-pack/examples/agent-research/manifest.json
+++ b/skillname-pack/examples/agent-research/manifest.json
@@ -46,8 +46,10 @@
     }
   ],
   "trust": {
-    "ensip25": {
-      "enabled": true
+    "ensip25": { "enabled": true },
+    "erc8004": {
+      "registry": "eip155:11155111:0x48f77FfE1f02FB94bDe9c8ffe84bB4956ace11e4",
+      "agentId": 12
     }
   }
 }

--- a/skillname-pack/examples/infer-0g/manifest.json
+++ b/skillname-pack/examples/infer-0g/manifest.json
@@ -33,5 +33,12 @@
         "systemPrompt": "You are a helpful AI assistant running on 0G Compute Network — a decentralized, censorship-resistant inference layer. Answer concisely and accurately."
       }
     }
-  ]
+  ],
+  "trust": {
+    "ensip25": { "enabled": true },
+    "erc8004": {
+      "registry": "eip155:11155111:0x48f77FfE1f02FB94bDe9c8ffe84bB4956ace11e4",
+      "agentId": 11
+    }
+  }
 }


### PR DESCRIPTION
## Summary
Closes #69. Closes the two leftover tasks from #56:

- Newly-published `infer.skilltest.eth` + `agent.skilltest.eth` had no ERC-8004 binding and showed as "trust: unverified" — undoing the signal #56 was meant to fix.
- `verify-ensip25.ts` existed as a script but no workflow invoked it, so a binding regression on re-pin would go silent until someone ran it by hand.

## Done on-chain (Sepolia, registry \`0x48f77FfE1f02FB94bDe9c8ffe84bB4956ace11e4\`)

| ENS | agentId | mint tx | bind tx | new 0G root |
|---|---|---|---|---|
| \`infer.skilltest.eth\` | 11 | [\`0x4c923d38…\`](https://sepolia.etherscan.io/tx/0x4c923d383bf6708f599a29311b6a7e25b07d399861abb5b4d688b857e95de4d5) | [\`0xae3cdef9…\`](https://sepolia.etherscan.io/tx/0xae3cdef9ac497fb5a688f6f0569d75da8c30fa490179f29bd3accac0b1cdb32c) | \`0x2b21fe87…\` |
| \`agent.skilltest.eth\` | 12 | [\`0xdff432ee…\`](https://sepolia.etherscan.io/tx/0xdff432ee673c8ac1f43dacfb3e04b8813ecb454ef1c0759512ab560297c56369) | [\`0x2d074b47…\`](https://sepolia.etherscan.io/tx/0x2d074b4768022df0bac31469142ce9af46cc2636c88a7678984fc8ac1c8c2050) | \`0xfdc19691…\` |

Verify smoke now reports **7/7 bound** end-to-end:
\`\`\`
hello.skilltest.eth   ✓ bound (agentId 6)
quote.skilltest.eth   ✓ bound (agentId 7)
swap.skilltest.eth    ✓ bound (agentId 8)
score.skilltest.eth   ✓ bound (agentId 9)
weather.skilltest.eth ✓ bound (agentId 10)
infer.skilltest.eth   ✓ bound (agentId 11)
agent.skilltest.eth   ✓ bound (agentId 12)
                      7/7 bound
\`\`\`

## Code changes

- **\`skillname-pack/examples/infer-0g/manifest.json\`**: add \`trust\` block (was missing entirely).
- **\`skillname-pack/examples/agent-research/manifest.json\`**: add \`trust.erc8004\` (had \`ensip25.enabled: true\` but no binding).
- **\`scripts/mint-agents.ts\`**: accept ENS names from argv, default to the original 5 — re-runnable for future late-added bundles.
- **\`scripts/bind-ensip25.ts\`**: two real bugs that surfaced during this run:
  1. Imported \`@skillname/sdk\` (workspace package not published) — failed with \`ERR_MODULE_NOT_FOUND\` from the repo root. Switched to a relative dist-path import, matching the convention already in \`verify-ensip25.ts\`.
  2. Didn't tolerate keys stored without the \`0x\` prefix (the repo's \`.env\` historically does so) — viem rejected with \`invalid private key\`. Same fix already applied to \`register-skills.ts\`.
- **\`scripts/verify-ensip25.ts\`**: \`NAMES\` extended to 7.
- **\`.github/workflows/register-skills.yml\`**: post-step \`Verify ENSIP-25 binding\` runs the smoke after every register run.

## Test plan

- [x] \`pnpm tsx scripts/verify-ensip25.ts\` reports 7/7 bound (locally, against publicnode Sepolia RPC)
- [x] \`agent.skilltest.eth\` is the **first bound composite** — stronger demo signal than another bound leaf
- [x] YAML parses (\`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/register-skills.yml'))"\` clean)
- [ ] CI register-skills workflow runs the new verify step on next \`workflow_dispatch\`

## Notes

- Operator key is the same one I asked you to rotate yesterday. After this PR lands and CI runs once, rotate is the obvious next step — every subsequent run uses the new key seamlessly because everything keys off \`secrets.SEPOLIA_PRIVATE_KEY\`.
- \`apps/web-react/*\` and \`pnpm-lock.yaml\` showed as staged in the working tree from the previous local branch state; left out of this commit so the diff stays focused. They're still in your tree if you need them.