### PR TITLE
fix(bridge): redirect console.log to stderr (MCP wire protocol fix)

### DIFF
--- a/skillname-pack/examples/agent-research/manifest.json
+++ b/skillname-pack/examples/agent-research/manifest.json
@@ -14,7 +14,7 @@
   "tools": [
     {
       "name": "research_token",
-      "description": "Fan out to three imported skills: get the token's USD price via quote.skilltest.eth, the holder's Gitcoin Passport score via score.skilltest.eth, then ask infer.skilltest.eth (0G Compute) for a one-sentence verdict on whether to interact. Returns all three artefacts plus the verdict.",
+      "description": "Composite research on a token + holder. Fans out to three imported skills internally: get the token's USD price via quote.skilltest.eth, the holder's Gitcoin Passport score via score.skilltest.eth, then ask infer.skilltest.eth (0G Compute, qwen-2.5-7b) for a one-sentence verdict. REQUIRED ARGS: token_id (CoinGecko coin id, e.g. 'usd-coin' / 'ethereum') and holder_address (0x-prefixed address). Do NOT use 'token' or 'address' — those names will be ignored. Returns { price_usd, passport_score, verdict, sources }.",
       "inputSchema": {
         "type": "object",
         "required": ["token_id", "holder_address"],

--- a/skillname-pack/packages/bridge/src/server.ts
+++ b/skillname-pack/packages/bridge/src/server.ts
@@ -22,6 +22,25 @@
  *   → Claude can immediately call it
  */
 
+// MCP STDIO transport is sacred: stdout MUST contain ONLY JSON-RPC messages.
+// Several deps (notably @0glabs/0g-serving-broker which prints "Detected testnet
+// (chain ID: 16602)") use console.log → that lands on stdout and breaks the
+// wire protocol with "Unexpected token 'D'... is not valid JSON" client errors.
+// Monkey-patch BEFORE any other import so all subsequent console output goes
+// to stderr where it belongs. This must run before MCP SDK or any 0G code loads.
+{
+  const toStderr = (...args: unknown[]) => {
+    const line = args
+      .map((a) => (typeof a === "string" ? a : JSON.stringify(a)))
+      .join(" ");
+    process.stderr.write(line + "\n");
+  };
+  console.log = toStderr;
+  console.info = toStderr;
+  console.debug = toStderr;
+  // console.warn + console.error already write to stderr by Node default.
+}
+
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import {


### PR DESCRIPTION
A noisy 0G dep was writing "Detected testnet" to stdout, breaking MCP. Patched console.log/info/debug to stderr. Also tightened the agent tool description so models use the right field names.