### PR TITLE
feat(web): browser→0G publish + on-chain caller log + 0G visibility

### DIFF
--- a/apps/web-react/public/logs/index.html
+++ b/apps/web-react/public/logs/index.html
@@ -584,12 +584,41 @@
 
       <main>
 
+        <!-- ── DAY 11 ── -->
+        <section class="day-section" id="day-11">
+          <div class="day-header">
+            <div class="day-num">D11</div>
+            <div class="day-name">browser→0G publish · on-chain caller log · 0G storage made visible</div>
+            <div class="label">2026·05·03 · SAT · TODAY</div>
+          </div>
+
+          <article class="card entry">
+            <div class="hover-flag">FEATURE</div>
+            <div class="entry-time">12:00 · STAGING</div>
+            <div class="entry-title">Publish a skill end-to-end in the browser — pin to 0G + 4 ENS sigs</div>
+            <ul>
+              <li>New <code>scripts/pin-server.ts</code> (Hono on :3030) wraps the 0G Go CLI behind <code>POST /pin</code>; <code>pnpm pin:server</code> boots it. Smoke test: pinned a 225-byte manifest to Galileo in 23s, root <code>0x4851da2c4995022e919c0ca8b4135d659337d0c59dbe01742528332e27be2e7c</code>, real submitLogEntry tx on the 0G storage contract</li>
+              <li><code>PublishOverlay</code> rebuilt as a 2-stage flow: Stage 1 — Pin to 0G (with live <code>● pin-service ready</code> health badge, ANSI-stripped CLI log details); Stage 2 — 4 wallet sigs on Sepolia. Manual CID input is gone. Pipeline checklist on the side rail ticks ✓ as each beat completes</li>
+              <li>On-chain caller log per skill (<code>components/CallerLog.tsx</code>): reads <code>SkillRegistered</code> + <code>SkillCalled</code> events from SkillLink filtered by namehash, decodes via 4byte directory, ENS-reverse on caller addresses (mainnet RPC). Renders below the Registry panel as a per-skill activity feed — proves real usage, not just deploy state</li>
+              <li>0G made visible everywhere: <code>OGStorageBadge</code> on Hero + SkillDetail header shows <code>● 0G GALILEO · root 0x… · Xms (+ens Yms)</code> with link to the indexer. New <code>OGStorageCard</code> on the homepage bento aggregates pinned manifest count + total bytes + avg fetch ms across the catalog</li>
+              <li><code>resolveSkill()</code> now captures per-stage timing (ENS read vs 0G storage round-trip vs total), so the badge is honest about what it&apos;s measuring</li>
+            </ul>
+            <div class="proof-label label">image (proof of work):</div>
+            <div class="proof-grid">
+              <div class="proof">pin-server health green</div>
+              <div class="proof">browser pinning to Galileo live</div>
+              <div class="proof">0G badge on Hero + SkillDetail</div>
+              <div class="proof">caller log per skill</div>
+            </div>
+          </article>
+        </section>
+
         <!-- ── DAY 10 ── -->
         <section class="day-section" id="day-10">
           <div class="day-header">
             <div class="day-num">D10</div>
             <div class="day-name">wallet sign in the UI · on-chain publish + register · my-skills discovery · trust reframed</div>
-            <div class="label">2026·05·03 · SAT · TODAY</div>
+            <div class="label">2026·05·03 · SAT</div>
           </div>
 
           <article class="card entry">

--- a/apps/web-react/src/App.tsx
+++ b/apps/web-react/src/App.tsx
@@ -13,6 +13,7 @@ import { PublishOverlay } from "./components/PublishOverlay";
 import { LiveTracePanel } from "./components/LiveTracePanel";
 import { PitchPanel } from "./components/PitchPanel";
 import { MySkillsCard } from "./components/MySkillsCard";
+import { OGStorageCard } from "./components/OGStorageCard";
 import { useRoute } from "./lib/router";
 import type { ResolvedSkill } from "./lib/skill-resolve";
 
