### PR TITLE
feat(web): surface ENSIP-25 + ERC-8004 across the homepage

### DIFF
--- a/apps/web-react/src/App.tsx
+++ b/apps/web-react/src/App.tsx
@@ -15,6 +15,7 @@ import { PitchPanel } from "./components/PitchPanel";
 import { MySkillsCard } from "./components/MySkillsCard";
 import { OGStorageCard } from "./components/OGStorageCard";
 import { OnchainActivityChart } from "./components/OnchainActivityChart";
+import { TrustBindingsCard } from "./components/TrustBindingsCard";
 import { useRoute } from "./lib/router";
 import type { ResolvedSkill } from "./lib/skill-resolve";
 
@@ -66,6 +67,11 @@ export function App() {
         </div>
         <div className="col-span-12 sm:col-span-6 lg:col-span-4">
           <OGStorageCard />
+        </div>
+        <div className="col-span-12 sm:col-span-6 lg:col-span-4">
+          <TrustBindingsCard
+            onSelect={(ens) => navigate({ kind: "skill", ensName: ens })}
+          />
         </div>
         <div className="col-span-12 sm:col-span-6 lg:col-span-4">
           <TotalToolsCard onOpen={() => setOverlay("tools")} />

--- a/apps/web-react/src/components/OnchainActivityChart.tsx
+++ b/apps/web-react/src/components/OnchainActivityChart.tsx
@@ -233,8 +233,16 @@ export function OnchainActivityChart({ onSelect }: Props) {
                   title={`${s.ens} — last activity at block ${s.lastBlock}`}
                 >
                   <div className="flex items-baseline justify-between font-mono text-[11px]">
-                    <span className="text-bento-text-display group-hover:underline truncate">
+                    <span className="flex items-center gap-1.5 text-bento-text-display group-hover:underline truncate">
                       {s.ens}
+                      {CATALOG_ITEMS.find((c) => c.ens === s.ens)?.trust && (
+                        <span
+                          className="text-bento-success text-[9px] font-mono uppercase tracking-wider"
+                          title="ENSIP-25 + ERC-8004 bound"
+                        >
+                          ✓ ensip-25
+                        </span>
+                      )}
                     </span>
                     <span className="text-bento-text-secondary tabular-nums">
                       {formatValue(metric, s.value)}

--- a/apps/web-react/src/components/SkillCatalog.tsx
+++ b/apps/web-react/src/components/SkillCatalog.tsx
@@ -1,14 +1,21 @@
-interface CatalogItem {
+export interface CatalogItem {
   ens: string;
   exec: string;
   badge?: string;
+  // Static knowledge of which catalog skills have an ENSIP-25 + ERC-8004
+  // trust binding declared in their manifest. The TrustBindingsCard verifies
+  // each one against on-chain state at page load — this is just the seed.
+  trust?: { agentId: number; registry: string };
 }
+
+const SEPOLIA_REGISTRY =
+  "eip155:11155111:0x48f77FfE1f02FB94bDe9c8ffe84bB4956ace11e4";
 
 // Exported so the tools-overlay + filter chips can share the same source of truth.
 export const CATALOG_ITEMS: CatalogItem[] = [
-  { ens: "agent.skilltest.eth",   exec: "local",      badge: "composite · 3 imports" },
-  { ens: "quote.skilltest.eth",   exec: "http" },
-  { ens: "swap.skilltest.eth",    exec: "keeperhub",  badge: "x402" },
+  { ens: "agent.skilltest.eth",   exec: "local",      badge: "composite · 3 imports", trust: { agentId: 12, registry: SEPOLIA_REGISTRY } },
+  { ens: "quote.skilltest.eth",   exec: "http",                                       trust: { agentId: 7,  registry: SEPOLIA_REGISTRY } },
+  { ens: "swap.skilltest.eth",    exec: "keeperhub",  badge: "x402",                  trust: { agentId: 8,  registry: SEPOLIA_REGISTRY } },
   { ens: "basescan.skilltest.eth", exec: "http",      badge: "live · base" },
   { ens: "score.skilltest.eth",   exec: "http" },
   { ens: "weather.skilltest.eth", exec: "http" },
@@ -53,7 +60,17 @@ export function SkillCatalog({ onSelect, filter, onClearFilter }: Props) {
             onClick={() => onSelect(it.ens)}
             className="w-full flex items-center justify-between py-3 px-2 rounded hover:bg-ghost-canvas text-left"
           >
-            <span className="font-mono text-base text-midnight-navy">{it.ens}</span>
+            <span className="flex items-center gap-2 font-mono text-base text-midnight-navy">
+              {it.ens}
+              {it.trust && (
+                <span
+                  className="font-mono text-[9px] uppercase tracking-wider px-1.5 py-0.5 rounded bg-bento-success/15 text-bento-success border border-bento-success/40"
+                  title={`ENSIP-25 bound to ERC-8004 agentId ${it.trust.agentId}`}
+                >
+                  ✓ ENSIP-25 · #{it.trust.agentId}
+                </span>
+              )}
+            </span>
             <span className="flex items-center gap-2 font-mono text-[10px] uppercase tracking-wider text-slate-ink">
               <span>{it.exec}</span>
               {it.badge && <span className="text-bento-accent-red">· {it.badge}</span>}

--- a/apps/web-react/src/components/TrustBindingsCard.tsx
+++ b/apps/web-react/src/components/TrustBindingsCard.tsx
@@ -1,0 +1,180 @@
+import { useEffect, useState } from "react";
+import { usePublicClient } from "wagmi";
+import { sepolia } from "viem/chains";
+import { namehash, parseAbi } from "viem";
+import { CATALOG_ITEMS } from "./SkillCatalog";
+
+const RESOLVER = "0xE99638b40E4Fff0129D56f03b55b6bbC4BBE49b5" as const;
+const RESOLVER_ABI = parseAbi([
+  "function text(bytes32 node, string key) view returns (string)",
+]);
+
+interface BindingStatus {
+  ens: string;
+  agentId: number;
+  bound: boolean | null; // null = still verifying
+  textValue?: string;
+}
+
+interface Props {
+  onSelect: (ens: string) => void;
+}
+
+/**
+ * Mirrors @skillname/sdk's encodeErc7930 — bytes layout for an ERC-7930
+ * interoperable address. Used to construct the ENS text-record key the
+ * bridge reads to confirm an ERC-8004 agent binding.
+ */
+function encodeErc7930(caip10: string): `0x${string}` {
+  const m = caip10.match(/^eip155:(\d+):(0x[a-fA-F0-9]{40})$/);
+  if (!m) throw new Error(`invalid caip10: ${caip10}`);
+  const chainId = parseInt(m[1], 10);
+  const addr = m[2].slice(2).toLowerCase();
+  let chainHex = chainId.toString(16);
+  if (chainHex.length % 2 === 1) chainHex = "0" + chainHex;
+  const lenHex = (chainHex.length / 2).toString(16).padStart(2, "0");
+  return `0x0001${"0000"}${lenHex}${chainHex}14${addr}` as `0x${string}`;
+}
+
+/**
+ * Surfaces ENSIP-25 + ERC-8004 status across the whole catalog so ENS
+ * judges don't have to drill into each skill's Trust tab to see the binding
+ * exists. Reads the agent-registration text record from each bound skill's
+ * ENS name in parallel and shows pass/fail per row.
+ */
+export function TrustBindingsCard({ onSelect }: Props) {
+  const client = usePublicClient({ chainId: sepolia.id });
+  const bound = CATALOG_ITEMS.filter((c) => c.trust);
+  const [rows, setRows] = useState<BindingStatus[]>(
+    bound.map((c) => ({ ens: c.ens, agentId: c.trust!.agentId, bound: null })),
+  );
+  const [verifying, setVerifying] = useState(true);
+  const [verifyMs, setVerifyMs] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (!client) return;
+    let cancelled = false;
+    setVerifying(true);
+    const t0 = performance.now();
+    Promise.all(
+      bound.map(async (item): Promise<BindingStatus> => {
+        const enc = encodeErc7930(item.trust!.registry);
+        const key = `agent-registration[${enc}][${item.trust!.agentId}]`;
+        try {
+          const v = (await client.readContract({
+            address: RESOLVER,
+            abi: RESOLVER_ABI,
+            functionName: "text",
+            args: [namehash(item.ens), key],
+          })) as string;
+          return {
+            ens: item.ens,
+            agentId: item.trust!.agentId,
+            bound: v === "1",
+            textValue: v,
+          };
+        } catch {
+          return {
+            ens: item.ens,
+            agentId: item.trust!.agentId,
+            bound: false,
+          };
+        }
+      }),
+    ).then((res) => {
+      if (cancelled) return;
+      setRows(res);
+      setVerifyMs(Math.round(performance.now() - t0));
+      setVerifying(false);
+    });
+    return () => {
+      cancelled = true;
+    };
+    // bound is derived from CATALOG_ITEMS at module load — stable.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [client]);
+
+  const okCount = rows.filter((r) => r.bound === true).length;
+  const total = bound.length;
+
+  return (
+    <article className="bg-bento-surface text-bento-text-primary rounded-2xl p-6 border border-bento-border h-full flex flex-col">
+      <header className="flex items-start justify-between gap-3">
+        <div>
+          <span className="font-mono text-[10px] uppercase tracking-wider text-bento-text-secondary">
+            Trust · ENSIP-25 + ERC-8004
+          </span>
+          <div className="mt-1 font-mono text-xs text-bento-text-display">
+            bidirectional identity binding
+          </div>
+        </div>
+        <span
+          className={`font-mono text-[10px] uppercase tracking-wider ${
+            verifying ? "text-bento-text-secondary" : okCount === total ? "text-bento-success" : "text-bento-accent-red"
+          }`}
+        >
+          {verifying ? "verifying…" : okCount === total ? "● all bound" : `${okCount}/${total} bound`}
+        </span>
+      </header>
+
+      <div className="mt-3 flex items-baseline gap-2">
+        <span className="font-doto text-5xl text-bento-text-display leading-none">
+          {String(okCount).padStart(2, "0")}
+        </span>
+        <span className="font-mono text-[10px] uppercase tracking-wider text-bento-text-secondary">
+          / {String(total).padStart(2, "0")} skills · spoof-proof
+        </span>
+      </div>
+
+      <ul className="mt-4 flex-1 space-y-1.5 font-mono text-[11px]">
+        {rows.map((r) => {
+          const dot =
+            r.bound === null
+              ? "text-bento-text-secondary"
+              : r.bound
+                ? "text-bento-success"
+                : "text-bento-accent-red";
+          return (
+            <li key={r.ens}>
+              <button
+                onClick={() => onSelect(r.ens)}
+                className="w-full flex items-baseline justify-between text-left rounded px-1.5 py-1 hover:bg-bento-text-display/5 transition group"
+                title={
+                  r.bound
+                    ? `ENS owner of ${r.ens} confirmed agentId ${r.agentId} on-chain`
+                    : `agent-registration text record empty — claim unconfirmed`
+                }
+              >
+                <span className="flex items-center gap-2 truncate">
+                  <span className={dot}>●</span>
+                  <span className="text-bento-text-display truncate group-hover:underline">
+                    {r.ens}
+                  </span>
+                </span>
+                <span className="text-bento-text-secondary tabular-nums">
+                  agent #{r.agentId}
+                </span>
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+
+      <footer className="mt-4 pt-4 border-t border-bento-border flex items-center justify-between font-mono text-[10px] uppercase tracking-wider text-bento-text-secondary">
+        <span>
+          {verifyMs !== null
+            ? `verified in ${verifyMs}ms · sepolia`
+            : "scanning text records…"}
+        </span>
+        <a
+          href="https://docs.ens.domains/ensip/25/"
+          target="_blank"
+          rel="noreferrer"
+          className="hover:text-bento-text-display"
+        >
+          ENSIP-25 spec ↗
+        </a>
+      </footer>
+    </article>
+  );
+}


### PR DESCRIPTION
ENS judges shouldn't have to dig two clicks deep to see we implement ENSIP-25 correctly. Adds: TrustBindingsCard on the bento (3/3 skills · spoof-proof, live verified, click → spoof check), inline ✓ ENSIP-25 · #N badge on bound catalog rows, ✓ ensip-25 marker on chart bars for bound skills.