### PR TITLE
feat(skill): basescan.skilltest.eth — real publish→import→execute

### DIFF
--- a/apps/web-react/src/components/SkillCatalog.tsx
+++ b/apps/web-react/src/components/SkillCatalog.tsx
@@ -9,6 +9,7 @@ export const CATALOG_ITEMS: CatalogItem[] = [
   { ens: "agent.skilltest.eth",   exec: "local",      badge: "composite · 3 imports" },
   { ens: "quote.skilltest.eth",   exec: "http" },
   { ens: "swap.skilltest.eth",    exec: "keeperhub",  badge: "x402" },
+  { ens: "basescan.skilltest.eth", exec: "http",      badge: "live · base" },
   { ens: "score.skilltest.eth",   exec: "http" },
   { ens: "weather.skilltest.eth", exec: "http" },
   { ens: "infer.skilltest.eth",   exec: "0g-compute" },

--- a/apps/web-react/src/components/ToolsOverlay.tsx
+++ b/apps/web-react/src/components/ToolsOverlay.tsx
@@ -32,6 +32,20 @@ export const FLAT_TOOLS: FlatTool[] = [
     badge: "x402",
   },
   {
+    ens: "basescan.skilltest.eth",
+    tool: "scan_contract",
+    exec: "http",
+    description: "Verified Solidity source + ABI for any contract on Base mainnet. Blockscout v1, no auth.",
+    badge: "live · base",
+  },
+  {
+    ens: "basescan.skilltest.eth",
+    tool: "get_token",
+    exec: "http",
+    description: "ERC-20/721 token metadata (name, symbol, decimals, totalSupply) on Base mainnet.",
+    badge: "live · base",
+  },
+  {
     ens: "score.skilltest.eth",
     tool: "trust_score",
     exec: "http",

--- a/skillname-pack/examples/basescan/manifest.json
+++ b/skillname-pack/examples/basescan/manifest.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://manifest.eth/schemas/skill-v1.json",
+  "name": "basescan",
+  "ensName": "basescan.skilltest.eth",
+  "version": "1.0.0",
+  "description": "Read contract metadata and source on Base mainnet via the Blockscout API. Free, no auth, public reads only.",
+  "license": "MIT",
+  "tools": [
+    {
+      "name": "scan_contract",
+      "description": "Fetch verified Solidity source + ABI for any contract on Base mainnet. Returns the source code, compiler settings, and proxy status from the Blockscout v1 API.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "address": {
+            "type": "string",
+            "description": "Base mainnet contract address (0x + 40 hex)",
+            "examples": [
+              "0x4200000000000000000000000000000000000006"
+            ]
+          }
+        },
+        "required": ["address"]
+      },
+      "execution": {
+        "type": "http",
+        "endpoint": "https://base.blockscout.com/api?module=contract&action=getsourcecode",
+        "method": "GET"
+      }
+    },
+    {
+      "name": "get_token",
+      "description": "Fetch ERC-20 / ERC-721 token metadata (name, symbol, decimals, totalSupply) for a contract on Base mainnet.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "contractaddress": {
+            "type": "string",
+            "description": "Base mainnet token contract address",
+            "examples": [
+              "0x4200000000000000000000000000000000000006"
+            ]
+          }
+        },
+        "required": ["contractaddress"]
+      },
+      "execution": {
+        "type": "http",
+        "endpoint": "https://base.blockscout.com/api?module=token&action=getToken",
+        "method": "GET"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Replaces the invented BaseScanner clip in the demo video with a skill that's actually pinned + published + callable.

**Real on-chain proof** (Sepolia + 0G Galileo):
- 0G manifest: `0g://0x4065c3e4fd7ec991f06ace194ce0e673ccb8e452895a60a080c855b4171ab26a` — [storage scan](https://indexer-storage-testnet-turbo.0g.ai/file?root=0x4065c3e4fd7ec991f06ace194ce0e673ccb8e452895a60a080c855b4171ab26a)
- ENS subname tx: `0xcfd5a5229b8a8d07cab64a8c597f14a3e64246d4bab2d6192068371c3be48304` ([Sepolia](https://sepolia.etherscan.io/tx/0xcfd5a5229b8a8d07cab64a8c597f14a3e64246d4bab2d6192068371c3be48304))
- Verify on app.ens.domains: `basescan.skilltest.eth`

**Tools**:
- `scan_contract(address)` → Blockscout getsourcecode (verified Solidity source + ABI)
- `get_token(contractaddress)` → Blockscout getToken (ERC-20/721 metadata)

Both no-auth public APIs on Base mainnet. Smoke-tested live: USDC `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913` returns FiatTokenProxy + 6 decimals + ~4.4M total supply.

Wired into the React app catalog (badge `live · base`) so it shows up everywhere — SkillCatalog, ToolsOverlay, MySkillsCard, OGStorageCard, OnchainActivityChart.