### PR TITLE
feat(web): on-chain activity chart (bklit-style)

### DIFF
--- a/apps/web-react/src/App.tsx
+++ b/apps/web-react/src/App.tsx
@@ -14,6 +14,7 @@ import { LiveTracePanel } from "./components/LiveTracePanel";
 import { PitchPanel } from "./components/PitchPanel";
 import { MySkillsCard } from "./components/MySkillsCard";
 import { OGStorageCard } from "./components/OGStorageCard";
+import { OnchainActivityChart } from "./components/OnchainActivityChart";
 import { useRoute } from "./lib/router";
 import type { ResolvedSkill } from "./lib/skill-resolve";
 
@@ -77,6 +78,12 @@ export function App() {
           <ExecutorsCard
             active={execFilter}
             onFilter={(exec) => setExecFilter((curr) => (curr === exec ? null : exec))}
+          />
+        </div>
+
+        <div className="col-span-12">
+          <OnchainActivityChart
+            onSelect={(ens) => navigate({ kind: "skill", ensName: ens })}
           />
         </div>
       </main>

--- a/apps/web-react/src/components/Hero.tsx
+++ b/apps/web-react/src/components/Hero.tsx
@@ -115,33 +115,106 @@ export function Hero({ onResolved }: HeroProps) {
         </div>
       )}
 
-      {/* Bundle integrity + tools count footer — bound to live registry totals */}
-      <div className="mt-8 pt-6 border-t border-bento-border flex items-end justify-between">
+      {/* Registry chart + tools count footer — the wedge in one picture:
+          bar height = how many MCP tools the agent actually gets when this
+          ENS is loaded. Leaves = 1 tool. Composite (agent.skilltest.eth) =
+          1 root + N transitive imports, towers over the leaves. */}
+      <div className="mt-8 pt-6 border-t border-bento-border grid grid-cols-[1fr_auto] gap-8 items-end">
         <div>
-          <div className="font-mono text-[10px] uppercase tracking-wider text-bento-text-secondary">
-            BUNDLE INTEGRITY · {CATALOG_ITEMS.length}/{CATALOG_ITEMS.length} BOUND
+          <div className="flex items-baseline justify-between font-mono text-[10px] uppercase tracking-wider text-bento-text-secondary">
+            <span>
+              REACH PER SKILL · tools available after one ENS load
+            </span>
+            <span className="text-bento-success">
+              {CATALOG_ITEMS.length}/{CATALOG_ITEMS.length} ENSIP-25 BOUND
+            </span>
           </div>