@@ -63,10 +64,13 @@ export function App() {
           <OnchainCard />
         </div>
         <div className="col-span-12 sm:col-span-6 lg:col-span-4">
-          <SchemaCard onOpen={() => setOverlay("schema")} />
+          <OGStorageCard />
         </div>
         <div className="col-span-12 sm:col-span-6 lg:col-span-4">
           <TotalToolsCard onOpen={() => setOverlay("tools")} />
+        </div>
+        <div className="col-span-12 sm:col-span-6 lg:col-span-4">
+          <SchemaCard onOpen={() => setOverlay("schema")} />
         </div>
 
         <div className="col-span-12 lg:col-span-8">

--- a/apps/web-react/src/components/CallerLog.tsx
+++ b/apps/web-react/src/components/CallerLog.tsx
@@ -1,0 +1,301 @@
+import { useEffect, useState } from "react";
+import { usePublicClient } from "wagmi";
+import { sepolia } from "viem/chains";
+import { mainnet } from "viem/chains";
+import { createPublicClient, http } from "viem";
+import {
+  fetchSkillEvents,
+  decodeSelector,
+  type SkillEvent,
+  type SkillEventStream,
+} from "../lib/skill-events";
+
+interface Props {
+  ensName: string;
+}
+
+// Mainnet client just for ENS reverse-resolution of caller addresses.
+// Sepolia ENS reverse-resolves to an empty string for most addresses, but
+// mainnet often has primary names set (judges + devs use the same wallet
+// across networks). This is read-only and rate-limited by the public RPC.
+const ensClient = createPublicClient({
+  chain: mainnet,
+  transport: http(),
+});
+
+const cachedEnsNames = new Map<string, string | null>();
+
+async function reverseEns(addr: `0x${string}`): Promise<string | null> {
+  const k = addr.toLowerCase();
+  if (cachedEnsNames.has(k)) return cachedEnsNames.get(k)!;
+  try {
+    const name = await ensClient.getEnsName({ address: addr });
+    cachedEnsNames.set(k, name);
+    return name;
+  } catch {
+    cachedEnsNames.set(k, null);
+    return null;
+  }
+}
+
+export function CallerLog({ ensName }: Props) {
+  const sepoliaClient = usePublicClient({ chainId: sepolia.id });
+  const [stream, setStream] = useState<SkillEventStream | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [labels, setLabels] = useState<{
+    ens: Record<string, string>;
+    sigs: Record<string, string>;
+  }>({ ens: {}, sigs: {} });
+
+  useEffect(() => {
+    if (!sepoliaClient) return;
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    setStream(null);
+    fetchSkillEvents(sepoliaClient, ensName)
+      .then(async (s) => {
+        if (cancelled) return;
+        setStream(s);
+        // Kick off ENS reverse + 4byte decodes in parallel; fold into state
+        // as they resolve.
+        const callers = new Set<string>();
+        const selectors = new Set<string>();
+        for (const e of s.events) {
+          if (e.kind === "called") {
+            callers.add(e.caller.toLowerCase());
+            selectors.add(e.selector);
+          }
+          if (e.kind === "registered") {
+            callers.add(e.owner.toLowerCase());
+            for (const sel of e.selectors) selectors.add(sel);
+          }
+        }
+        const [names, sigs] = await Promise.all([
+          Promise.all(
+            [...callers].map(async (addr) => [
+              addr,
+              await reverseEns(addr as `0x${string}`),
+            ]),
+          ),
+          Promise.all(
+            [...selectors].map(async (sel) => [
+              sel,
+              await decodeSelector(sel as `0x${string}`),
+            ]),
+          ),
+        ]);
+        if (cancelled) return;
+        setLabels({
+          ens: Object.fromEntries(names.filter(([, v]) => v) as [string, string][]),
+          sigs: Object.fromEntries(sigs.filter(([, v]) => v) as [string, string][]),
+        });
+      })
+      .catch((e) => !cancelled && setError(String(e instanceof Error ? e.message : e)))
+      .finally(() => !cancelled && setLoading(false));
+    return () => {
+      cancelled = true;
+    };
+  }, [ensName, sepoliaClient]);
+
+  if (loading) {
+    return (
+      <div className="mt-6 border-t border-fog-border pt-6">
+        <div className="font-mono text-xs text-slate-ink">
+          scanning SkillLink event log on Sepolia…
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="mt-6 border-t border-fog-border pt-6">
+        <div className="font-mono text-xs text-bento-accent-red">
+          activity log error · {error}
+        </div>
+      </div>
+    );
+  }
+
+  if (!stream) return null;
+
+  const { events, totalsByKind, uniqueCallers, scannedFromBlock, scannedToBlock, ms } = stream;
+  const total = events.length;
+
+  return (
+    <div className="mt-6 border-t border-fog-border pt-6">
+      <div className="flex items-baseline justify-between flex-wrap gap-2">
+        <h3 className="font-display text-2xl">Activity</h3>
+        <div className="font-mono text-[10px] uppercase tracking-wider text-slate-ink">
+          {total} events · {totalsByKind.called} calls · {uniqueCallers} unique callers ·{" "}
+          scanned {(scannedToBlock - scannedFromBlock).toString()} blocks · {ms}ms
+        </div>
+      </div>
+      <p className="font-body text-xs text-slate-ink mt-1">
+        Every <code className="font-mono">SkillLink.register</code> + dispatch on this ENS name. Read live from the
+        contract event log on Sepolia — same provenance an indexer would build on.
+      </p>
+
+      {total === 0 && (
+        <div className="mt-4 rounded border border-fog-border bg-pure-surface p-4 font-mono text-xs text-slate-ink">
+          No on-chain activity for{" "}
+          <code className="text-midnight-navy">{ensName}</code> yet. Once someone registers an
+          impl or calls a selector, the event lands here.
+        </div>
+      )}
+
+      {total > 0 && (
+        <ol className="mt-4 space-y-2">
+          {events.map((e, i) => (
+            <EventRow
+              key={`${e.txHash}-${i}`}
+              event={e}
+              ensLabel={resolveLabel(e, labels.ens)}
+              sigLabel={resolveSig(e, labels.sigs)}
+            />
+          ))}
+        </ol>
+      )}
+    </div>
+  );
+}
+
+function resolveLabel(e: SkillEvent, ens: Record<string, string>): string | null {
+  const addr =
+    e.kind === "called" ? e.caller : e.kind === "registered" ? e.owner : null;
+  if (!addr) return null;
+  return ens[addr.toLowerCase()] ?? null;
+}
+
+function resolveSig(e: SkillEvent, sigs: Record<string, string>): string | null {
+  if (e.kind === "called") return sigs[e.selector] ?? null;
+  if (e.kind === "registered") {
+    const decoded = e.selectors
+      .map((sel) => sigs[sel])
+      .filter(Boolean) as string[];
+    return decoded.length > 0 ? decoded.join(", ") : null;
+  }
+  return null;
+}
+
+function EventRow({
+  event,
+  ensLabel,
+  sigLabel,
+}: {
+  event: SkillEvent;
+  ensLabel: string | null;
+  sigLabel: string | null;
+}) {
+  if (event.kind === "registered") {
+    return (
+      <li className="rounded border border-fog-border bg-pure-surface p-3">
+        <div className="flex items-baseline justify-between gap-2 flex-wrap">
+          <span className="font-mono text-[10px] uppercase tracking-wider text-bento-success">
+            ● REGISTERED
+          </span>
+          <BlockLink txHash={event.txHash} blockNumber={event.blockNumber} />
+        </div>
+        <div className="mt-1 font-mono text-xs text-midnight-navy">
+          {ensLabel ? (
+            <span className="text-midnight-navy font-semibold">{ensLabel}</span>
+          ) : (
+            <AddrLink addr={event.owner} />
+          )}{" "}
+          <span className="text-slate-ink">bound impl</span>{" "}
+          <AddrLink addr={event.impl} />
+        </div>
+        <div className="mt-1 font-mono text-[11px] text-slate-ink">
+          selectors: {event.selectors.length}{" "}
+          {event.selectors.map((s) => (
+            <code key={s} className="ml-1 text-midnight-navy">{s}</code>
+          ))}
+          {sigLabel && (
+            <span className="ml-2 text-bento-success">
+              → {sigLabel}
+            </span>
+          )}
+        </div>
+      </li>
+    );
+  }
+  if (event.kind === "called") {
+    return (
+      <li className="rounded border border-fog-border bg-pure-surface p-3">
+        <div className="flex items-baseline justify-between gap-2 flex-wrap">
+          <span
+            className={`font-mono text-[10px] uppercase tracking-wider ${
+              event.success ? "text-bento-success" : "text-bento-accent-red"
+            }`}
+          >
+            ● CALLED {event.success ? "" : "· reverted"}
+          </span>
+          <BlockLink txHash={event.txHash} blockNumber={event.blockNumber} />
+        </div>
+        <div className="mt-1 font-mono text-xs text-midnight-navy">
+          {ensLabel ? (
+            <span className="font-semibold">{ensLabel}</span>
+          ) : (
+            <AddrLink addr={event.caller} />
+          )}{" "}
+          <span className="text-slate-ink">called</span>{" "}
+          <code className="text-midnight-navy">{event.selector}</code>
+          {sigLabel && (
+            <span className="ml-2 text-bento-success font-mono text-[11px]">
+              {sigLabel}
+            </span>
+          )}
+        </div>
+      </li>
+    );
+  }
+  // unknown
+  return (
+    <li className="rounded border border-fog-border bg-pure-surface p-3">
+      <div className="flex items-baseline justify-between gap-2 flex-wrap">
+        <span className="font-mono text-[10px] uppercase tracking-wider text-slate-ink">
+          ● UNKNOWN EVENT
+        </span>
+        <BlockLink txHash={event.txHash} blockNumber={event.blockNumber} />
+      </div>
+      <div className="mt-1 font-mono text-[10px] text-slate-ink break-all">
+        topic[0] {event.topic0}
+      </div>
+    </li>
+  );
+}
+
+function AddrLink({ addr }: { addr: `0x${string}` }) {
+  return (
+    <a
+      href={`https://sepolia.etherscan.io/address/${addr}`}
+      target="_blank"
+      rel="noreferrer"
+      className="underline hover:text-midnight-navy"
+      title={addr}
+    >
+      {addr.slice(0, 6)}…{addr.slice(-4)}
+    </a>
+  );
+}
+
+function BlockLink({
+  txHash,
+  blockNumber,
+}: {
+  txHash: `0x${string}`;
+  blockNumber: bigint;
+}) {
+  return (
+    <a
+      href={`https://sepolia.etherscan.io/tx/${txHash}`}
+      target="_blank"
+      rel="noreferrer"
+      className="font-mono text-[10px] uppercase tracking-wider text-slate-ink hover:text-midnight-navy"
+    >
+      block {blockNumber.toString()} · tx {txHash.slice(0, 10)}… ↗
+    </a>
+  );
+}

--- a/apps/web-react/src/components/Hero.tsx
+++ b/apps/web-react/src/components/Hero.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { resolveSkill, type ResolvedSkill } from "../lib/skill-resolve";
+import { OGStorageBadge } from "./OGStorageBadge";
 
 interface HeroProps {
   onResolved: (ens: string, r: ResolvedSkill) => void;
@@ -85,13 +86,18 @@ export function Hero({ onResolved }: HeroProps) {
         </div>
       </div>
 
-      {/* CID line */}
-      <div className="mt-3 min-h-[20px] font-mono text-xs">
+      {/* Storage badge + CID line */}
+      <div className="mt-3 min-h-[28px] font-mono text-xs space-y-2">
         {error && <div className="text-bento-accent-red">error · {error}</div>}
         {result && !error && (
-          <div className="text-bento-success break-all">
-            {result.cid} · validated{result.resolvedFromRange && ` · resolved from ${result.resolvedFromRange}`}
-          </div>
+          <>
+            <OGStorageBadge storage={result.storage} ensMs={result.ensMs} variant="dark" />
+            {result.resolvedFromRange && (
+              <div className="text-bento-text-secondary text-[10px] uppercase tracking-wider">
+                resolved from {result.resolvedFromRange}
+              </div>
+            )}
+          </>
         )}
       </div>
 

--- a/apps/web-react/src/components/OGStorageBadge.tsx
+++ b/apps/web-react/src/components/OGStorageBadge.tsx
@@ -1,0 +1,43 @@
+import type { ResolvedSkill } from "../lib/skill-resolve";
+
+interface Props {
+  storage: ResolvedSkill["storage"];
+  ensMs: number;
+  variant?: "dark" | "light";
+}
+
+/**
+ * Compact badge that surfaces "this manifest came off 0G storage" with the
+ * actual root, indexer host, and round-trip time. Sits next to the skill
+ * title or in the hero so 0G's role isn't a whisper in a sidebar URI.
+ */
+export function OGStorageBadge({ storage, ensMs, variant = "light" }: Props) {
+  const isDark = variant === "dark";
+  const base = isDark
+    ? "bg-bento-surface text-bento-text-primary border-bento-border"
+    : "bg-bento-black text-bento-text-primary border-bento-border";
+  const dot =
+    storage.kind === "0g" ? "bg-chartreuse-pulse" : "bg-bento-text-secondary";
+  const label = storage.kind === "0g" ? "0G GALILEO" : "IPFS";
+  return (
+    <a
+      href={storage.fetchUrl}
+      target="_blank"
+      rel="noreferrer"
+      className={`inline-flex items-center gap-2 rounded border px-2.5 py-1 font-mono text-[10px] uppercase tracking-wider hover:-translate-y-px transition no-underline ${base}`}
+      title={`Open the manifest from ${storage.indexerHost ?? "storage"}`}
+    >
+      <span className={`inline-block w-1.5 h-1.5 rounded-full ${dot}`} />
+      <span>{label}</span>
+      <span className="text-bento-text-secondary">·</span>
+      <code className="text-bento-text-display">
+        {storage.root.slice(0, 6)}…{storage.root.slice(-4)}
+      </code>
+      <span className="text-bento-text-secondary">·</span>
+      <span>
+        {storage.fetchMs}ms{ensMs ? ` (+ens ${ensMs}ms)` : ""}
+      </span>
+      <span className="text-bento-text-display">↗</span>
+    </a>
+  );
+}

--- a/apps/web-react/src/components/OGStorageCard.tsx
+++ b/apps/web-react/src/components/OGStorageCard.tsx
@@ -1,0 +1,162 @@
+import { useEffect, useState } from "react";
+import { usePublicClient } from "wagmi";
+import { sepolia } from "viem/chains";
+import { namehash } from "viem";
+import { CATALOG_ITEMS } from "./SkillCatalog";
+
+const RESOLVER_ADDR = "0xE99638b40E4Fff0129D56f03b55b6bbC4BBE49b5" as const;
+const RESOLVER_ABI = [
+  {
+    name: "text",
+    type: "function",
+    stateMutability: "view",
+    inputs: [
+      { name: "node", type: "bytes32" },
+      { name: "key", type: "string" },
+    ],
+    outputs: [{ name: "", type: "string" }],
+  },
+] as const;
+
+const OG_INDEXER_URL = "https://indexer-storage-testnet-turbo.0g.ai";
+
+interface PinnedSkill {
+  ens: string;
+  root: string | null;
+  bytes: number | null;
+  fetchMs: number | null;
+}
+
+export function OGStorageCard() {
+  const publicClient = usePublicClient({ chainId: sepolia.id });
+  const [items, setItems] = useState<PinnedSkill[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!publicClient) return;
+    let cancelled = false;
+    setLoading(true);
+    Promise.all(
+      CATALOG_ITEMS.map(async (it): Promise<PinnedSkill> => {
+        const node = namehash(it.ens);
+        try {
+          const uri = (await publicClient.readContract({
+            address: RESOLVER_ADDR,
+            abi: RESOLVER_ABI,
+            functionName: "text",
+            args: [node, "xyz.manifest.skill"],
+          })) as string;
+          if (!uri || !uri.startsWith("0g://")) {
+            return { ens: it.ens, root: null, bytes: null, fetchMs: null };
+          }
+          const root = uri.slice(5);
+          // Probe the indexer for the manifest size — single round-trip per
+          // skill, parallel across the catalog. We don't parse the body.
+          const t0 = performance.now();
+          const r = await fetch(`${OG_INDEXER_URL}/file?root=${root}`).catch(
+            () => null,
+          );
+          const fetchMs = Math.round(performance.now() - t0);
+          let bytes: number | null = null;
+          if (r?.ok) {
+            const text = await r.text().catch(() => "");
+            bytes = text.length;
+          }
+          return { ens: it.ens, root, bytes, fetchMs };
+        } catch {
+          return { ens: it.ens, root: null, bytes: null, fetchMs: null };
+        }
+      }),
+    )
+      .then((res) => !cancelled && setItems(res))
+      .finally(() => !cancelled && setLoading(false));
+    return () => {
+      cancelled = true;
+    };
+  }, [publicClient]);
+
+  const pinned = items.filter((i) => i.root);
+  const totalBytes = pinned.reduce((s, i) => s + (i.bytes ?? 0), 0);
+  const avgMs = pinned.filter((i) => i.fetchMs).length
+    ? Math.round(
+        pinned.reduce((s, i) => s + (i.fetchMs ?? 0), 0) /
+          pinned.filter((i) => i.fetchMs).length,
+      )
+    : null;
+
+  return (
+    <article className="bg-bento-surface text-bento-text-primary rounded-2xl p-6 border border-bento-border h-full flex flex-col">
+      <div className="flex items-start justify-between">
+        <div>
+          <span className="font-mono text-[10px] uppercase tracking-wider text-bento-text-secondary">
+            0G Galileo storage
+          </span>
+          <div className="mt-1 font-mono text-xs text-bento-text-display">
+            indexer-storage-testnet-turbo.0g.ai ↗
+          </div>
+        </div>
+        <span
+          className="font-mono text-[10px] uppercase tracking-wider text-chartreuse-pulse"
+          title="Storage layer for every manifest in the catalog"
+        >
+          ● live
+        </span>
+      </div>
+
+      <div className="mt-4 grid grid-cols-3 gap-4 flex-1">
+        <Stat
+          label="manifests pinned"
+          value={loading ? "—" : String(pinned.length).padStart(2, "0")}
+          sub={loading ? "scanning…" : `of ${items.length} catalog`}
+        />
+        <Stat
+          label="total bytes"
+          value={loading ? "—" : formatBytes(totalBytes)}
+          sub="across catalog"
+        />
+        <Stat
+          label="avg fetch"
+          value={loading ? "—" : avgMs !== null ? `${avgMs}ms` : "—"}
+          sub="from indexer"
+        />
+      </div>
+
+      <div className="mt-4 pt-4 border-t border-bento-border font-mono text-[10px] uppercase tracking-wider text-bento-text-secondary">
+        every <code className="text-bento-text-display normal-case">resolveSkill()</code>{" "}
+        fetches the manifest off 0G — no IPFS gateway in the hot path.
+      </div>
+    </article>
+  );
+}
+
+function Stat({
+  label,
+  value,
+  sub,
+}: {
+  label: string;
+  value: string;
+  sub?: string;
+}) {
+  return (
+    <div className="flex flex-col">
+      <span className="font-mono text-[10px] uppercase tracking-wider text-bento-text-secondary">
+        {label}
+      </span>
+      <span className="font-doto text-3xl text-bento-text-display mt-1">
+        {value}
+      </span>
+      {sub && (
+        <span className="font-mono text-[10px] uppercase tracking-wider text-bento-text-secondary mt-auto pt-1">
+          {sub}
+        </span>
+      )}
+    </div>
+  );
+}
+
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n}b`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)}kb`;
+  return `${(n / 1024 / 1024).toFixed(1)}mb`;
+}

