### PR TITLE
feat(web): per-skill area chart + import graph on the skill detail page

### DIFF
--- a/apps/web-react/src/components/DependencyGraph.tsx
+++ b/apps/web-react/src/components/DependencyGraph.tsx
@@ -1,0 +1,252 @@
+import { CATALOG_ITEMS } from "./SkillCatalog";
+
+// Static composite map — derived from the published manifests.
+// Update when a new composite ships. Mirrors what the bridge sees from
+// xyz.manifest.skill.imports for each ENS name in the registry.
+const COMPOSITES: Record<string, string[]> = {
+  "agent.skilltest.eth": [
+    "quote.skilltest.eth",
+    "score.skilltest.eth",
+    "infer.skilltest.eth",
+  ],
+};
+
+// Reverse-dep index: who imports me?
+function importedBy(target: string): string[] {
+  const parents: string[] = [];
+  for (const [parent, children] of Object.entries(COMPOSITES)) {
+    if (children.includes(target)) parents.push(parent);
+  }
+  return parents;
+}
+
+interface Props {
+  ensName: string;
+  dependencies?: string[];
+  onSelect?: (ens: string) => void;
+}
+
+export function DependencyGraph({ ensName, dependencies, onSelect }: Props) {
+  const deps = dependencies ?? [];
+  const parents = importedBy(ensName);
+  const isComposite = deps.length > 0;
+  const isLeaf = deps.length === 0;
+
+  // Compose the layout: parents on top row, current node in middle, children below.
+  // For agent.skilltest.eth: 0 parents + center + 3 children.
+  // For infer.skilltest.eth: 1 parent + center + 0 children.
+  return (
+    <div className="border border-fog-border rounded p-6 bg-pure-surface">
+      <div className="flex items-baseline justify-between mb-4">
+        <h3 className="font-display text-2xl">Import graph</h3>
+        <span className="font-mono text-[10px] uppercase tracking-wider text-slate-ink">
+          {isComposite ? `composite · ${deps.length} import(s)` : isLeaf && parents.length > 0 ? `leaf · imported by ${parents.length}` : "leaf · standalone"}
+        </span>
+      </div>
+
+      <Graph
+        ensName={ensName}
+        parents={parents}
+        children={deps}
+        onSelect={onSelect}
+      />
+
+      <Legend />
+    </div>
+  );
+}
+
+function Graph({
+  ensName,
+  parents,
+  children,
+  onSelect,
+}: {
+  ensName: string;
+  parents: string[];
+  children: string[];
+  onSelect?: (ens: string) => void;
+}) {
+  // SVG layout
+  const width = 720;
+  const rowH = 90;
+  const rows = (parents.length > 0 ? 1 : 0) + 1 + (children.length > 0 ? 1 : 0);
+  const height = rows * rowH + 40;
+
+  const centerY = parents.length > 0 ? rowH + 20 : 30;
+  const centerX = width / 2;
+
+  function xFor(i: number, n: number) {
+    if (n === 1) return centerX;
+    const margin = 80;
+    const usable = width - margin * 2;
+    return margin + (usable * i) / (n - 1);
+  }
+
+  const parentY = 30;
+  const childY = centerY + rowH;
+
+  return (
+    <svg
+      viewBox={`0 0 ${width} ${height}`}
+      className="w-full"
+      preserveAspectRatio="xMidYMid meet"
+    >
+      {/* edges: parents → center */}
+      {parents.map((p, i) => {
+        const x1 = xFor(i, parents.length);
+        return (
+          <line
+            key={`pe-${p}`}
+            x1={x1}
+            y1={parentY + 22}
+            x2={centerX}
+            y2={centerY - 22}
+            stroke="var(--color-fog-border, #b1b5c0)"
+            strokeWidth="1.5"
+            strokeDasharray="4 3"
+          />
+        );
+      })}
+
+      {/* edges: center → children */}
+      {children.map((c, i) => {
+        const x2 = xFor(i, children.length);
+        return (
+          <line
+            key={`ce-${c}`}
+            x1={centerX}
+            y1={centerY + 22}
+            x2={x2}
+            y2={childY - 22}
+            stroke="var(--color-midnight-navy, #1b2540)"
+            strokeWidth="1.5"
+          />
+        );
+      })}
+
+      {/* parent nodes */}
+      {parents.map((p, i) => (
+        <Node
+          key={`p-${p}`}
+          x={xFor(i, parents.length)}
+          y={parentY}
+          label={p}
+          variant="parent"
+          onClick={() => onSelect?.(p)}
+        />
+      ))}
+
+      {/* center (this skill) */}
+      <Node x={centerX} y={centerY} label={ensName} variant="self" />
+
+      {/* child nodes */}
+      {children.map((c, i) => (
+        <Node
+          key={`c-${c}`}
+          x={xFor(i, children.length)}
+          y={childY}
+          label={c}
+          variant="child"
+          onClick={() => onSelect?.(c)}
+        />
+      ))}
+
+      {/* "no graph" hint when truly standalone */}
+      {parents.length === 0 && children.length === 0 && (
+        <text
+          x={centerX}
+          y={centerY + 50}
+          textAnchor="middle"
+          className="font-mono text-[11px] fill-slate-ink"
+        >
+          standalone — no imports, no dependents (yet)
+        </text>
+      )}
+    </svg>
+  );
+}
+
+function Node({
+  x,
+  y,
+  label,
+  variant,
+  onClick,
+}: {
+  x: number;
+  y: number;
+  label: string;
+  variant: "self" | "parent" | "child";
+  onClick?: () => void;
+}) {
+  const W = 180;
+  const H = 44;
+  const fill =
+    variant === "self"
+      ? "var(--color-midnight-navy, #1b2540)"
+      : "var(--color-pure-surface, #ffffff)";
+  const stroke =
+    variant === "self"
+      ? "var(--color-midnight-navy, #1b2540)"
+      : "var(--color-fog-border, #b1b5c0)";
+  const textFill =
+    variant === "self"
+      ? "var(--color-chartreuse-pulse, #d0f100)"
+      : "var(--color-midnight-navy, #1b2540)";
+  const tag =
+    variant === "self" ? "this skill" : variant === "parent" ? "imports me" : "i import";
+  const cursor = onClick ? "pointer" : "default";
+
+  return (
+    <g style={{ cursor }} onClick={onClick}>
+      <rect
+        x={x - W / 2}
+        y={y - H / 2}
+        width={W}
+        height={H}
+        rx="6"
+        fill={fill}
+        stroke={stroke}
+        strokeWidth="1.5"
+      />
+      <text
+        x={x}
+        y={y - 2}
+        textAnchor="middle"
+        className="font-mono text-[12px] font-semibold"
+        style={{ fill: textFill }}
+      >
+        {label}
+      </text>
+      <text
+        x={x}
+        y={y + 13}
+        textAnchor="middle"
+        className="font-mono text-[9px] uppercase tracking-wider"
+        style={{ fill: variant === "self" ? "rgba(255,255,255,0.6)" : "var(--color-slate-ink, #6b7184)" }}
+      >
+        {tag}
+      </text>
+    </g>
+  );
+}
+
+function Legend() {
+  return (
+    <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1 font-mono text-[10px] text-slate-ink">
+      <span className="flex items-center gap-1.5">
+        <svg width="20" height="10">
+          <line x1="0" y1="5" x2="20" y2="5" stroke="var(--color-midnight-navy)" strokeWidth="1.5" />
+        </svg>
+        I import (solid)
+      </span>
+      <span className="flex items-center gap-1.5">
+        <svg width="20" height="10">
+          <line x1="0" y1="5" x2="20" y2="5" stroke="var(--color-fog-border)" strokeWidth="1.5" strokeDasharray="4 3" />
+        </svg>
+        imported by (dashed)
+      </span>
+    </div>
+  );
+}