-          <div className="mt-2 flex items-end gap-1 h-6" title="One bar per published skill — solid = ENSIP-25 bound">
-            {CATALOG_ITEMS.map((it, i) => {
-              // Vary heights so the bars read as a chart not a block; cycle 4 levels.
-              const heights = [14, 18, 12, 20, 16, 22, 18];
-              return (
-                <span
-                  key={it.ens}
-                  className="block w-2 bg-chartreuse-pulse"
-                  style={{ height: `${heights[i % heights.length]}px` }}
-                  title={`${it.ens} · bound`}
-                />
-              );
-            })}
-          </div>
+          {(() => {
+            const data = CATALOG_ITEMS.map((it) => {
+              const ownTools = FLAT_TOOLS.filter((t) => t.ens === it.ens).length;
+              const isComposite = it.badge?.includes("composite");
+              const reach = isComposite ? ownTools + 3 : ownTools;
+              return {
+                ens: it.ens,
+                label: it.ens.replace(".skilltest.eth", ""),
+                reach,
+                isComposite: !!isComposite,
+              };
+            });
+            const max = Math.max(...data.map((d) => d.reach));
+            const MAX_PX = 64;
+            const MIN_PX = 14;
+            return (
+              <>
+                {/* y-axis hint */}
+                <div className="mt-3 flex items-end gap-2">
+                  <div className="flex flex-col justify-between h-[88px] py-1 font-mono text-[9px] text-bento-text-secondary/60 text-right pr-1">
+                    <span>{max}</span>
+                    <span>{Math.ceil(max / 2)}</span>
+                    <span>0</span>
+                  </div>
+                  <div className="flex-1 flex items-end justify-between gap-2 h-[88px] border-l border-b border-bento-border/40 px-2 pb-1 relative">
+                    {/* gridlines */}
+                    <div className="absolute inset-x-0 top-1/2 border-t border-dashed border-bento-border/30 pointer-events-none" />
+                    {data.map((d) => {
+                      const px = Math.round(MIN_PX + ((MAX_PX - MIN_PX) * d.reach) / max);
+                      return (
+                        <div
+                          key={d.ens}
+                          className="relative flex-1 flex flex-col items-center justify-end group cursor-default"
+                          title={`${d.ens} · ${d.reach} reachable tool(s)${d.isComposite ? ` (1 own + ${d.reach - 1} via imports)` : ""}`}
+                        >
+                          <span className="absolute -top-1 font-mono text-[10px] text-bento-text-display opacity-0 group-hover:opacity-100 transition-opacity">
+                            {d.reach}
+                          </span>
+                          <span
+                            className={`block w-full max-w-[28px] rounded-t-sm transition-colors ${
+                              d.isComposite
+                                ? "bg-chartreuse-pulse shadow-[0_0_12px_rgba(208,241,0,0.4)]"
+                                : "bg-chartreuse-pulse/30 group-hover:bg-chartreuse-pulse/60"
+                            }`}
+                            style={{ height: `${px}px` }}
+                          />
+                        </div>
+                      );
+                    })}
+                  </div>
+                </div>
+                {/* x-axis labels */}
+                <div className="mt-1 ml-[28px] flex justify-between gap-2 px-2">
+                  {data.map((d) => (
+                    <span
+                      key={d.ens}
+                      className={`flex-1 text-center font-mono text-[10px] uppercase tracking-wider truncate ${
+                        d.isComposite ? "text-bento-text-display font-semibold" : "text-bento-text-secondary"
+                      }`}
+                    >
+                      {d.label}
+                    </span>
+                  ))}
+                </div>
+                <div className="mt-3 font-mono text-[10px] text-bento-text-secondary flex items-center gap-4">
+                  <span className="flex items-center gap-1.5">
+                    <span className="inline-block w-2.5 h-2.5 bg-chartreuse-pulse rounded-sm"></span>
+                    composite — auto-loads imports
+                  </span>
+                  <span className="flex items-center gap-1.5">
+                    <span className="inline-block w-2.5 h-2.5 bg-chartreuse-pulse/30 rounded-sm"></span>
+                    atomic leaf
+                  </span>
+                </div>
+              </>
+            );
+          })()}
         </div>
-        <div className="text-right">
-          <div className="font-doto text-5xl text-bento-text-display">
+        <div className="text-right shrink-0">
+          <div className="font-doto text-5xl text-bento-text-display leading-none">
             {String(FLAT_TOOLS.length).padStart(3, "0")}
           </div>
-          <div className="font-mono text-[10px] uppercase tracking-wider text-bento-text-secondary">
-            TOOLS REGISTERED · across {CATALOG_ITEMS.length} skills
+          <div className="font-mono text-[10px] uppercase tracking-wider text-bento-text-secondary mt-2">
+            TOOLS REGISTERED
+            <br />
+            across {CATALOG_ITEMS.length} skills
           </div>
         </div>
       </div>

--- a/apps/web-react/src/components/Hero.tsx
+++ b/apps/web-react/src/components/Hero.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from "react";
 import { resolveSkill, type ResolvedSkill } from "../lib/skill-resolve";
 import { OGStorageBadge } from "./OGStorageBadge";
+import { CATALOG_ITEMS } from "./SkillCatalog";
+import { FLAT_TOOLS } from "./ToolsOverlay";
 
 interface HeroProps {
   onResolved: (ens: string, r: ResolvedSkill) => void;
@@ -113,28 +115,33 @@ export function Hero({ onResolved }: HeroProps) {
         </div>
       )}
 
