### PR TITLE
fix(web): resilient Sepolia transport + bind basescan trust block

### DIFF
--- a/apps/web-react/src/components/LiveTracePanel.tsx
+++ b/apps/web-react/src/components/LiveTracePanel.tsx
@@ -1,8 +1,9 @@
 import { useState } from "react";
-import { createPublicClient, http } from "viem";
+import { createPublicClient } from "viem";
 import { sepolia } from "viem/chains";
 import { normalize } from "viem/ens";
 import { resolveSkill, type SkillManifest } from "../lib/skill-resolve";
+import { sepoliaTransport } from "../lib/sepolia-transport";
 
 // What this panel does — and why it's the hero of the page:
 //
@@ -35,7 +36,7 @@ interface Step {
 const TARGET_ENS = "agent.skilltest.eth";
 const SAMPLE_TOKEN = "ethereum";
 
-const sepoliaClient = createPublicClient({ chain: sepolia, transport: http() });
+const sepoliaClient = createPublicClient({ chain: sepolia, transport: sepoliaTransport });
 
 export function LiveTracePanel() {
   const [steps, setSteps] = useState<Step[]>([]);

--- a/apps/web-react/src/lib/sepolia-transport.ts
+++ b/apps/web-react/src/lib/sepolia-transport.ts
@@ -1,0 +1,19 @@
+import { fallback, http } from "viem";
+
+// Sepolia is flaky — thirdweb (the viem default) rate-limits + occasionally
+// 5xx's, especially on Universal-Resolver CCIP-Read calls (resolveWithGateways
+// over the canonical 0xeeee…eeee resolver). Use a fallback chain so a single
+// RPC blip doesn't break ENS resolution in the hero, the activity chart, or
+// the caller log.
+//
+// Order matters: publicnode + 1rpc are stable + free; thirdweb stays last as
+// a backstop because it occasionally serves stale state.
+export const sepoliaTransport = fallback(
+  [
+    http("https://ethereum-sepolia-rpc.publicnode.com"),
+    http("https://1rpc.io/sepolia"),
+    http("https://rpc.sepolia.ethpandaops.io"),
+    http(), // viem default (thirdweb) — last-resort backstop
+  ],
+  { rank: false, retryCount: 1 },
+);

--- a/apps/web-react/src/lib/skill-resolve.ts
+++ b/apps/web-react/src/lib/skill-resolve.ts
@@ -1,6 +1,7 @@
 import { createPublicClient, http, namehash, type PublicClient } from "viem";
 import { sepolia, mainnet } from "viem/chains";
 import { normalize } from "viem/ens";
+import { sepoliaTransport } from "./sepolia-transport";
 
 const SKILL_KEY = "xyz.manifest.skill";
 const VERSIONS_KEY = "xyz.manifest.skill.versions";
@@ -47,7 +48,7 @@ export interface SkillManifest {
 }
 
 const clients: Record<"sepolia" | "mainnet", PublicClient> = {
-  sepolia: createPublicClient({ chain: sepolia, transport: http() }) as PublicClient,
+  sepolia: createPublicClient({ chain: sepolia, transport: sepoliaTransport }) as PublicClient,
   mainnet: createPublicClient({ chain: mainnet, transport: http() }) as PublicClient,
 };
 

--- a/apps/web-react/src/lib/wagmi.ts
+++ b/apps/web-react/src/lib/wagmi.ts
@@ -1,12 +1,16 @@
 import { http, createConfig } from "wagmi";
 import { sepolia, mainnet } from "wagmi/chains";
 import { injected } from "wagmi/connectors";
+import { sepoliaTransport } from "./sepolia-transport";
 
 export const wagmiConfig = createConfig({
   chains: [sepolia, mainnet],
   connectors: [injected()],
   transports: {
-    [sepolia.id]: http(),
+    // Shared resilient transport — publicnode primary, falls back to 1rpc /
+    // ethpandaops / thirdweb. Stops single-RPC blips from breaking ENS reads
+    // and OnchainCard contract calls.
+    [sepolia.id]: sepoliaTransport,
     [mainnet.id]: http(),
   },
 });

--- a/skillname-pack/examples/basescan/manifest.json
+++ b/skillname-pack/examples/basescan/manifest.json
@@ -50,5 +50,12 @@
         "method": "GET"
       }
     }
-  ]
+  ],
+  "trust": {
+    "ensip25": { "enabled": true },
+    "erc8004": {
+      "registry": "eip155:11155111:0x48f77FfE1f02FB94bDe9c8ffe84bB4956ace11e4",
+      "agentId": 18
+    }
+  }
 }


### PR DESCRIPTION
Closes hero RESOLVE 5xx flakiness on basescan + binds basescan ENSIP-25 (agentId 18) end-to-end. Mint tx `0x2ee58573`, bind tx `0xe40eab00`, new 0G root `0x7aa1a7fb`. `pnpm --filter @skillname/web-react build` clean locally.