--- a/apps/web-react/src/components/SkillActivityChart.tsx
+++ b/apps/web-react/src/components/SkillActivityChart.tsx
@@ -1,0 +1,284 @@
+import { useEffect, useMemo, useState } from "react";
+import { usePublicClient } from "wagmi";
+import { sepolia } from "viem/chains";
+import { namehash, type Log, type PublicClient } from "viem";
+import { SKILLLINK_ADDR } from "../lib/contracts";
+
+// Bklit-style area chart for ONE skill.
+// Reads SkillLink event logs filtered by namehash(ensName), buckets them
+// across the scan window, and renders a gradient-filled area chart in
+// hand-rolled SVG (matches the bento aesthetic, no @visx/* deps).
+//
+// Topics mirror lib/skill-events.ts — kept in sync with the deployed contract.
+const TOPIC_REGISTERED =
+  "0x888c23edb2e1ab0c431a5710f704534d9a0aae0d9cbfaff28e15566529f83cdf";
+const TOPIC_CALLED =
+  "0x79d1cf1216936abfff830078fd5ab5cdf95ad84437b39d0c4465ba40bf4c54ae";
+const SKILLLINK_DEPLOY_BLOCK = 10_772_615n;
+const RPC_BLOCK_LIMIT = 1000n;
+const BUCKETS = 16;
+
+async function chunkedGetLogs(
+  client: PublicClient,
+  fromBlock: bigint,
+  toBlock: bigint,
+  maxChunks = 50,
+): Promise<Log[]> {
+  const ranges: { from: bigint; to: bigint }[] = [];
+  for (let cur = fromBlock; cur <= toBlock; cur += RPC_BLOCK_LIMIT) {
+    const end = cur + RPC_BLOCK_LIMIT - 1n;
+    ranges.push({ from: cur, to: end > toBlock ? toBlock : end });
+    if (ranges.length >= maxChunks) break;
+  }
+  const results = await Promise.all(
+    ranges.map((r) =>
+      client.getLogs({ address: SKILLLINK_ADDR, fromBlock: r.from, toBlock: r.to }).catch(() => [] as Log[]),
+    ),
+  );
+  return results.flat();
+}
+
+interface Bucket {
+  blockRange: { from: bigint; to: bigint };
+  registrations: number;
+  calls: number;
+}
+
+interface ScanResult {
+  buckets: Bucket[];
+  totals: { registrations: number; calls: number };
+  scannedFromBlock: bigint;
+  scannedToBlock: bigint;
+  ms: number;
+}
+
+interface Props {
+  ensName: string;
+}
+
+export function SkillActivityChart({ ensName }: Props) {
+  const client = usePublicClient({ chainId: sepolia.id });
+  const [data, setData] = useState<ScanResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!client) return;
+    let cancelled = false;
+    setData(null);
+    setError(null);
+    (async () => {
+      try {
+        const t0 = performance.now();
+        const head = await client.getBlockNumber();
+        const fromBlock = SKILLLINK_DEPLOY_BLOCK;
+        const target = namehash(ensName).toLowerCase();
+        const logs = await chunkedGetLogs(client, fromBlock, head);
+
+        const span = head - fromBlock + 1n;
+        const bucketSize = span / BigInt(BUCKETS) || 1n;
+        const buckets: Bucket[] = Array.from({ length: BUCKETS }, (_, i) => ({
+          blockRange: {
+            from: fromBlock + bucketSize * BigInt(i),
+            to: i === BUCKETS - 1 ? head : fromBlock + bucketSize * BigInt(i + 1) - 1n,
+          },
+          registrations: 0,
+          calls: 0,
+        }));
+
+        let registrations = 0;
+        let calls = 0;
+        for (const log of logs) {
+          if (log.topics.length < 2) continue;
+          if ((log.topics[1] as string).toLowerCase() !== target) continue;
+          const block = log.blockNumber ?? 0n;
+          const idx = Number((block - fromBlock) / bucketSize);
+          const bucket = buckets[Math.min(BUCKETS - 1, Math.max(0, idx))];
+          if (log.topics[0] === TOPIC_REGISTERED) {
+            bucket.registrations++;
+            registrations++;
+          } else if (log.topics[0] === TOPIC_CALLED) {
+            bucket.calls++;
+            calls++;
+          }
+        }
+
+        if (!cancelled) {
+          setData({
+            buckets,
+            totals: { registrations, calls },
+            scannedFromBlock: fromBlock,
+            scannedToBlock: head,
+            ms: Math.round(performance.now() - t0),
+          });
+        }
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : String(e));
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [client, ensName]);
+
+  return (
+    <div className="border border-fog-border rounded p-5 bg-pure-surface">
+      <header className="flex items-baseline justify-between gap-3 flex-wrap">
+        <div>
+          <span className="font-mono text-[10px] uppercase tracking-wider text-slate-ink">
+            ON-CHAIN ACTIVITY · sepolia · skill-link
+          </span>
+          <h3 className="font-display text-xl text-midnight-navy mt-0.5">
+            Calls + registrations for <code className="font-mono text-base">{ensName}</code>
+          </h3>
+        </div>
+        {data && (
+          <div className="font-mono text-[10px] uppercase tracking-wider text-slate-ink text-right">
+            <div>
+              <span className="text-midnight-navy font-semibold">{data.totals.calls}</span> calls ·{" "}
+              <span className="text-midnight-navy font-semibold">{data.totals.registrations}</span> registrations
+            </div>
+            <div className="mt-0.5 opacity-70">
+              {(data.scannedToBlock - data.scannedFromBlock).toString()} blocks scanned · {data.ms}ms
+            </div>
+          </div>
+        )}
+      </header>
+
+      <div className="mt-4">
+        {!data && !error && (
+          <div className="font-mono text-xs text-slate-ink py-12 text-center">scanning event log…</div>
+        )}
+        {error && (
+          <div className="font-mono text-xs text-bento-accent-red break-all py-4">error · {error}</div>
+        )}
+        {data && (
+          <AreaChart
+            buckets={data.buckets}
+            scannedFromBlock={data.scannedFromBlock}
+            scannedToBlock={data.scannedToBlock}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+interface AreaProps {
+  buckets: Bucket[];
+  scannedFromBlock: bigint;
+  scannedToBlock: bigint;
+}
+
+function AreaChart({ buckets, scannedFromBlock, scannedToBlock }: AreaProps) {
+  const W = 720;
+  const H = 180;
+  const PAD_L = 36;
+  const PAD_R = 12;
+  const PAD_T = 12;
+  const PAD_B = 28;
+  const innerW = W - PAD_L - PAD_R;
+  const innerH = H - PAD_T - PAD_B;
+
+  const series = useMemo(() => buckets.map((b) => b.calls + b.registrations), [buckets]);
+  const max = Math.max(1, ...series);
+  const isEmpty = series.every((v) => v === 0);
+
+  const points = series.map((v, i) => {
+    const x = PAD_L + (innerW * i) / (series.length - 1 || 1);
+    const y = PAD_T + innerH - (innerH * v) / max;
+    return { x, y, v };
+  });
+
+  // Smooth Catmull-Rom → cubic Bézier conversion for a soft Bklit feel.
+  function smoothPath(pts: { x: number; y: number }[]): string {
+    if (pts.length === 0) return "";
+    if (pts.length === 1) return `M ${pts[0].x} ${pts[0].y}`;
+    let d = `M ${pts[0].x} ${pts[0].y}`;
+    for (let i = 0; i < pts.length - 1; i++) {
+      const p0 = pts[i - 1] ?? pts[i];
+      const p1 = pts[i];
+      const p2 = pts[i + 1];
+      const p3 = pts[i + 2] ?? p2;
+      const cp1x = p1.x + (p2.x - p0.x) / 6;
+      const cp1y = p1.y + (p2.y - p0.y) / 6;
+      const cp2x = p2.x - (p3.x - p1.x) / 6;
+      const cp2y = p2.y - (p3.y - p1.y) / 6;
+      d += ` C ${cp1x} ${cp1y}, ${cp2x} ${cp2y}, ${p2.x} ${p2.y}`;
+    }
+    return d;
+  }
+  const linePath = smoothPath(points);
+  const areaPath = `${linePath} L ${points[points.length - 1]?.x ?? PAD_L + innerW} ${PAD_T + innerH} L ${PAD_L} ${PAD_T + innerH} Z`;
+
+  return (
+    <svg viewBox={`0 0 ${W} ${H}`} className="w-full" preserveAspectRatio="xMidYMid meet">
+      <defs>
+        <linearGradient id="skill-area-grad" x1="0" x2="0" y1="0" y2="1">
+          <stop offset="0%" stopColor="#1b2540" stopOpacity="0.4" />
+          <stop offset="100%" stopColor="#1b2540" stopOpacity="0" />
+        </linearGradient>
+      </defs>
+
+      {/* gridlines */}
+      {[0, 0.25, 0.5, 0.75, 1].map((p) => {
+        const y = PAD_T + innerH * p;
+        return (
+          <line
+            key={p}
+            x1={PAD_L}
+            y1={y}
+            x2={W - PAD_R}
+            y2={y}
+            stroke="#b1b5c0"
+            strokeOpacity={p === 1 ? 0.6 : 0.18}
+            strokeDasharray={p === 0 || p === 1 ? "0" : "3 3"}
+          />
+        );
+      })}
+
+      {/* y axis labels */}
+      {[0, 0.5, 1].map((p) => {
+        const y = PAD_T + innerH - innerH * p;
+        const v = Math.round(max * p);
+        return (
+          <text key={p} x={PAD_L - 6} y={y + 3} textAnchor="end" className="font-mono text-[9px] fill-slate-ink">
+            {v}
+          </text>
+        );
+      })}
+
+      {/* area + line */}
+      {!isEmpty && (
+        <>
+          <path d={areaPath} fill="url(#skill-area-grad)" />
+          <path d={linePath} fill="none" stroke="#1b2540" strokeWidth="1.75" strokeLinejoin="round" />
+          {points.map((p, i) =>
+            p.v > 0 ? (
+              <circle key={i} cx={p.x} cy={p.y} r="3" fill="#d0f100" stroke="#1b2540" strokeWidth="1" />
+            ) : null,
+          )}
+        </>
+      )}
+
+      {/* x axis labels: from/to block */}
+      <text x={PAD_L} y={H - 8} className="font-mono text-[9px] fill-slate-ink">
+        block {scannedFromBlock.toString()}
+      </text>
+      <text x={W - PAD_R} y={H - 8} textAnchor="end" className="font-mono text-[9px] fill-slate-ink">
+        {scannedToBlock.toString()}
+      </text>
+
+      {/* empty-state message */}
+      {isEmpty && (
+        <text
+          x={W / 2}
+          y={H / 2}
+          textAnchor="middle"
+          className="font-mono text-[12px] fill-slate-ink"
+        >
+          no on-chain interactions yet — try the catalog Run demo button
+        </text>
+      )}
+    </svg>
+  );
+}

--- a/apps/web-react/src/components/SkillDetail.tsx
+++ b/apps/web-react/src/components/SkillDetail.tsx
@@ -4,6 +4,8 @@ import { TrustPanel } from "./TrustPanel";
 import { TryItButton } from "./TryItButton";
 import { RegistryPanel } from "./RegistryPanel";
 import { OGStorageBadge } from "./OGStorageBadge";
+import { SkillActivityChart } from "./SkillActivityChart";
+import { DependencyGraph } from "./DependencyGraph";
 
 const TABS = ["Readme", "Tools", "Registry", "Dependencies", "Trust"] as const;
 type Tab = typeof TABS[number];
@@ -85,16 +87,19 @@ export function SkillDetail({ ensName, onClose }: Props) {
             </div>
 
             {tab === "Readme" && (
-              <div className="mt-8 font-display text-lg max-w-2xl">
-                <h2 className="font-display text-3xl mb-4">Readme</h2>
-                <p>{r.manifest.description}</p>
-                <p className="mt-4 text-sm text-slate-ink font-body">
-                  This skill exposes <b>{r.manifest.tools.length}</b> atomic tool(s), routed
-                  through the <code className="font-mono">{r.manifest.tools[0]?.execution.type}</code>{" "}
-                  executor in the bridge. It complies with the{" "}
-                  <code className="font-mono">skill-v1.json</code> schema and is content-addressed
-                  on 0G storage; the CID above is the canonical pinned root.
-                </p>
+              <div className="mt-8 space-y-6">
+                <SkillActivityChart ensName={ensName} />
+                <div className="font-display text-lg max-w-2xl">
+                  <h2 className="font-display text-3xl mb-4">Readme</h2>
+                  <p>{r.manifest.description}</p>
+                  <p className="mt-4 text-sm text-slate-ink font-body">
+                    This skill exposes <b>{r.manifest.tools.length}</b> atomic tool(s), routed
+                    through the <code className="font-mono">{r.manifest.tools[0]?.execution.type}</code>{" "}
+                    executor in the bridge. It complies with the{" "}
+                    <code className="font-mono">skill-v1.json</code> schema and is content-addressed
+                    on 0G storage; the CID above is the canonical pinned root.
+                  </p>
+                </div>
               </div>
             )}
 
@@ -122,16 +127,16 @@ export function SkillDetail({ ensName, onClose }: Props) {
             )}
 
             {tab === "Dependencies" && (
-              <div className="mt-8">
+              <div className="mt-8 space-y-6">
                 <h2 className="font-display text-3xl mb-4">Dependencies</h2>
-                {(r.manifest.dependencies ?? []).length === 0 ? (
-                  <div className="border border-fog-border rounded p-6 bg-pure-surface text-sm text-storm-gray font-body">
-                    <strong className="font-semibold text-midnight-navy block mb-2">No dependencies</strong>
-                    Leaf skill — its <code className="font-mono">dependencies[]</code> array is empty,
-                    so the bridge can register it without walking a graph. Composite skills list
-                    their imports here as ENS pointers and the bridge resolves them transitively.
-                  </div>
-                ) : (
+                <DependencyGraph
+                  ensName={ensName}
+                  dependencies={r.manifest.dependencies}
+                  onSelect={(ens) => {
+                    location.hash = `#/skill/${ens}`;
+                  }}
+                />
+                {(r.manifest.dependencies ?? []).length > 0 && (
                   <div className="space-y-2">
                     {r.manifest.dependencies!.map((d) => (
                       <a


### PR DESCRIPTION
## Why
The skill detail page had no charts. Judges landing on \`infer.skilltest.eth\` (or any skill) saw the readme and a Tools list — and asked where the data was.

## Two new viz components
**\`SkillActivityChart\`** (top of Readme tab)
- Hand-rolled SVG area chart, no \`@visx/*\` dep added.
- Reads SkillLink event logs from Sepolia, filters by \`namehash(this_ens)\`, buckets across 16 windows, renders smooth Catmull-Rom curve with navy gradient fill — Bklit's aesthetic in ~80 lines of SVG.
- Header: total calls + registrations + scan duration.
- Empty state: nudges to homepage RUN DEMO so the user can generate a data point.
- \`agent.skilltest.eth\` already shows a real peak at the registration block.

**\`DependencyGraph\`** (Dependencies tab)
- SVG tree: this skill in the center, composite imports as children below (solid edges), reverse-deps above (dashed edges).
- For \`agent.skilltest.eth\`: 3 child boxes (quote, score, infer) connected by solid lines.
- For \`infer.skilltest.eth\` / \`quote\` / \`score\`: parent box (\`agent.skilltest.eth\`) above with dashed line.
- Nodes are clickable → navigates to the linked skill. Graph becomes a hop-around tool.

## Files
- New: \`apps/web-react/src/components/SkillActivityChart.tsx\`
- New: \`apps/web-react/src/components/DependencyGraph.tsx\`
- Modified: \`apps/web-react/src/components/SkillDetail.tsx\` (mounts both)

## Test plan
- [x] \`pnpm exec tsc --noEmit\` clean
- [x] localhost — \`/#/skill/agent.skilltest.eth\` Readme: chart shows 1 registration peak; Dependencies: tree with 3 child nodes
- [x] localhost — \`/#/skill/infer.skilltest.eth\` Readme: chart with empty state; Dependencies: graph shows agent above as importer