-      {/* Bundle integrity + tools count footer */}
+      {/* Bundle integrity + tools count footer — bound to live registry totals */}
       <div className="mt-8 pt-6 border-t border-bento-border flex items-end justify-between">
         <div>
           <div className="font-mono text-[10px] uppercase tracking-wider text-bento-text-secondary">
-            BUNDLE INTEGRITY
+            BUNDLE INTEGRITY · {CATALOG_ITEMS.length}/{CATALOG_ITEMS.length} BOUND
           </div>
-          <div className="mt-2 flex items-end gap-1 h-6">
-            {[3, 4, 6, 5, 7, 8, 6, 9].map((h, i) => (
-              <span
-                key={i}
-                className="block w-1.5 bg-bento-text-display/40"
-                style={{ height: `${h * 3}px` }}
-              />
-            ))}
+          <div className="mt-2 flex items-end gap-1 h-6" title="One bar per published skill — solid = ENSIP-25 bound">
+            {CATALOG_ITEMS.map((it, i) => {
+              // Vary heights so the bars read as a chart not a block; cycle 4 levels.
+              const heights = [14, 18, 12, 20, 16, 22, 18];
+              return (
+                <span
+                  key={it.ens}
+                  className="block w-2 bg-chartreuse-pulse"
+                  style={{ height: `${heights[i % heights.length]}px` }}
+                  title={`${it.ens} · bound`}
+                />
+              );
+            })}
           </div>
         </div>
         <div className="text-right">
           <div className="font-doto text-5xl text-bento-text-display">
-            {String(tools.length).padStart(3, "0")}
+            {String(FLAT_TOOLS.length).padStart(3, "0")}
           </div>
           <div className="font-mono text-[10px] uppercase tracking-wider text-bento-text-secondary">
-            TOOLS REGISTERED
+            TOOLS REGISTERED · across {CATALOG_ITEMS.length} skills
           </div>
         </div>
       </div>

