### PR TITLE
chore: cherry-pick safe parts of #70 (ENSIP-25 followup)

### DIFF
--- a/.github/workflows/register-skills.yml
+++ b/.github/workflows/register-skills.yml
@@ -47,3 +47,11 @@ jobs:
             ARGS="$ARGS --cids ${{ inputs.cids }}"
           fi
           pnpm tsx scripts/register-skills.ts $ARGS
+
+      # Issue #69: smoke test ENSIP-25 binding after every register run, so a
+      # broken text record (or a re-pin that drops the binding) fails the
+      # workflow instead of silently degrading the demo signal.
+      - name: Verify ENSIP-25 binding
+        env:
+          SEPOLIA_RPC_URL: ${{ secrets.SEPOLIA_RPC_URL }}
+        run: pnpm tsx scripts/verify-ensip25.ts

--- a/scripts/bind-ensip25.ts
+++ b/scripts/bind-ensip25.ts
@@ -38,7 +38,10 @@ import {
 } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
 import { sepolia } from "viem/chains";
-import { encodeErc7930 } from "@skillname/sdk";
+// Workspace package isn't published; import from the built dist by relative
+// path (same convention as scripts/verify-ensip25.ts). Keeps the script
+// runnable from the repo root via pnpm tsx.
+import { encodeErc7930 } from "../skillname-pack/packages/sdk/dist/index.js";
 
 const RESOLVER_DEFAULT = "0xE99638b40E4Fff0129D56f03b55b6bbC4BBE49b5";
 