--- a/apps/web-react/src/components/PublishOverlay.tsx
+++ b/apps/web-react/src/components/PublishOverlay.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useAccount, useChainId, usePublicClient, useSwitchChain, useWriteContract } from "wagmi";
 import { keccak256, namehash, parseAbi, toBytes, type Hex } from "viem";
 import { sepolia } from "wagmi/chains";
@@ -17,16 +17,32 @@ const RESOLVER_ABI = parseAbi([
 ]);
 
 const SCHEMA_URL = "https://manifest.eth/schemas/skill-v1.json";
+const PIN_SERVICE = (import.meta.env.VITE_PIN_SERVICE as string | undefined) ?? "http://localhost:3030";
 
 interface Props {
   onClose: () => void;
 }
 
-type Status =
+type PinStatus =
+  | { kind: "idle" }
+  | { kind: "pinging" }
+  | { kind: "running"; step: string }
+  | { kind: "ok"; root: `0x${string}`; ms: number; log?: string }
+  | { kind: "err"; msg: string };
+
+type PubStatus =
   | { kind: "idle" }
   | { kind: "running"; step: string }
   | { kind: "ok"; lastTx: Hex }
   | { kind: "err"; msg: string };
+
+interface PinHealth {
+  ok: boolean;
+  cli?: string;
+  indexer?: string;
+  rpc?: string;
+  keyConfigured?: boolean;
+}
 
 export function PublishOverlay({ onClose }: Props) {
   const { address, isConnected } = useAccount();
@@ -35,7 +51,6 @@ export function PublishOverlay({ onClose }: Props) {
   const publicClient = usePublicClient({ chainId: sepolia.id });
   const { writeContractAsync } = useWriteContract();
 
-  // Form state
   const [parent, setParent] = useState("skilltest.eth");
   const [label, setLabel] = useState("my-new-skill");
   const [name, setName] = useState("my-new-skill");
@@ -43,11 +58,25 @@ export function PublishOverlay({ onClose }: Props) {
   const [description, setDescription] = useState("");
   const [exec, setExec] = useState<"http" | "local">("http");
   const [endpoint, setEndpoint] = useState("https://api.example.com/v1/run");
-  const [cid, setCid] = useState("");
-  const [status, setStatus] = useState<Status>({ kind: "idle" });
+
+  const [pinStatus, setPinStatus] = useState<PinStatus>({ kind: "idle" });
+  const [pubStatus, setPubStatus] = useState<PubStatus>({ kind: "idle" });
+  const [pinHealth, setPinHealth] = useState<PinHealth | null>(null);
 
   const fullName = `${label}.${parent}`;
   const wrongChain = isConnected && chainId !== sepolia.id;
+
+  // Probe the pin server on mount + every time the overlay reopens
+  useEffect(() => {
+    let cancelled = false;
+    fetch(`${PIN_SERVICE}/health`, { cache: "no-store" })
+      .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))))
+      .then((j: PinHealth) => !cancelled && setPinHealth({ ...j, ok: true }))
+      .catch(() => !cancelled && setPinHealth({ ok: false }));
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const manifest = useMemo(
     () => ({
@@ -72,23 +101,70 @@ export function PublishOverlay({ onClose }: Props) {
     [name, fullName, version, description, exec, endpoint],
   );
 
-  const valid =
+  const formValid =
     /^[a-z0-9-]+$/.test(label) &&
     /^[a-z0-9-]+\.eth$/.test(parent) &&
     /^[a-z0-9-]+$/.test(name) &&
-    /^\d+\.\d+\.\d+$/.test(version) &&
-    cid.length > 5;
+    /^\d+\.\d+\.\d+$/.test(version);
+
+  const pinnedRoot = pinStatus.kind === "ok" ? pinStatus.root : null;
+
+  async function handlePin() {
+    if (!formValid) {
+      setPinStatus({ kind: "err", msg: "Fill in name / version / endpoint first." });
+      return;
+    }
+    setPinStatus({ kind: "pinging" });
+    try {
+      const t0 = performance.now();
+      const res = await fetch(`${PIN_SERVICE}/pin`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ slug: name, manifest }),
+      });
+      const body = (await res.json().catch(() => ({}))) as {
+        root?: string;
+        ms?: number;
+        log?: string;
+        error?: string;
+      };
+      if (!res.ok || !body.root) {
+        setPinStatus({
+          kind: "err",
+          msg: body.error ?? `Pin server returned HTTP ${res.status}`,
+        });
+        return;
+      }
+      const total = Math.round(performance.now() - t0);
+      setPinStatus({
+        kind: "ok",
+        root: body.root as `0x${string}`,
+        ms: body.ms ?? total,
+        log: body.log,
+      });
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      setPinStatus({
+        kind: "err",
+        msg: `Couldn't reach pin server at ${PIN_SERVICE} — start it with "pnpm pin:server" in the repo root. (${msg})`,
+      });
+    }
+  }
 
   async function handlePublish() {
     if (!isConnected || !address) {
-      setStatus({ kind: "err", msg: "Connect wallet first" });
+      setPubStatus({ kind: "err", msg: "Connect wallet first" });
+      return;
+    }
+    if (!pinnedRoot) {
+      setPubStatus({ kind: "err", msg: "Pin to 0G first." });
       return;
     }
     if (wrongChain) {
       try {
         await switchChainAsync({ chainId: sepolia.id });
       } catch (e) {
-        setStatus({ kind: "err", msg: `Switch to Sepolia first: ${(e as Error).message}` });
+        setPubStatus({ kind: "err", msg: `Switch to Sepolia first: ${(e as Error).message}` });
         return;
       }
     }
@@ -98,7 +174,6 @@ export function PublishOverlay({ onClose }: Props) {
     const labelHash = keccak256(toBytes(label));
 
     try {
-      // 0. Sanity: do we own the parent? (read-only — saves a wasted signature)
       if (publicClient) {
         const parentOwner = (await publicClient.readContract({
           address: ENS_REGISTRY,
@@ -107,7 +182,7 @@ export function PublishOverlay({ onClose }: Props) {
           args: [parentNode],
         })) as `0x${string}`;
         if (parentOwner.toLowerCase() !== address.toLowerCase()) {
-          setStatus({
+          setPubStatus({
             kind: "err",
             msg: `You don't own ${parent} (owner is ${parentOwner.slice(0, 10)}…). Try a parent you control.`,
           });
@@ -115,8 +190,7 @@ export function PublishOverlay({ onClose }: Props) {
         }
       }
 
-      // 1. setSubnodeRecord — creates the subname pointing at PublicResolver
-      setStatus({ kind: "running", step: `Step 1/4 · setSubnodeRecord(${fullName})` });
+      setPubStatus({ kind: "running", step: `Step 1/4 · setSubnodeRecord(${fullName})` });
       const tx1 = await writeContractAsync({
         address: ENS_REGISTRY,
         abi: ENS_REGISTRY_ABI,
@@ -125,19 +199,15 @@ export function PublishOverlay({ onClose }: Props) {
       });
       await publicClient!.waitForTransactionReceipt({ hash: tx1 });
 
-      // 2-4. setText × 3
       const records: [string, string][] = [
-        ["xyz.manifest.skill", `0g://${cid.startsWith("0x") ? cid : "0x" + cid}`],
+        ["xyz.manifest.skill", `0g://${pinnedRoot}`],
         ["xyz.manifest.skill.version", version],
         ["xyz.manifest.skill.schema", SCHEMA_URL],
       ];
       let lastTx: Hex = tx1;
       for (let i = 0; i < records.length; i++) {
         const [k, v] = records[i];
-        setStatus({
-          kind: "running",
-          step: `Step ${i + 2}/4 · setText(${k})`,
-        });
+        setPubStatus({ kind: "running", step: `Step ${i + 2}/4 · setText(${k})` });
         const tx = await writeContractAsync({
           address: RESOLVER,
           abi: RESOLVER_ABI,
@@ -150,14 +220,14 @@ export function PublishOverlay({ onClose }: Props) {
       addPublished(address, {
         ensName: fullName,
         version,
-        cid,
+        cid: pinnedRoot,
         txHash: lastTx,
         ts: Date.now(),
       });
-      setStatus({ kind: "ok", lastTx });
+      setPubStatus({ kind: "ok", lastTx });
     } catch (e: unknown) {
       const msg = e instanceof Error ? e.message : String(e);
-      setStatus({ kind: "err", msg: msg.slice(0, 240) });
+      setPubStatus({ kind: "err", msg: msg.slice(0, 240) });
     }
   }
 
@@ -185,14 +255,18 @@ export function PublishOverlay({ onClose }: Props) {
 
       <main className="max-w-5xl mx-auto px-6 py-8 grid grid-cols-1 lg:grid-cols-[1fr_360px] gap-8">
         <section>
-          <h1 className="font-display text-4xl">Bind a function to an ENS name</h1>
+          <h1 className="font-display text-4xl">Publish a skill end-to-end</h1>
           <p className="font-body text-sm text-slate-ink mt-2 max-w-2xl">
-            Four signed transactions on Sepolia: <code className="font-mono">setSubnodeRecord</code> creates
-            the subname under your parent, then <code className="font-mono">setText</code> × 3 publishes
-            the bundle pointer + version + schema URL. After this lands, anyone can{" "}
-            <code className="font-mono">resolveSkill(&quot;{label}.{parent}&quot;)</code> from any RPC.
+            Two beats:{" "}
+            <strong className="text-midnight-navy">pin the manifest to 0G Galileo</strong> (one
+            real on-chain submitLogEntry to the 0G storage contract), then{" "}
+            <strong className="text-midnight-navy">sign 4 Sepolia transactions</strong> binding
+            the bundle root to your ENS name. After both land, anyone can{" "}
+            <code className="font-mono">resolveSkill(&quot;{label}.{parent}&quot;)</code>{" "}
+            from any RPC, and the bridge fetches the manifest off 0G in one read.
           </p>
 
+          {/* Form */}
           <div className="mt-6 space-y-4 font-mono text-sm">
             <Row label="Parent ENS">
               <input value={parent} onChange={(e) => setParent(e.target.value.trim())} className={input} />
@@ -231,78 +305,202 @@ export function PublishOverlay({ onClose }: Props) {
                 <input value={endpoint} onChange={(e) => setEndpoint(e.target.value.trim())} className={input} />
               </Row>
             )}
-            <Row label="0G manifest CID">
-              <input
-                value={cid}
-                onChange={(e) => setCid(e.target.value.trim())}
-                className={input}
-                placeholder="0x… (run `pnpm cli skill publish` first to pin to 0G)"
-              />
-            </Row>
           </div>
 
-          <div className="mt-8 flex items-center gap-3">
-            <button
-              onClick={handlePublish}
-              disabled={!valid || !isConnected || status.kind === "running"}
-              className="px-5 py-2 bg-chartreuse-pulse text-bento-black font-mono text-xs uppercase tracking-wider disabled:opacity-40 hover:-translate-y-px transition"
-            >
-              {status.kind === "running" ? "Signing…" : `Publish ${fullName} →`}
-            </button>
-            {!isConnected && (
-              <span className="font-mono text-xs text-slate-ink">Connect wallet first ↑</span>
-            )}
-            {!valid && isConnected && (
-              <span className="font-mono text-xs text-slate-ink">Fill all fields including a 0G CID</span>
+          {/* Stage 1 — Pin to 0G */}
+          <div className="mt-8 rounded border border-fog-border p-4 bg-pure-surface">
+            <div className="flex items-baseline justify-between">
+              <div>
+                <div className="font-mono text-[10px] uppercase tracking-wider text-slate-ink">
+                  Stage 1 · 0G Galileo storage
+                </div>
+                <h2 className="font-display text-xl mt-1">Pin the manifest</h2>
+              </div>
+              <PinHealthBadge health={pinHealth} />
+            </div>
+            <p className="font-body text-xs text-slate-ink mt-2 max-w-md">
+              POST the JSON to the local pin-service, which spawns the official 0G
+              Go CLI to compute the merkle root, submit it to the 0G log contract,
+              and propagate to storage nodes. Same flow as <code className="font-mono">pnpm cli skill publish</code>.
+            </p>
+
+            <div className="mt-4 flex flex-col sm:flex-row gap-3 items-start">
+              <button
+                onClick={handlePin}
+                disabled={!formValid || pinStatus.kind === "pinging" || pinHealth?.ok === false}
+                className="px-4 py-2 bg-midnight-navy text-chartreuse-pulse font-mono text-xs uppercase tracking-wider rounded hover:-translate-y-px transition disabled:opacity-40"
+              >
+                {pinStatus.kind === "pinging" ? "Pinning to 0G…" : pinnedRoot ? "✓ Re-pin" : "▶ Pin to 0G"}
+              </button>
+              {pinStatus.kind === "ok" && (
+                <div className="flex-1 min-w-0 font-mono text-[11px] text-bento-success">
+                  <div>
+                    ✓ root <code className="break-all">{pinnedRoot}</code>
+                  </div>
+                  <div className="text-slate-ink mt-0.5">
+                    pinned in {pinStatus.ms.toLocaleString()}ms · indexer {pinHealth?.indexer?.replace(/^https?:\/\//, "") ?? "0g indexer"}
+                  </div>
+                </div>
+              )}
+              {pinStatus.kind === "err" && (
+                <div className="flex-1 min-w-0 font-mono text-[11px] text-bento-accent-red break-all">
+                  ✗ {pinStatus.msg}
+                </div>
+              )}
+              {pinStatus.kind === "pinging" && (
+                <div className="font-mono text-[11px] text-slate-ink">
+                  submitLogEntry → uploading by root → waiting for finality (typ. 15-25s)…
+                </div>
+              )}
+            </div>
+
+            {pinStatus.kind === "ok" && pinStatus.log && (
+              <details className="mt-3">
+                <summary className="font-mono text-[10px] uppercase tracking-wider text-slate-ink cursor-pointer hover:text-midnight-navy">
+                  0G CLI log (last lines)
+                </summary>
+                <pre className="mt-2 bg-bento-black text-bento-text-primary p-3 rounded text-[10px] overflow-auto max-h-56 whitespace-pre-wrap break-all">
+                  {/* eslint-disable-next-line no-control-regex */}
+                  {pinStatus.log.replace(/\[[0-9;]*m/g, "")}
+                </pre>
+              </details>
             )}
           </div>
 
-          <div className="mt-4 min-h-[80px] font-mono text-xs">
-            {status.kind === "running" && (
-              <div className="text-midnight-navy">{status.step}…</div>
-            )}
-            {status.kind === "ok" && (
-              <div className="bg-bento-success/10 text-bento-success rounded p-3 break-all">
-                ✓ Published {fullName} — last tx{" "}
-                <a
-                  href={`https://sepolia.etherscan.io/tx/${status.lastTx}`}
-                  target="_blank"
-                  rel="noreferrer"
-                  className="underline"
-                >
-                  {status.lastTx.slice(0, 14)}… ↗
-                </a>
-              </div>
-            )}
-            {status.kind === "err" && (
-              <div className="bg-bento-accent-red/10 text-bento-accent-red rounded p-3 break-all">
-                ✗ {status.msg}
-              </div>
-            )}
+          {/* Stage 2 — Bind on Sepolia */}
+          <div className="mt-6 rounded border border-fog-border p-4 bg-pure-surface">
+            <div className="font-mono text-[10px] uppercase tracking-wider text-slate-ink">
+              Stage 2 · Sepolia ENS
+            </div>
+            <h2 className="font-display text-xl mt-1">Bind to {fullName}</h2>
+            <p className="font-body text-xs text-slate-ink mt-2 max-w-md">
+              4 wallet signatures: <code className="font-mono">setSubnodeRecord</code> creates the
+              subname under your parent, then <code className="font-mono">setText</code> × 3
+              writes the 0G root + version + schema URL into the resolver.
+            </p>
+
+            <div className="mt-4 flex items-center gap-3">
+              <button
+                onClick={handlePublish}
+                disabled={
+                  !pinnedRoot ||
+                  !isConnected ||
+                  pubStatus.kind === "running"
+                }
+                className="px-5 py-2 bg-chartreuse-pulse text-bento-black font-mono text-xs uppercase tracking-wider disabled:opacity-40 hover:-translate-y-px transition rounded"
+              >
+                {pubStatus.kind === "running" ? "Signing…" : `Publish ${fullName} →`}
+              </button>
+              {!pinnedRoot && (
+                <span className="font-mono text-[11px] text-slate-ink">Pin to 0G first ↑</span>
+              )}
+              {pinnedRoot && !isConnected && (
+                <span className="font-mono text-[11px] text-slate-ink">Connect wallet (top-right) to sign.</span>
+              )}
+            </div>
+
+            <div className="mt-3 min-h-[44px] font-mono text-[11px]">
+              {pubStatus.kind === "running" && (
+                <div className="text-midnight-navy">{pubStatus.step}…</div>
+              )}
+              {pubStatus.kind === "ok" && (
+                <div className="bg-bento-success/10 text-bento-success rounded p-2 break-all">
+                  ✓ Published {fullName} — last tx{" "}
+                  <a
+                    href={`https://sepolia.etherscan.io/tx/${pubStatus.lastTx}`}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="underline"
+                  >
+                    {pubStatus.lastTx.slice(0, 14)}… ↗
+                  </a>
+                </div>
+              )}
+              {pubStatus.kind === "err" && (
+                <div className="bg-bento-accent-red/10 text-bento-accent-red rounded p-2 break-all">
+                  ✗ {pubStatus.msg}
+                </div>
+              )}
+            </div>
           </div>
         </section>
 
         <aside className="font-mono text-xs space-y-4">
           <div>
-            <h3 className="text-[10px] uppercase tracking-wider text-slate-ink">Manifest preview</h3>
+            <h3 className="text-[10px] uppercase tracking-wider text-slate-ink">
+              Manifest preview · {JSON.stringify(manifest).length}b
+            </h3>
             <pre className="mt-2 bg-bento-black text-bento-text-primary p-3 rounded text-[10px] overflow-auto max-h-72">
 {JSON.stringify(manifest, null, 2)}
             </pre>
           </div>
           <div>
-            <h3 className="text-[10px] uppercase tracking-wider text-slate-ink">Resulting ENS records</h3>
-            <dl className="mt-2 grid grid-cols-[140px_1fr] gap-y-1">
-              <dt className="text-slate-ink">Subname</dt>
-              <dd className="break-all">{fullName}</dd>
-              <dt className="text-slate-ink">Resolver</dt>
-              <dd className="break-all">{RESOLVER.slice(0, 10)}…</dd>
-              <dt className="text-slate-ink">Records</dt>
-              <dd>3 setText calls</dd>
-            </dl>
+            <h3 className="text-[10px] uppercase tracking-wider text-slate-ink">Pipeline</h3>
+            <ol className="mt-2 space-y-1 text-storm-gray">
+              <PipelineRow done={pinStatus.kind === "ok"}>0G manifest pin</PipelineRow>
+              <PipelineRow done={pubStatus.kind === "running" && pubStatus.step.includes("Step 1") || pubStatus.kind === "ok"}>
+                ENS subname created
+              </PipelineRow>
+              <PipelineRow done={pubStatus.kind === "ok"}>
+                3× setText (root + version + schema)
+              </PipelineRow>
+            </ol>
           </div>
+          {pinnedRoot && (
+            <div>
+              <h3 className="text-[10px] uppercase tracking-wider text-slate-ink">
+                Resulting ENS records
+              </h3>
+              <dl className="mt-2 grid grid-cols-[80px_1fr] gap-y-1">
+                <dt className="text-slate-ink">.skill</dt>
+                <dd className="break-all">0g://{pinnedRoot.slice(0, 16)}…</dd>
+                <dt className="text-slate-ink">.version</dt>
+                <dd>{version}</dd>
+                <dt className="text-slate-ink">.schema</dt>
+                <dd className="break-all">manifest.eth/…/v1.json</dd>
+              </dl>
+            </div>
+          )}
         </aside>
       </main>
     </aside>
+  );
+}
+
+function PinHealthBadge({ health }: { health: PinHealth | null }) {
+  if (health === null) {
+    return <span className="font-mono text-[10px] text-slate-ink">probing pin-service…</span>;
+  }
+  if (!health.ok) {
+    return (
+      <span
+        className="font-mono text-[10px] text-bento-accent-red"
+        title={`pin-service unreachable at ${PIN_SERVICE}`}
+      >
+        ● pin-service offline
+      </span>
+    );
+  }
+  if (!health.keyConfigured) {
+    return (
+      <span className="font-mono text-[10px] text-bento-accent-red" title="server has no SEPOLIA_PRIVATE_KEY">
+        ● key missing
+      </span>
+    );
+  }
+  return (
+    <span className="font-mono text-[10px] text-bento-success" title={PIN_SERVICE}>
+      ● pin-service ready
+    </span>
+  );
+}
+
+function PipelineRow({ done, children }: { done: boolean; children: React.ReactNode }) {
+  return (
+    <li className="flex items-baseline gap-2">
+      <span className={done ? "text-bento-success" : "text-fog-border"}>{done ? "✓" : "○"}</span>
+      <span className={done ? "text-midnight-navy" : "text-storm-gray"}>{children}</span>
+    </li>
   );
 }
 

--- a/apps/web-react/src/components/RegistryPanel.tsx
+++ b/apps/web-react/src/components/RegistryPanel.tsx
@@ -9,6 +9,7 @@ import {
 import { sepolia } from "viem/chains";
 import { isAddress, namehash, parseAbi, type Hex } from "viem";
 import { SKILLLINK_ADDR } from "../lib/contracts";
+import { CallerLog } from "./CallerLog";
 
 const SKILLS_ABI = parseAbi([
   "function skills(bytes32 node) external view returns (address impl, address owner, uint96 registeredAt, uint256 selectorBitmap)",
@@ -535,6 +536,9 @@ export function RegistryPanel({ ensName }: Props) {
           </div>
         </>
       )}
+
+      {/* Activity log shows in both states — registered (with calls) or pre-registration */}
+      <CallerLog ensName={ensName} />
     </div>
   );
 }

--- a/apps/web-react/src/components/SkillDetail.tsx
+++ b/apps/web-react/src/components/SkillDetail.tsx
@@ -3,6 +3,7 @@ import { resolveSkill, type ResolvedSkill } from "../lib/skill-resolve";
 import { TrustPanel } from "./TrustPanel";
 import { TryItButton } from "./TryItButton";
 import { RegistryPanel } from "./RegistryPanel";
+import { OGStorageBadge } from "./OGStorageBadge";
 
 const TABS = ["Readme", "Tools", "Registry", "Dependencies", "Trust"] as const;
 type Tab = typeof TABS[number];
@@ -78,6 +79,9 @@ export function SkillDetail({ ensName, onClose }: Props) {
             <h1 className="font-display text-6xl mt-2">{r.manifest.name}</h1>
             <div className="mt-2 font-mono text-sm text-slate-ink">
               v{r.manifest.version} · {r.manifest.license ?? "MIT"} · {r.manifest.ensName}
+            </div>
+            <div className="mt-3">
+              <OGStorageBadge storage={r.storage} ensMs={r.ensMs} />
             </div>
 
             {tab === "Readme" && (

--- a/apps/web-react/src/lib/skill-events.ts
+++ b/apps/web-react/src/lib/skill-events.ts
@@ -1,0 +1,213 @@
+import { decodeAbiParameters, namehash, parseAbiItem, type PublicClient } from "viem";
+import { SKILLLINK_ADDR } from "./contracts";
+
+// Confirmed signature on the deployed SkillLink (probed via eth_getLogs):
+//   SkillRegistered(bytes32 node, address impl, address owner, bytes4[] selectors)
+// First three fields are indexed; selectors lives in `data`.
+const TOPIC_REGISTERED =
+  "0x888c23edb2e1ab0c431a5710f704534d9a0aae0d9cbfaff28e15566529f83cdf" as const;
+
+// Most-likely signature for the call event. Falling back gracefully if unmatched.
+//   SkillCalled(bytes32 indexed node, address indexed caller, bytes4 selector, bool success)
+const TOPIC_CALLED =
+  "0x79d1cf1216936abfff830078fd5ab5cdf95ad84437b39d0c4465ba40bf4c54ae" as const;
+
+const REGISTERED_EVENT = parseAbiItem(
+  "event SkillRegistered(bytes32 indexed node, address indexed impl, address indexed owner, bytes4[] selectors)",
+);
+
+export type SkillEvent =
+  | {
+      kind: "registered";
+      txHash: `0x${string}`;
+      blockNumber: bigint;
+      timestamp?: number; // unix seconds, populated lazily
+      node: `0x${string}`;
+      impl: `0x${string}`;
+      owner: `0x${string}`;
+      selectors: `0x${string}`[];
+    }
+  | {
+      kind: "called";
+      txHash: `0x${string}`;
+      blockNumber: bigint;
+      timestamp?: number;
+      node: `0x${string}`;
+      caller: `0x${string}`;
+      selector: `0x${string}`;
+      success: boolean;
+    }
+  | {
+      kind: "unknown";
+      txHash: `0x${string}`;
+      blockNumber: bigint;
+      timestamp?: number;
+      topic0: `0x${string}`;
+      topics: readonly `0x${string}`[];
+      data: `0x${string}`;
+    };
+
+export interface SkillEventStream {
+  events: SkillEvent[];
+  totalsByKind: { registered: number; called: number; unknown: number };
+  uniqueCallers: number;
+  scannedFromBlock: bigint;
+  scannedToBlock: bigint;
+  ms: number;
+}
+
+/**
+ * Fetch all SkillLink events for one ENS name. Reads raw logs filtered by
+ * `topic[1] === namehash(ensName)` (both SkillRegistered and SkillCalled
+ * have the namehash as their first indexed arg) so we don't need to know
+ * the exact SkillCalled signature ahead of time.
+ *
+ * `lookbackBlocks` is the cap on how far we scan. Default ~600k blocks (~80
+ * days on Sepolia) which covers the entire SkillLink deployment lifetime.
+ */
+export async function fetchSkillEvents(
+  client: PublicClient,
+  ensName: string,
+  lookbackBlocks = 600_000n,
+): Promise<SkillEventStream> {
+  const t0 = performance.now();
+  const node = namehash(ensName) as `0x${string}`;
+  const head = await client.getBlockNumber();
+  const fromBlock = head > lookbackBlocks ? head - lookbackBlocks : 0n;
+
+  // Fetch ALL logs from the contract, filter by topic[1] = node client-side.
+  // viem's typed getLogs doesn't expose a raw topics filter without binding
+  // to a specific event ABI. SkillLink is low-traffic so the unfiltered fetch
+  // is cheap; this also lets us discover unknown event types alongside the
+  // known SkillRegistered/SkillCalled topics.
+  const allLogs = await client.getLogs({
+    address: SKILLLINK_ADDR,
+    fromBlock,
+    toBlock: head,
+  });
+  const logs = allLogs.filter(
+    (l) => l.topics.length > 1 && (l.topics[1] as string).toLowerCase() === node.toLowerCase(),
+  );
+
+  const events: SkillEvent[] = [];
+  const totalsByKind = { registered: 0, called: 0, unknown: 0 };
+  const callers = new Set<string>();
+
+  for (const log of logs) {
+    const topic0 = log.topics[0] as `0x${string}` | undefined;
+    const topics = log.topics.filter(Boolean) as `0x${string}`[];
+    if (!topic0) continue;
+
+    if (topic0 === TOPIC_REGISTERED) {
+      try {
+        const [selectors] = decodeAbiParameters(
+          [{ type: "bytes4[]" }],
+          log.data,
+        ) as [`0x${string}`[]];
+        events.push({
+          kind: "registered",
+          txHash: log.transactionHash!,
+          blockNumber: log.blockNumber!,
+          node: log.topics[1] as `0x${string}`,
+          impl: ("0x" + (log.topics[2] as string).slice(26)) as `0x${string}`,
+          owner: ("0x" + (log.topics[3] as string).slice(26)) as `0x${string}`,
+          selectors,
+        });
+        totalsByKind.registered++;
+      } catch {
+        events.push({
+          kind: "unknown",
+          txHash: log.transactionHash!,
+          blockNumber: log.blockNumber!,
+          topic0,
+          topics,
+          data: log.data,
+        });
+        totalsByKind.unknown++;
+      }
+    } else if (topic0 === TOPIC_CALLED) {
+      try {
+        // SkillCalled(bytes32 indexed node, address indexed caller, bytes4 selector, bool success)
+        const [selector, success] = decodeAbiParameters(
+          [{ type: "bytes4" }, { type: "bool" }],
+          log.data,
+        ) as [`0x${string}`, boolean];
+        const caller = ("0x" + (log.topics[2] as string).slice(26)) as `0x${string}`;
+        events.push({
+          kind: "called",
+          txHash: log.transactionHash!,
+          blockNumber: log.blockNumber!,
+          node: log.topics[1] as `0x${string}`,
+          caller,
+          selector,
+          success,
+        });
+        totalsByKind.called++;
+        callers.add(caller.toLowerCase());
+      } catch {
+        events.push({
+          kind: "unknown",
+          txHash: log.transactionHash!,
+          blockNumber: log.blockNumber!,
+          topic0,
+          topics,
+          data: log.data,
+        });
+        totalsByKind.unknown++;
+      }
+    } else {
+      events.push({
+        kind: "unknown",
+        txHash: log.transactionHash!,
+        blockNumber: log.blockNumber!,
+        topic0,
+        topics,
+        data: log.data,
+      });
+      totalsByKind.unknown++;
+    }
+  }
+
+  // Sort newest first.
+  events.sort((a, b) => Number(b.blockNumber - a.blockNumber));
+
+  return {
+    events,
+    totalsByKind,
+    uniqueCallers: callers.size,
+    scannedFromBlock: fromBlock,
+    scannedToBlock: head,
+    ms: Math.round(performance.now() - t0),
+  };
+}
+
+/**
+ * Decode a 4-byte selector to a human-readable signature using the public
+ * 4byte directory. Returns null if no match or network error. Cached in
+ * memory for the page session.
+ */
+const fourByteCache = new Map<string, string | null>();
+
+export async function decodeSelector(selector: `0x${string}`): Promise<string | null> {
+  if (fourByteCache.has(selector)) return fourByteCache.get(selector)!;
+  try {
+    const r = await fetch(
+      `https://www.4byte.directory/api/v1/signatures/?hex_signature=${selector}`,
+      { cache: "force-cache" },
+    );
+    if (!r.ok) {
+      fourByteCache.set(selector, null);
+      return null;
+    }
+    const j = (await r.json()) as { results?: { text_signature: string }[] };
+    const sig = j.results?.[0]?.text_signature ?? null;
+    fourByteCache.set(selector, sig);
+    return sig;
+  } catch {
+    fourByteCache.set(selector, null);
+    return null;
+  }
+}
+
+/** Markers used by REGISTERED_EVENT consumer in tests; exported to keep import live. */
+export const _eventFragment = REGISTERED_EVENT;

--- a/apps/web-react/src/lib/skill-resolve.ts
+++ b/apps/web-react/src/lib/skill-resolve.ts
@@ -8,9 +8,17 @@ const VERSIONS_KEY = "xyz.manifest.skill.versions";
 export interface ResolvedSkill {
   ensName: string;
   manifest: SkillManifest;
-  cid: string;
-  ms: number;
+  cid: string;                    // raw URI value (0g://… or ipfs://…)
+  ms: number;                     // total resolve time
   resolvedFromRange?: string;
+  storage: {
+    kind: "0g" | "ipfs";
+    root: string;                 // hex root for 0g, CID for ipfs
+    fetchMs: number;              // time for the storage round-trip
+    fetchUrl: string;             // exact URL the browser hit
+    indexerHost?: string;         // 0G indexer hostname (or ipfs gateway)
+  };
+  ensMs: number;                  // time spent reading the text record
 }
 
 export interface SkillManifest {
@@ -117,19 +125,43 @@ async function resolveVersionedName(
 
 const OG_INDEXER_URL = "https://indexer-storage-testnet-turbo.0g.ai";
 
-async function fetchManifest(uri: string): Promise<SkillManifest> {
+interface FetchedManifest {
+  manifest: SkillManifest;
+  storage: ResolvedSkill["storage"];
+}
+
+async function fetchManifest(uri: string): Promise<FetchedManifest> {
   if (uri.startsWith("0g://")) {
     const root = uri.slice(5);
     const url = `${OG_INDEXER_URL}/file?root=${root}`;
+    const t0 = performance.now();
     const res = await fetch(url, { headers: { Accept: "application/json" } });
+    const fetchMs = Math.round(performance.now() - t0);
     if (!res.ok) throw new Error(`0G fetch failed for ${root}: HTTP ${res.status}`);
-    return (await res.json()) as SkillManifest;
+    const manifest = (await res.json()) as SkillManifest;
+    return {
+      manifest,
+      storage: {
+        kind: "0g",
+        root,
+        fetchMs,
+        fetchUrl: url,
+        indexerHost: new URL(OG_INDEXER_URL).host,
+      },
+    };
   }
   if (uri.startsWith("ipfs://")) {
     const cid = uri.slice(7);
-    const res = await fetch(`https://w3s.link/ipfs/${cid}/manifest.json`);
+    const url = `https://w3s.link/ipfs/${cid}/manifest.json`;
+    const t0 = performance.now();
+    const res = await fetch(url);
+    const fetchMs = Math.round(performance.now() - t0);
     if (!res.ok) throw new Error(`IPFS fetch failed for ${cid}`);
-    return (await res.json()) as SkillManifest;
+    const manifest = (await res.json()) as SkillManifest;
+    return {
+      manifest,
+      storage: { kind: "ipfs", root: cid, fetchMs, fetchUrl: url, indexerHost: "w3s.link" },
+    };
   }
   throw new Error(`unsupported URI scheme: ${uri.slice(0, 12)}…`);
 }
@@ -147,15 +179,19 @@ export async function resolveSkill(
     ensName = await resolveVersionedName(ensName, chain);
   }
   const normalized = normalize(ensName);
+  const ensT0 = performance.now();
   const uri = await clients[chain].getEnsText({ name: normalized, key: SKILL_KEY });
+  const ensMs = Math.round(performance.now() - ensT0);
   if (!uri) throw new Error(`no ${SKILL_KEY} text record on ${ensName}`);
-  const manifest = await fetchManifest(uri);
+  const { manifest, storage } = await fetchManifest(uri);
   return {
     ensName: normalized,
     manifest,
     cid: uri,
     ms: Math.round(performance.now() - t0),
     resolvedFromRange,
+    storage,
+    ensMs,
   };
 }
 

--- a/apps/web-react/src/vite-env.d.ts
+++ b/apps/web-react/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test": "pnpm -r test",
     "lint": "pnpm -r lint",
     "dev:bridge": "pnpm --filter @skillname/bridge dev",
+    "pin:server": "tsx scripts/pin-server.ts",
     "cli": "pnpm --filter @skillname/cli exec skill",
     "validate-skills": "./scripts/test-issue-10.sh"
   },

--- a/scripts/pin-server.ts
+++ b/scripts/pin-server.ts
@@ -1,0 +1,183 @@
+#!/usr/bin/env tsx
+/**
+ * Pin server — wraps the 0G storage Go CLI behind a tiny HTTP endpoint so the
+ * publish overlay in apps/web-react can pin a manifest from the browser
+ * without users having to drop into a terminal.
+ *
+ * The actual pin logic mirrors scripts/pin-to-0g.ts (which is what CI uses):
+ * spawn `0g-storage-client upload`, parse the root from the merged stdout/
+ * stderr, return it. Same code path the demo skills were pinned with —
+ * judges are seeing the same Galileo testnet, same indexer, same root format.
+ *
+ * Usage:
+ *   pnpm pin:server                # listen on :3030
+ *   PIN_PORT=4000 pnpm pin:server  # custom port
+ *
+ * Endpoints:
+ *   GET  /health        → { ok: true, cli, indexer }
+ *   POST /pin           → { manifest, tools?, prompts? } → { root, ms, log }
+ *
+ * The browser POSTs the manifest JSON; the server materialises it under
+ * a tmp dir, runs the CLI, returns the root. CORS is open for localhost:5173.
+ */
+
+import 'dotenv/config'
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+
+import { Hono } from 'hono'
+import { cors } from 'hono/cors'
+import { logger } from 'hono/logger'
+import { serve } from '@hono/node-server'
+
+const PORT = Number(process.env.PIN_PORT ?? 3030)
+const OG_RPC = process.env.OG_RPC_URL ?? 'https://evmrpc-testnet.0g.ai'
+const INDEXER_URL =
+  process.env.OG_INDEXER_URL ?? 'https://indexer-storage-testnet-turbo.0g.ai'
+const PRIVATE_KEY = process.env.SEPOLIA_PRIVATE_KEY
+const CLI_DEFAULT = resolve('.vendor/0g-storage-client/0g-storage-client')
+const CLI = process.env.OG_CLI_BIN ?? (existsSync(CLI_DEFAULT) ? CLI_DEFAULT : '0g-storage-client')
+
+const ROOT_LINE_RX = /file uploaded(?:[^,]*,)?\s*roots?\s*=\s*([^\s]+)/i
+
+if (!PRIVATE_KEY) {
+  console.error(
+    'SEPOLIA_PRIVATE_KEY env var not set — the pin server can boot but every /pin call will fail.',
+  )
+}
+
+interface PinRequest {
+  manifest: unknown
+  tools?: Record<string, unknown>
+  prompts?: Record<string, string>
+  slug?: string
+}
+
+const app = new Hono()
+app.use('*', logger())
+app.use(
+  '*',
+  cors({
+    origin: (origin) =>
+      origin?.startsWith('http://localhost') || origin?.endsWith('.pages.dev')
+        ? origin
+        : 'http://localhost:5173',
+    allowMethods: ['GET', 'POST', 'OPTIONS'],
+    maxAge: 600,
+  }),
+)
+
+app.get('/health', (c) =>
+  c.json({
+    ok: true,
+    cli: CLI,
+    indexer: INDEXER_URL,
+    rpc: OG_RPC,
+    keyConfigured: Boolean(PRIVATE_KEY),
+  }),
+)
+
+app.post('/pin', async (c) => {
+  if (!PRIVATE_KEY) {
+    return c.json({ error: 'server missing SEPOLIA_PRIVATE_KEY' }, 500)
+  }
+  let body: PinRequest
+  try {
+    body = (await c.req.json()) as PinRequest
+  } catch {
+    return c.json({ error: 'invalid JSON body' }, 400)
+  }
+
+  const { manifest, tools = {}, prompts = {}, slug = 'pin' } = body
+  if (!manifest || typeof manifest !== 'object') {
+    return c.json({ error: 'manifest must be an object' }, 400)
+  }
+  // Cheap sanity guard — full schema validation lives in the SDK / publish
+  // overlay; here we only refuse obvious junk so the CLI doesn't waste a tx.
+  const m = manifest as Record<string, unknown>
+  if (typeof m.name !== 'string' || typeof m.ensName !== 'string') {
+    return c.json({ error: 'manifest.name and manifest.ensName are required' }, 400)
+  }
+
+  const dir = mkdtempSync(join(tmpdir(), `skill-pin-${slug}-`))
+  const manifestPath = join(dir, 'manifest.json')
+  try {
+    writeFileSync(manifestPath, JSON.stringify(manifest, null, 2))
+    if (Object.keys(tools).length) {
+      mkdirSync(join(dir, 'tools'), { recursive: true })
+      for (const [name, content] of Object.entries(tools)) {
+        writeFileSync(
+          join(dir, 'tools', name.endsWith('.json') ? name : `${name}.json`),
+          JSON.stringify(content, null, 2),
+        )
+      }
+    }
+    if (Object.keys(prompts).length) {
+      mkdirSync(join(dir, 'prompts'), { recursive: true })
+      for (const [name, body] of Object.entries(prompts)) {
+        writeFileSync(
+          join(dir, 'prompts', name.endsWith('.md') ? name : `${name}.md`),
+          String(body),
+        )
+      }
+    }
+
+    const t0 = Date.now()
+    const result = spawnSync(
+      CLI,
+      [
+        'upload',
+        '--url', OG_RPC,
+        '--indexer', INDEXER_URL,
+        '--key', PRIVATE_KEY,
+        '--file', manifestPath,
+      ],
+      { encoding: 'utf8', timeout: 120_000 },
+    )
+    const ms = Date.now() - t0
+    const stdout = result.stdout ?? ''
+    const stderr = result.stderr ?? ''
+    const log = (stdout + '\n' + stderr).trim()
+    if (result.error || result.status !== 0) {
+      return c.json(
+        {
+          error: `CLI exit ${result.status ?? '?'}${result.error ? ` (${result.error.message})` : ''}`,
+          log,
+          ms,
+        },
+        500,
+      )
+    }
+    const match = log.match(ROOT_LINE_RX)
+    if (!match) {
+      return c.json({ error: 'no root in CLI output', log, ms }, 500)
+    }
+    const root = match[1].split(',')[0].trim()
+    return c.json({
+      root,
+      ms,
+      indexer: INDEXER_URL,
+      rpc: OG_RPC,
+      // last 30 lines of the CLI log so the UI can stream a "what just happened"
+      // detail panel without dumping 500 lines of logrus into the page
+      log: log.split('\n').slice(-30).join('\n'),
+    })
+  } finally {
+    try {
+      rmSync(dir, { recursive: true, force: true })
+    } catch {
+      /* tmpdir cleanup is best effort */
+    }
+  }
+})
+
+console.log(`pin-server  → http://localhost:${PORT}`)
+console.log(`  CLI:      ${CLI}`)
+console.log(`  Indexer:  ${INDEXER_URL}`)
+console.log(`  RPC:      ${OG_RPC}`)
+console.log(`  Key:      ${PRIVATE_KEY ? '✓ loaded' : '✗ missing'}`)
+console.log()
+
+serve({ fetch: app.fetch, port: PORT })


### PR DESCRIPTION
Three drops in one PR:

**A. PublishOverlay end-to-end in the UI**
- New `scripts/pin-server.ts` (Hono on :3030) wraps the 0G Go CLI behind `POST /pin`
- Smoke test: pinned 225b manifest to Galileo in 23s, real submitLogEntry tx
- 2-stage publish flow: Pin to 0G → 4 ENS sigs (manual CID input removed)
- Live health badge + ANSI-stripped CLI log details

**B. On-chain caller log per skill**
- `SkillRegistered` event topic `0x888c23ed…` confirmed via probe
- `SkillCalled` topic guessed (`SkillCalled(bytes32,address,bytes4,bool)`); falls back to 'unknown' if shape differs
- ENS reverse-lookup on caller addresses via mainnet RPC, 4byte directory for selector decode
- Renders below RegistryPanel as a per-skill activity feed

**D. 0G made visible**
- `resolveSkill` captures per-stage timing (ENS read vs 0G storage round-trip)
- `OGStorageBadge` on Hero + SkillDetail headers
- `OGStorageCard` on homepage bento aggregates pinned count + bytes + avg fetch ms

Local build clean (201KB gz). Pin-service runs only locally for now (it shells out to a Go binary so won't run on Cloudflare Pages workers); production would need a small Render/Fly host.