### PR TITLE
fix(web): drop unused CATALOG_ITEMS import in DependencyGraph (unblocks deploy)

### DIFF
--- a/apps/web-react/src/components/DependencyGraph.tsx
+++ b/apps/web-react/src/components/DependencyGraph.tsx
@@ -1,5 +1,3 @@
-import { CATALOG_ITEMS } from "./SkillCatalog";
-
 // Static composite map — derived from the published manifests.
 // Update when a new composite ships. Mirrors what the bridge sees from
 // xyz.manifest.skill.imports for each ENS name in the registry.


### PR DESCRIPTION
## Why
Cloudflare deploy after #79 failed with TS6133:

```
src/components/DependencyGraph.tsx(1,1): error TS6133: 'CATALOG_ITEMS' is declared but its value is never read.
```

The component imports `CATALOG_ITEMS` but only uses the local `COMPOSITES` map. Strict `noUnusedLocals` in the prod `tsc -b` build rejects the import; my local `tsc --noEmit` didn't surface it.

## Fix
Drop the import. One line.

## Test plan
- [x] `pnpm --filter @skillname/web-react build` clean locally