@@ -71,8 +74,11 @@ async function main() {
   const key = `agent-registration[${erc7930}][${agentId}]`;
   const node = namehash(ensName);
 
-  const privateKey = process.env.SEPOLIA_PRIVATE_KEY;
-  if (!privateKey) throw new Error("SEPOLIA_PRIVATE_KEY not set");
+  const rawKey = process.env.SEPOLIA_PRIVATE_KEY;
+  if (!rawKey) throw new Error("SEPOLIA_PRIVATE_KEY not set");
+  // Tolerate keys stored without the 0x prefix (the .env in this repo
+  // historically did so — see register-skills.ts for the same fix).
+  const privateKey = (rawKey.toLowerCase().startsWith("0x") ? rawKey : `0x${rawKey}`) as `0x${string}`;
 
   const rpcUrl =
     process.env.SEPOLIA_RPC_URL ??
@@ -82,7 +88,7 @@ async function main() {
     RESOLVER_DEFAULT) as `0x${string}`;
   if (!isAddress(resolver)) throw new Error(`Invalid resolver: ${resolver}`);
 
-  const account = privateKeyToAccount(privateKey as `0x${string}`);
+  const account = privateKeyToAccount(privateKey);
   const publicClient = createPublicClient({
     chain: sepolia,
     transport: http(rpcUrl),

--- a/scripts/mint-agents.ts
+++ b/scripts/mint-agents.ts
@@ -23,13 +23,16 @@ import { privateKeyToAccount } from "viem/accounts";
 import { sepolia } from "viem/chains";
 
 const REGISTRY = "0x48f77FfE1f02FB94bDe9c8ffe84bB4956ace11e4" as const;
-const NAMES = [
+const DEFAULT_NAMES = [
   "hello.skilltest.eth",
   "quote.skilltest.eth",
   "swap.skilltest.eth",
   "score.skilltest.eth",
   "weather.skilltest.eth",
 ];
+// Accept ENS names from argv so the script can be re-run for late-added
+// bundles (e.g. infer.skilltest.eth, agent.skilltest.eth — see issue #69).
+const NAMES = process.argv.slice(2).length > 0 ? process.argv.slice(2) : DEFAULT_NAMES;
 
 const ABI = parseAbi([
   "function register(string name) external returns (uint256 agentId)",

--- a/scripts/verify-ensip25.ts
+++ b/scripts/verify-ensip25.ts
@@ -26,10 +26,14 @@ const NAMES = [
   "swap.skilltest.eth",
   "score.skilltest.eth",
   "weather.skilltest.eth",
+  // Added 2026-05-03 (issue #69): infer + agent skills published after #56
+  // closed; bound via mint-agents.ts agentIds 11/12.
+  "infer.skilltest.eth",
+  "agent.skilltest.eth",
 ];
 
 async function main() {
-  console.log("verifying ENSIP-25 binding on 5 reference subnames\n");
+  console.log(`verifying ENSIP-25 binding on ${NAMES.length} reference subnames\n`);
   let pass = 0;
   let fail = 0;
   for (const name of NAMES) {

--- a/skillname-pack/examples/agent-research/manifest.json
+++ b/skillname-pack/examples/agent-research/manifest.json
@@ -2,8 +2,8 @@
   "$schema": "https://manifest.eth/schemas/skill-v1.json",
   "name": "agent-research",
   "ensName": "agent.skilltest.eth",
-  "version": "1.0.0",
-  "description": "Composite skill: research a token + holder by fanning out to three atomic skills — quote (price), score (Passport reputation), infer (LLM verdict). Demonstrates the import-graph: one ENS name resolves to three transitive tools at the bridge.",
+  "version": "1.1.3",
+  "description": "Composite skill: research a token + holder by fanning out to three atomic skills \u2014 quote (price), score (Passport reputation), infer (LLM verdict). Demonstrates the import-graph: one ENS name resolves to three transitive tools at the bridge.",
   "createdAt": "2026-05-02T00:00:00Z",
   "license": "MIT",
   "dependencies": [
@@ -14,15 +14,21 @@
   "tools": [
     {
       "name": "research_token",
-      "description": "Composite research on a token + holder. Fans out to three imported skills internally: get the token's USD price via quote.skilltest.eth, the holder's Gitcoin Passport score via score.skilltest.eth, then ask infer.skilltest.eth (0G Compute, qwen-2.5-7b) for a one-sentence verdict. REQUIRED ARGS: token_id (CoinGecko coin id, e.g. 'usd-coin' / 'ethereum') and holder_address (0x-prefixed address). Do NOT use 'token' or 'address' — those names will be ignored. Returns { price_usd, passport_score, verdict, sources }.",
+      "description": "Composite research on a token + holder. Fans out to three imported skills internally: get the token's USD price via quote.skilltest.eth, the holder's Gitcoin Passport score via score.skilltest.eth, then ask infer.skilltest.eth (0G Compute, qwen-2.5-7b) for a one-sentence verdict. REQUIRED ARGS: token_id (CoinGecko coin id, e.g. 'usd-coin' / 'ethereum') and holder_address (0x-prefixed address). Do NOT use 'token' or 'address' \u2014 those names will be ignored. Returns { price_usd, passport_score, verdict, sources }.",
       "inputSchema": {
         "type": "object",
-        "required": ["token_id", "holder_address"],
+        "required": [
+          "token_id",
+          "holder_address"
+        ],
         "properties": {
           "token_id": {
             "type": "string",
             "description": "CoinGecko coin id (e.g. 'ethereum', 'usd-coin')",
-            "examples": ["ethereum", "usd-coin"]
+            "examples": [
+              "ethereum",
+              "usd-coin"
+            ]
           },
           "holder_address": {
             "type": "string",
@@ -34,21 +40,31 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "price_usd": { "type": "number" },
-          "passport_score": { "type": "string" },
-          "verdict": { "type": "string" }
+          "price_usd": {
+            "type": "number"
+          },
+          "passport_score": {
+            "type": "string"
+          },
+          "verdict": {
+            "type": "string"
+          }
         }
       },
       "execution": {
         "type": "local",
         "runtime": "ctx-v1",
-        "code": "(async ({ token_id, holder_address }, ctx) => { const [quote, social] = await Promise.all([ ctx.call('quote.skilltest.eth', 'get_quote', { ids: token_id }).catch(e => ({ _err: String(e?.message ?? e) })), ctx.call('score.skilltest.eth', 'trust_score', { address: holder_address }).catch(e => ({ _err: String(e?.message ?? e) })) ]); const price_usd = quote?.[token_id]?.usd ?? null; const followers = social?.followers_count; const following = social?.following_count; const social_signal = followers !== undefined ? `${followers} EFP followers, ${following} following` : (social?._err ? `unavailable (${social._err.slice(0, 60)})` : 'unknown'); const promptText = `Token \"${token_id}\" trades at $${price_usd}. Holder ${holder_address} has ${social_signal} on Ethereum Follow Protocol. In one sentence: is this a reasonable counterparty to interact with on-chain?`; let verdict; try { const v = await ctx.call('infer.skilltest.eth', 'infer', { prompt: promptText }); verdict = typeof v === 'string' ? v : (v?.text ?? v?.content?.[0]?.text ?? JSON.stringify(v)); } catch (e) { verdict = `0G Compute unavailable: ${String(e?.message ?? e).slice(0, 80)}`; } return { token_id, holder_address, price_usd, social_signal, followers, following, verdict, sources: { quote: 'quote.skilltest.eth → CoinGecko', social: 'score.skilltest.eth → Ethereum Follow Protocol (EFP)', verdict: 'infer.skilltest.eth → 0G Compute (qwen-2.5-7b)' } }; })"
+        "code": "(async ({ token_id, holder_address }, ctx) => { const [quote, social] = await Promise.all([ ctx.call('quote.skilltest.eth', 'get_quote', { ids: token_id }).catch(e => ({ _err: String(e?.message ?? e) })), ctx.call('score.skilltest.eth', 'trust_score', { address: holder_address }).catch(e => ({ _err: String(e?.message ?? e) })) ]); const price_usd = quote?.[token_id]?.usd ?? null; const followers = social?.followers_count; const following = social?.following_count; const social_signal = followers !== undefined ? `${followers} EFP followers, ${following} following` : (social?._err ? `unavailable (${social._err.slice(0, 60)})` : 'unknown'); const promptText = `Token \"${token_id}\" trades at $${price_usd}. Holder ${holder_address} has ${social_signal} on Ethereum Follow Protocol. In one sentence: is this a reasonable counterparty to interact with on-chain?`; let verdict; try { const v = await ctx.call('infer.skilltest.eth', 'infer', { prompt: promptText }); verdict = typeof v === 'string' ? v : (v?.text ?? v?.content?.[0]?.text ?? JSON.stringify(v)); } catch (e) { verdict = `0G Compute unavailable: ${String(e?.message ?? e).slice(0, 80)}`; } return { token_id, holder_address, price_usd, social_signal, followers, following, verdict, sources: { quote: 'quote.skilltest.eth \u2192 CoinGecko', social: 'score.skilltest.eth \u2192 Ethereum Follow Protocol (EFP)', verdict: 'infer.skilltest.eth \u2192 0G Compute (qwen-2.5-7b)' } }; })"
       }
     }
   ],
   "trust": {
     "ensip25": {
       "enabled": true
+    },
+    "erc8004": {
+      "registry": "eip155:11155111:0x48f77FfE1f02FB94bDe9c8ffe84bB4956ace11e4",
+      "agentId": 12
     }
   }
 }

--- a/skillname-pack/examples/infer-0g/manifest.json
+++ b/skillname-pack/examples/infer-0g/manifest.json
@@ -33,5 +33,12 @@
         "systemPrompt": "You are a helpful AI assistant running on 0G Compute Network — a decentralized, censorship-resistant inference layer. Answer concisely and accurately."
       }
     }
-  ]
+  ],
+  "trust": {
+    "ensip25": { "enabled": true },
+    "erc8004": {
+      "registry": "eip155:11155111:0x48f77FfE1f02FB94bDe9c8ffe84bB4956ace11e4",
+      "agentId": 11
+    }
+  }
 }


### PR DESCRIPTION
Lands the 5 safe files from #70 + adds the trust block to agent-research without reverting the EFP/inline-handler work that landed since #70 was opened. Closes #70. Verified 7/7 bound.