### PR TITLE
fix(web): chunk eth_getLogs into 1000-block ranges

### DIFF
--- a/apps/web-react/src/components/OnchainActivityChart.tsx
+++ b/apps/web-react/src/components/OnchainActivityChart.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { usePublicClient } from "wagmi";
 import { sepolia } from "viem/chains";
-import { namehash } from "viem";
+import { namehash, type Log, type PublicClient } from "viem";
 import { SKILLLINK_ADDR } from "../lib/contracts";
 import { CATALOG_ITEMS } from "./SkillCatalog";
 
@@ -10,6 +10,37 @@ const TOPIC_REGISTERED =
   "0x888c23edb2e1ab0c431a5710f704534d9a0aae0d9cbfaff28e15566529f83cdf";
 const TOPIC_CALLED =
   "0x79d1cf1216936abfff830078fd5ab5cdf95ad84437b39d0c4465ba40bf4c54ae";
+
+// SkillLink deploy block (mirrors apps/analytics START_BLOCK). Public Sepolia
+// RPCs cap eth_getLogs at 1000 blocks per call, so we anchor here and chunk.
+const SKILLLINK_DEPLOY_BLOCK = 10_772_615n;
+const RPC_BLOCK_LIMIT = 1000n;
+
+async function chunkedGetLogs(
+  client: PublicClient,
+  fromBlock: bigint,
+  toBlock: bigint,
+  maxChunks = 50,
+): Promise<Log[]> {
+  const ranges: { from: bigint; to: bigint }[] = [];
+  for (let cur = fromBlock; cur <= toBlock; cur += RPC_BLOCK_LIMIT) {
+    const end = cur + RPC_BLOCK_LIMIT - 1n;
+    ranges.push({ from: cur, to: end > toBlock ? toBlock : end });
+    if (ranges.length >= maxChunks) break;
+  }
+  const results = await Promise.all(
+    ranges.map((r) =>
+      client
+        .getLogs({
+          address: SKILLLINK_ADDR,
+          fromBlock: r.from,
+          toBlock: r.to,
+        })
+        .catch(() => [] as Log[]),
+    ),
+  );
+  return results.flat();
+}
 
 interface SkillBucket {
   ens: string;
@@ -60,12 +91,8 @@ export function OnchainActivityChart({ onSelect }: Props) {
       try {
         const t0 = performance.now();
         const head = await client.getBlockNumber();
-        const fromBlock = head > 600_000n ? head - 600_000n : 0n;
-        const logs = await client.getLogs({
-          address: SKILLLINK_ADDR,
-          fromBlock,
-          toBlock: head,
-        });
+        const fromBlock = SKILLLINK_DEPLOY_BLOCK;
+        const logs = await chunkedGetLogs(client, fromBlock, head);
         const byNode = new Map<string, SkillBucket>(
           CATALOG_ITEMS.map((it) => [
             namehash(it.ens).toLowerCase(),

--- a/apps/web-react/src/lib/skill-events.ts
+++ b/apps/web-react/src/lib/skill-events.ts
@@ -1,5 +1,11 @@
-import { decodeAbiParameters, namehash, parseAbiItem, type PublicClient } from "viem";
+import { decodeAbiParameters, namehash, parseAbiItem, type Log, type PublicClient } from "viem";
 import { SKILLLINK_ADDR } from "./contracts";
+
+// Block at which SkillLink was deployed. Mirrors apps/analytics START_BLOCK
+// so we never scan further back than necessary — public Sepolia RPCs cap
+// eth_getLogs at 1000 blocks per call, so unbounded sweeps fail outright.
+const SKILLLINK_DEPLOY_BLOCK = 10_772_615n;
+const RPC_BLOCK_LIMIT = 1000n;
 
 // Confirmed signature on the deployed SkillLink (probed via eth_getLogs):
 //   SkillRegistered(bytes32 node, address impl, address owner, bytes4[] selectors)
@@ -57,34 +63,56 @@ export interface SkillEventStream {
 }
 
 /**
+ * Public Sepolia RPCs (thirdweb, publicnode, etc.) cap eth_getLogs at 1000
+ * blocks per request. Chunk the [from, to] range into 1000-block windows
+ * and fan them out in parallel. Caps total chunks to avoid hammering an RPC
+ * when fromBlock is wildly behind head.
+ */
+async function chunkedGetLogs(
+  client: PublicClient,
+  fromBlock: bigint,
+  toBlock: bigint,
+  maxChunks = 50,
+): Promise<Log[]> {
+  const ranges: { from: bigint; to: bigint }[] = [];
+  for (let cur = fromBlock; cur <= toBlock; cur += RPC_BLOCK_LIMIT) {
+    const end = cur + RPC_BLOCK_LIMIT - 1n;
+    ranges.push({ from: cur, to: end > toBlock ? toBlock : end });
+    if (ranges.length >= maxChunks) break;
+  }
+  const results = await Promise.all(
+    ranges.map((r) =>
+      client
+        .getLogs({
+          address: SKILLLINK_ADDR,
+          fromBlock: r.from,
+          toBlock: r.to,
+        })
+        .catch(() => [] as Log[]),
+    ),
+  );
+  return results.flat();
+}
+
+/**
  * Fetch all SkillLink events for one ENS name. Reads raw logs filtered by
  * `topic[1] === namehash(ensName)` (both SkillRegistered and SkillCalled
  * have the namehash as their first indexed arg) so we don't need to know
  * the exact SkillCalled signature ahead of time.
  *
- * `lookbackBlocks` is the cap on how far we scan. Default ~600k blocks (~80
- * days on Sepolia) which covers the entire SkillLink deployment lifetime.
+ * Scan starts at the SkillLink deploy block — public Sepolia RPCs cap
+ * eth_getLogs at 1000 blocks per call, so we chunk and parallelize.
  */
 export async function fetchSkillEvents(
   client: PublicClient,
   ensName: string,
-  lookbackBlocks = 600_000n,
 ): Promise<SkillEventStream> {
   const t0 = performance.now();
   const node = namehash(ensName) as `0x${string}`;
   const head = await client.getBlockNumber();
-  const fromBlock = head > lookbackBlocks ? head - lookbackBlocks : 0n;
+  const fromBlock = SKILLLINK_DEPLOY_BLOCK;
 
-  // Fetch ALL logs from the contract, filter by topic[1] = node client-side.
-  // viem's typed getLogs doesn't expose a raw topics filter without binding
-  // to a specific event ABI. SkillLink is low-traffic so the unfiltered fetch
-  // is cheap; this also lets us discover unknown event types alongside the
-  // known SkillRegistered/SkillCalled topics.
-  const allLogs = await client.getLogs({
-    address: SKILLLINK_ADDR,
-    fromBlock,
-    toBlock: head,
-  });
+  const allLogs = await chunkedGetLogs(client, fromBlock, head);
   const logs = allLogs.filter(
     (l) => l.topics.length > 1 && (l.topics[1] as string).toLowerCase() === node.toLowerCase(),
   );


### PR DESCRIPTION
Public Sepolia RPCs cap eth_getLogs at 1000 blocks/call → the 600k-block sweep was failing on staging. Anchor scans at SkillLink deploy block (10772615), chunk + parallelize. Smoke: 8 chunks, ~1s, finds 4 real SkillRegistered events that were getting hidden by the error.