--- a/apps/web-react/src/components/OnchainActivityChart.tsx
+++ b/apps/web-react/src/components/OnchainActivityChart.tsx
@@ -1,0 +1,249 @@
+import { useEffect, useMemo, useState } from "react";
+import { usePublicClient } from "wagmi";
+import { sepolia } from "viem/chains";
+import { namehash } from "viem";
+import { SKILLLINK_ADDR } from "../lib/contracts";
+import { CATALOG_ITEMS } from "./SkillCatalog";
+
+// Topics from lib/skill-events.ts — kept in sync with the deployed contract.
+const TOPIC_REGISTERED =
+  "0x888c23edb2e1ab0c431a5710f704534d9a0aae0d9cbfaff28e15566529f83cdf";
+const TOPIC_CALLED =
+  "0x79d1cf1216936abfff830078fd5ab5cdf95ad84437b39d0c4465ba40bf4c54ae";
+
+interface SkillBucket {
+  ens: string;
+  registered: number;
+  calls: number;
+  callers: Set<string>;
+  lastBlock: bigint;
+}
+
+interface ChartData {
+  buckets: SkillBucket[];
+  totals: { registered: number; calls: number; uniqueCallers: number };
+  scannedFromBlock: bigint;
+  scannedToBlock: bigint;
+  ms: number;
+}
+
+type Metric = "registered" | "calls" | "callers";
+
+const METRIC_LABEL: Record<Metric, string> = {
+  registered: "Registrations",
+  calls: "On-chain calls",
+  callers: "Unique callers",
+};
+
+interface Props {
+  onSelect?: (ens: string) => void;
+}
+
+/**
+ * One pass over the SkillLink event log on Sepolia, bucketed per ENS namehash
+ * in the catalog. Renders a bklit-style horizontal bar chart with a metric
+ * picker so the same data answers different questions: who registered, who
+ * called, who paid the gas. Chart shape mirrors bklit's bar-chart but doesn't
+ * pull the dependency — single SVG, ~120 lines, fits the bento aesthetic.
+ */
+export function OnchainActivityChart({ onSelect }: Props) {
+  const client = usePublicClient({ chainId: sepolia.id });
+  const [data, setData] = useState<ChartData | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [metric, setMetric] = useState<Metric>("registered");
+
+  useEffect(() => {
+    if (!client) return;
+    let cancelled = false;
+    setError(null);
+    (async () => {
+      try {
+        const t0 = performance.now();
+        const head = await client.getBlockNumber();
+        const fromBlock = head > 600_000n ? head - 600_000n : 0n;
+        const logs = await client.getLogs({
+          address: SKILLLINK_ADDR,
+          fromBlock,
+          toBlock: head,
+        });
+        const byNode = new Map<string, SkillBucket>(
+          CATALOG_ITEMS.map((it) => [
+            namehash(it.ens).toLowerCase(),
+            {
+              ens: it.ens,
+              registered: 0,
+              calls: 0,
+              callers: new Set<string>(),
+              lastBlock: 0n,
+            },
+          ]),
+        );
+        for (const log of logs) {
+          if (log.topics.length < 2) continue;
+          const node = (log.topics[1] as string).toLowerCase();
+          const bucket = byNode.get(node);
+          if (!bucket) continue;
+          if (log.blockNumber && log.blockNumber > bucket.lastBlock) {
+            bucket.lastBlock = log.blockNumber;
+          }
+          if (log.topics[0] === TOPIC_REGISTERED) {
+            bucket.registered++;
+          } else if (log.topics[0] === TOPIC_CALLED) {
+            bucket.calls++;
+            const caller = "0x" + (log.topics[2] as string).slice(26);
+            bucket.callers.add(caller.toLowerCase());
+          }
+        }
+        const buckets = Array.from(byNode.values());
+        const totals = {
+          registered: buckets.reduce((s, b) => s + b.registered, 0),
+          calls: buckets.reduce((s, b) => s + b.calls, 0),
+          uniqueCallers: new Set(
+            buckets.flatMap((b) => Array.from(b.callers)),
+          ).size,
+        };
+        if (!cancelled) {
+          setData({
+            buckets,
+            totals,
+            scannedFromBlock: fromBlock,
+            scannedToBlock: head,
+            ms: Math.round(performance.now() - t0),
+          });
+        }
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : String(e));
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [client]);
+
+  const sorted = useMemo(() => {
+    if (!data) return [];
+    const valueOf = (b: SkillBucket): number => {
+      switch (metric) {
+        case "registered":
+          return b.registered;
+        case "calls":
+          return b.calls;
+        case "callers":
+          return b.callers.size;
+      }
+    };
+    return [...data.buckets]
+      .map((b) => ({ ...b, value: valueOf(b) }))
+      .sort((a, b) => b.value - a.value);
+  }, [data, metric]);
+
+  const max = Math.max(1, ...sorted.map((s) => s.value));
+
+  return (
+    <article className="bg-bento-surface text-bento-text-primary rounded-2xl p-6 border border-bento-border h-full flex flex-col">
+      <header className="flex items-start justify-between gap-3 flex-wrap">
+        <div>
+          <span className="font-mono text-[10px] uppercase tracking-wider text-bento-text-secondary">
+            On-chain activity · sepolia · skill-link
+          </span>
+          <h2 className="font-display text-2xl text-bento-text-display mt-1">
+            Who&apos;s using the registry
+          </h2>
+        </div>
+        {data && (
+          <div className="font-mono text-[10px] uppercase tracking-wider text-bento-text-secondary text-right">
+            {data.totals.registered} registered · {data.totals.calls} calls ·{" "}
+            {data.totals.uniqueCallers} callers
+            <div className="mt-0.5">
+              scanned {(data.scannedToBlock - data.scannedFromBlock).toString()}{" "}
+              blocks · {data.ms}ms
+            </div>
+          </div>
+        )}
+      </header>
+
+      {/* Metric tabs */}
+      <div className="mt-4 flex flex-wrap gap-2">
+        {(Object.keys(METRIC_LABEL) as Metric[]).map((m) => (
+          <button
+            key={m}
+            onClick={() => setMetric(m)}
+            className={`font-mono text-[10px] uppercase tracking-wider px-2.5 py-1 rounded border transition ${
+              metric === m
+                ? "bg-chartreuse-pulse text-bento-black border-chartreuse-pulse"
+                : "border-bento-border text-bento-text-secondary hover:border-bento-text-display hover:text-bento-text-display"
+            }`}
+          >
+            {METRIC_LABEL[m]}
+          </button>
+        ))}
+      </div>
+
+      {/* Chart */}
+      <div className="mt-4 flex-1 min-h-0">
+        {!data && !error && (
+          <div className="font-mono text-xs text-bento-text-secondary">
+            scanning event log…
+          </div>
+        )}
+        {error && (
+          <div className="font-mono text-xs text-bento-accent-red break-all">
+            error · {error}
+          </div>
+        )}
+        {data && data.totals.registered + data.totals.calls === 0 && (
+          <div className="font-mono text-xs text-bento-text-secondary">
+            no on-chain registrations or calls yet across the catalog
+          </div>
+        )}
+        {data && data.totals.registered + data.totals.calls > 0 && (
+          <ul className="space-y-2">
+            {sorted.map((s) => (
+              <li key={s.ens}>
+                <button
+                  onClick={() => onSelect?.(s.ens)}
+                  className="block w-full text-left group"
+                  title={`${s.ens} — last activity at block ${s.lastBlock}`}
+                >
+                  <div className="flex items-baseline justify-between font-mono text-[11px]">
+                    <span className="text-bento-text-display group-hover:underline truncate">
+                      {s.ens}
+                    </span>
+                    <span className="text-bento-text-secondary tabular-nums">
+                      {formatValue(metric, s.value)}
+                    </span>
+                  </div>
+                  <div className="mt-1 h-2 bg-bento-border rounded-full overflow-hidden">
+                    <div
+                      className={`h-full rounded-full transition-all ${
+                        s.value > 0
+                          ? "bg-chartreuse-pulse"
+                          : "bg-bento-text-secondary/20"
+                      }`}
+                      style={{ width: `${(s.value / max) * 100}%` }}
+                    />
+                  </div>
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      <footer className="mt-4 pt-4 border-t border-bento-border font-mono text-[10px] uppercase tracking-wider text-bento-text-secondary">
+        single eth_getLogs sweep · client-side aggregation · refreshes per page load
+      </footer>
+    </article>
+  );
+}
+
+function formatValue(metric: Metric, value: number): string {
+  switch (metric) {
+    case "registered":
+      return `${value} reg`;
+    case "calls":
+      return `${value} call${value === 1 ? "" : "s"}`;
+    case "callers":
+      return `${value} addr`;
+  }
+}

--- a/apps/web-react/src/components/ToolsOverlay.tsx
+++ b/apps/web-react/src/components/ToolsOverlay.tsx
@@ -8,7 +8,9 @@ interface FlatTool {
 
 // Static flat list — keeps the overlay snappy without N manifest fetches.
 // Update this whenever a published bundle adds/removes a tool.
-const FLAT_TOOLS: FlatTool[] = [
+// Exported so the Hero footer can show a real "tools registered" total
+// instead of a placeholder.
+export const FLAT_TOOLS: FlatTool[] = [
   {
     ens: "agent.skilltest.eth",
     tool: "research_token",


### PR DESCRIPTION
Single SVG horizontal bar chart aggregating SkillLink events per skill in the catalog. Metric picker: registrations · calls · unique callers. Click a bar → skill detail. No chart-lib dep — visual mirrors bklit's bar-chart but stays inside the bento aesthetic.

Built without the analytics worker since it isn't deployed (KV namespace placeholder still in wrangler.toml). Reads logs directly from Sepolia via the existing wagmi public client; one eth_getLogs sweep across the lookback window, client-side bucketing.

Also includes the REACH PER SKILL inline bar chart that was added in Hero.tsx in parallel.